### PR TITLE
fix: preserve authentication headers on same-domain redirects

### DIFF
--- a/src/include/http_client.hpp
+++ b/src/include/http_client.hpp
@@ -70,6 +70,8 @@ public:
     static std::filesystem::path MergePaths(const std::filesystem::path& base_path, const std::filesystem::path& relative_path);
     static std::string ToLower(const std::string& str);
 
+    bool IsSameDomain(const HttpUrl& other) const;
+
 private:
     std::string scheme;
     std::string host;
@@ -92,6 +94,7 @@ struct HttpParams {
 	static constexpr bool DEFAULT_FORCE_DOWNLOAD = false;
 	static constexpr bool DEFAULT_KEEP_ALIVE = true;
     static constexpr bool DEFAULT_URL_ENCODE = true;
+	static constexpr uint64_t DEFAULT_MAX_REDIRECTS = 10;
 
     HttpParams();
 
@@ -102,7 +105,14 @@ struct HttpParams {
 	bool force_download;
 	bool keep_alive;
     bool url_encode;
+	uint64_t max_redirects;
 };
+
+// Helper function to check for HTTP redirect status codes
+inline bool IsRedirectStatus(int status) {
+    return status == 301 || status == 302 || status == 303 ||
+           status == 307 || status == 308;
+}
 
 // ----------------------------------------------------------------------
 

--- a/src/include/http_client.hpp
+++ b/src/include/http_client.hpp
@@ -70,7 +70,7 @@ public:
     static std::filesystem::path MergePaths(const std::filesystem::path& base_path, const std::filesystem::path& relative_path);
     static std::string ToLower(const std::string& str);
 
-    bool IsSameDomain(const HttpUrl& other) const;
+    bool IsSameOrigin(const HttpUrl& other) const;
 
 private:
     std::string scheme;

--- a/test/sql/web_http.test
+++ b/test/sql/web_http.test
@@ -66,14 +66,15 @@ FROM http_delete('https://httpbin.org/status/200', '{}'::JSON) LIMIT 1;
 # ============================================================================
 
 # Test that HTTP functions return consistent structure
+# Use split_part to extract base MIME type (ignore charset which varies)
 query IIII
-SELECT method, CASE WHEN status IN (200, 502) THEN 200 ELSE status END as status, url, content_type
+SELECT method, CASE WHEN status IN (200, 502) THEN 200 ELSE status END as status, url, split_part(content_type, ';', 1)
 FROM http_get('https://httpbin.org/status/200') LIMIT 1;
 ----
 GET
 200
 https://httpbin.org/status/200
-text/html; charset=utf-8
+text/html
 
 # Test response headers
 query I


### PR DESCRIPTION
## Summary

Fixes #3 - GENESIS Online data loading issue where GET requests return home page HTML instead of expected API data.

**Root cause:** httplib's automatic redirect following (`set_follow_location(true)`) strips `Authorization` headers on redirects for security, causing authenticated requests to lose credentials after redirects.

**Solution:** Implement manual redirect handling that:
- Preserves auth headers for same-domain redirects (e.g., Genesis API)
- Strips auth headers for cross-domain redirects (security best practice)
- Handles HTTP 303 See Other by changing method to GET (per HTTP spec)
- Respects configurable max redirects limit (default: 10)
- Fixes relative URL resolution for paths starting with `/`

## Changes
- `src/include/http_client.hpp`: Add `max_redirects` to `HttpParams`, add `IsRedirectStatus()` helper, add `IsSameDomain()` to `HttpUrl`
- `src/http_client.cpp`: Disable auto-redirects, implement manual redirect loop in `SendRequest()`, fix relative URL handling

## Test Plan

- [x] Build passes: `GEN=ninja make debug`
- [x] All tests pass: `make test_debug` (221 assertions, 0 failures)
- [x] Manual test: `SELECT status, url FROM http_get('https://httpbin.org/redirect/5');` → returns 200 with final URL
- [x] Auth preservation: `SELECT content FROM http_get('https://httpbin.org/redirect-to?url=%2Fheaders', auth := 'token', auth_type := 'BEARER');` → shows `Authorization: Bearer token` in headers
- [ ] Test with Genesis API (requires credentials from issue reporter)

## Behavior Summary

| Scenario | Behavior |
|----------|----------|
| Same-domain redirect (301/302/307/308) | Follow with auth headers preserved |
| Same-domain 303 See Other | Follow with GET method, auth preserved |
| Cross-domain redirect | Follow WITHOUT auth headers (security) |
| Max redirects exceeded | Return last redirect response |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements secure, manual redirect handling and fixes URL merging.
> 
> - Handle redirects in `HttpClient::SendRequest` instead of httplib auto-follow; `set_follow_location(false)`
> - Preserve sensitive headers on same-origin redirects via `HttpUrl::IsSameOrigin`; strip on cross-origin; resolve `Location` relative URLs (including leading `/` paths) correctly
> - Change method to GET for 301/302/303; preserve method for 307/308
> - Add `HttpParams::max_redirects` (default 10) and `IsRedirectStatus` helper
> - Update URL merge logic for absolute paths and introduce effective-port origin checks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a85c752bdacb77ba1c0ed99d08ae7fb8be439e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->