### PR TITLE
feat: populate duckdb_functions() metadata for all public functions

### DIFF
--- a/src/erpl_web_extension.cpp
+++ b/src/erpl_web_extension.cpp
@@ -1,5 +1,6 @@
 #include "duckdb.hpp"
 #include <duckdb/parser/parsed_data/create_scalar_function_info.hpp>
+#include <duckdb/parser/parsed_data/create_table_function_info.hpp>
 #include "duckdb/function/pragma_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 #ifdef DUCKDB_HAS_EXTENSION_CALLBACK_MANAGER
@@ -241,12 +242,101 @@ static void RegisterConfiguration(DatabaseInstance &instance)
 static void RegisterWebFunctions(ExtensionLoader &loader)
 {
     loader.RegisterType("HTTP_HEADER", erpl_web::CreateHttpHeaderType());
-    loader.RegisterFunction(erpl_web::CreateHttpGetFunction());
-    loader.RegisterFunction(erpl_web::CreateHttpPostFunction());
-    loader.RegisterFunction(erpl_web::CreateHttpPutFunction());
-    loader.RegisterFunction(erpl_web::CreateHttpPatchFunction());
-    loader.RegisterFunction(erpl_web::CreateHttpDeleteFunction());
-    loader.RegisterFunction(erpl_web::CreateHttpHeadFunction());
+
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateHttpGetFunction());
+        FunctionDescription desc;
+        desc.description = "Send an HTTP GET request and return the response as a table.";
+        desc.parameter_names = {"url"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM http_get('https://httpbin.org/ip')"};
+        desc.categories = {"http"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateHttpHeadFunction());
+        FunctionDescription desc;
+        desc.description = "Send an HTTP HEAD request and return the response headers as a table.";
+        desc.parameter_names = {"url"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM http_head('https://httpbin.org/ip')"};
+        desc.categories = {"http"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateHttpPostFunction());
+        FunctionDescription desc1;
+        desc1.description = "Send an HTTP POST request with a JSON body and return the response as a table.";
+        desc1.parameter_names = {"url", "body"};
+        desc1.parameter_types = {LogicalType::VARCHAR, LogicalType::JSON()};
+        desc1.examples = {"SELECT * FROM http_post('https://httpbin.org/post', '{\"key\": \"value\"}'::JSON)"};
+        desc1.categories = {"http"};
+        info.descriptions.push_back(std::move(desc1));
+        FunctionDescription desc2;
+        desc2.description = "Send an HTTP POST request with raw content and return the response as a table.";
+        desc2.parameter_names = {"url", "content", "content_type"};
+        desc2.parameter_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
+        desc2.examples = {"SELECT * FROM http_post('https://httpbin.org/post', 'hello', 'text/plain')"};
+        desc2.categories = {"http"};
+        info.descriptions.push_back(std::move(desc2));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateHttpPutFunction());
+        FunctionDescription desc1;
+        desc1.description = "Send an HTTP PUT request with a JSON body and return the response as a table.";
+        desc1.parameter_names = {"url", "body"};
+        desc1.parameter_types = {LogicalType::VARCHAR, LogicalType::JSON()};
+        desc1.examples = {"SELECT * FROM http_put('https://httpbin.org/put', '{\"key\": \"value\"}'::JSON)"};
+        desc1.categories = {"http"};
+        info.descriptions.push_back(std::move(desc1));
+        FunctionDescription desc2;
+        desc2.description = "Send an HTTP PUT request with raw content and return the response as a table.";
+        desc2.parameter_names = {"url", "content", "content_type"};
+        desc2.parameter_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
+        desc2.examples = {"SELECT * FROM http_put('https://example.com/resource', 'data', 'text/plain')"};
+        desc2.categories = {"http"};
+        info.descriptions.push_back(std::move(desc2));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateHttpPatchFunction());
+        FunctionDescription desc1;
+        desc1.description = "Send an HTTP PATCH request with a JSON body and return the response as a table.";
+        desc1.parameter_names = {"url", "body"};
+        desc1.parameter_types = {LogicalType::VARCHAR, LogicalType::JSON()};
+        desc1.examples = {"SELECT * FROM http_patch('https://httpbin.org/patch', '{\"key\": \"value\"}'::JSON)"};
+        desc1.categories = {"http"};
+        info.descriptions.push_back(std::move(desc1));
+        FunctionDescription desc2;
+        desc2.description = "Send an HTTP PATCH request with raw content and return the response as a table.";
+        desc2.parameter_names = {"url", "content", "content_type"};
+        desc2.parameter_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
+        desc2.examples = {"SELECT * FROM http_patch('https://example.com/resource', 'patch', 'text/plain')"};
+        desc2.categories = {"http"};
+        info.descriptions.push_back(std::move(desc2));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateHttpDeleteFunction());
+        FunctionDescription desc1;
+        desc1.description = "Send an HTTP DELETE request with a JSON body and return the response as a table.";
+        desc1.parameter_names = {"url", "body"};
+        desc1.parameter_types = {LogicalType::VARCHAR, LogicalType::JSON()};
+        desc1.examples = {"SELECT * FROM http_delete('https://httpbin.org/delete', '{}'::JSON)"};
+        desc1.categories = {"http"};
+        info.descriptions.push_back(std::move(desc1));
+        FunctionDescription desc2;
+        desc2.description = "Send an HTTP DELETE request with raw content and return the response as a table.";
+        desc2.parameter_names = {"url", "content", "content_type"};
+        desc2.parameter_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
+        desc2.examples = {"SELECT * FROM http_delete('https://example.com/resource', '', 'text/plain')"};
+        desc2.categories = {"http"};
+        info.descriptions.push_back(std::move(desc2));
+        loader.RegisterFunction(std::move(info));
+    }
 
     erpl::CreateBasicSecretFunctions::Register(loader);
     erpl::CreateBearerTokenSecretFunctions::Register(loader);
@@ -255,10 +345,50 @@ static void RegisterWebFunctions(ExtensionLoader &loader)
 
 static void RegisterODataFunctions(ExtensionLoader &loader)
 {
-    loader.RegisterFunction(erpl_web::CreateODataReadFunction());
-    loader.RegisterFunction(erpl_web::CreateODataDescribeFunction());
-    loader.RegisterFunction(erpl_web::CreateODataAttachFunction());
-    loader.RegisterFunction(erpl_web::CreateODataSapShowFunction());
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateODataReadFunction());
+        FunctionDescription desc;
+        desc.description = "Read data from an OData v2/v4 entity set with automatic version detection and predicate pushdown.";
+        desc.parameter_names = {"url"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM odata_read('https://services.odata.org/V4/Northwind/Northwind.svc/Customers')"};
+        desc.categories = {"odata"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateODataDescribeFunction());
+        FunctionDescription desc;
+        desc.description = "Describe the schema of an OData entity set by reading its metadata document.";
+        desc.parameter_names = {"url"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM odata_describe('https://services.odata.org/V4/Northwind/Northwind.svc/Customers')"};
+        desc.categories = {"odata"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateODataAttachFunction());
+        FunctionDescription desc;
+        desc.description = "Attach all entity sets of an OData service as views in the current DuckDB catalog.";
+        desc.parameter_names = {"url"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM odata_attach('https://services.odata.org/V4/Northwind/Northwind.svc/')"};
+        desc.categories = {"odata"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateODataSapShowFunction());
+        FunctionDescription desc;
+        desc.description = "List available SAP OData entity sets and services at a given service root URL.";
+        desc.parameter_names = {"url"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM odata_sap_show('https://<host>/sap/opu/odata/sap/')"};
+        desc.categories = {"odata", "sap"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
     
 
 #ifdef DUCKDB_HAS_EXTENSION_CALLBACK_MANAGER
@@ -274,40 +404,214 @@ static void RegisterODataFunctions(ExtensionLoader &loader)
 
 static void RegisterDatasphereFunctions(ExtensionLoader &loader)
 {
-    // Register catalog discovery functions
-    loader.RegisterFunction(erpl_web::CreateDatasphereShowSpacesFunction());
-    loader.RegisterFunction(erpl_web::CreateDatasphereShowAssetsFunction());
-    loader.RegisterFunction(erpl_web::CreateDatasphereDescribeSpaceFunction());
-    loader.RegisterFunction(erpl_web::CreateDatasphereDescribeAssetFunction());
-    
-    // Register asset consumption functions
-    loader.RegisterFunction(erpl_web::CreateDatasphereReadRelationalFunction());
-    loader.RegisterFunction(erpl_web::CreateDatasphereReadAnalyticalFunction());
-    
-    // Register Datasphere secret management functions
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateDatasphereShowSpacesFunction());
+        FunctionDescription desc;
+        desc.description = "List all SAP Datasphere spaces accessible with the configured credentials.";
+        desc.parameter_names = {};
+        desc.parameter_types = {};
+        desc.examples = {"SELECT * FROM datasphere_show_spaces()"};
+        desc.categories = {"sap", "datasphere"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateDatasphereShowAssetsFunction());
+        FunctionDescription desc1;
+        desc1.description = "List all assets in a specific SAP Datasphere space.";
+        desc1.parameter_names = {"space_id"};
+        desc1.parameter_types = {LogicalType::VARCHAR};
+        desc1.examples = {"SELECT * FROM datasphere_show_assets('MY_SPACE')"};
+        desc1.categories = {"sap", "datasphere"};
+        info.descriptions.push_back(std::move(desc1));
+        FunctionDescription desc2;
+        desc2.description = "List all assets across all accessible SAP Datasphere spaces.";
+        desc2.parameter_names = {};
+        desc2.parameter_types = {};
+        desc2.examples = {"SELECT * FROM datasphere_show_assets()"};
+        desc2.categories = {"sap", "datasphere"};
+        info.descriptions.push_back(std::move(desc2));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateDatasphereDescribeSpaceFunction());
+        FunctionDescription desc;
+        desc.description = "Describe the metadata and configuration of a SAP Datasphere space.";
+        desc.parameter_names = {"space_id"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM datasphere_describe_space('MY_SPACE')"};
+        desc.categories = {"sap", "datasphere"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateDatasphereDescribeAssetFunction());
+        FunctionDescription desc;
+        desc.description = "Describe the schema and metadata of a specific asset in a SAP Datasphere space.";
+        desc.parameter_names = {"space_id", "asset_id"};
+        desc.parameter_types = {LogicalType::VARCHAR, LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM datasphere_describe_asset('MY_SPACE', 'MY_VIEW')"};
+        desc.categories = {"sap", "datasphere"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateDatasphereReadRelationalFunction());
+        FunctionDescription desc1;
+        desc1.description = "Read data from a relational asset in SAP Datasphere using space and asset ID.";
+        desc1.parameter_names = {"space_id", "asset_id"};
+        desc1.parameter_types = {LogicalType::VARCHAR, LogicalType::VARCHAR};
+        desc1.examples = {"SELECT * FROM datasphere_read_relational('MY_SPACE', 'MY_VIEW')"};
+        desc1.categories = {"sap", "datasphere"};
+        info.descriptions.push_back(std::move(desc1));
+        FunctionDescription desc2;
+        desc2.description = "Read data from a relational asset in SAP Datasphere using space, asset ID, and explicit secret name.";
+        desc2.parameter_names = {"space_id", "asset_id", "secret"};
+        desc2.parameter_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
+        desc2.examples = {"SELECT * FROM datasphere_read_relational('MY_SPACE', 'MY_VIEW', 'my_secret')"};
+        desc2.categories = {"sap", "datasphere"};
+        info.descriptions.push_back(std::move(desc2));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateDatasphereReadAnalyticalFunction());
+        FunctionDescription desc1;
+        desc1.description = "Read data from an analytical (cube/view) asset in SAP Datasphere using space and asset ID.";
+        desc1.parameter_names = {"space_id", "asset_id"};
+        desc1.parameter_types = {LogicalType::VARCHAR, LogicalType::VARCHAR};
+        desc1.examples = {"SELECT * FROM datasphere_read_analytical('MY_SPACE', 'MY_CUBE')"};
+        desc1.categories = {"sap", "datasphere"};
+        info.descriptions.push_back(std::move(desc1));
+        FunctionDescription desc2;
+        desc2.description = "Read data from an analytical asset in SAP Datasphere using space, asset ID, and explicit secret name.";
+        desc2.parameter_names = {"space_id", "asset_id", "secret"};
+        desc2.parameter_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
+        desc2.examples = {"SELECT * FROM datasphere_read_analytical('MY_SPACE', 'MY_CUBE', 'my_secret')"};
+        desc2.categories = {"sap", "datasphere"};
+        info.descriptions.push_back(std::move(desc2));
+        loader.RegisterFunction(std::move(info));
+    }
+
     erpl_web::CreateDatasphereSecretFunctions::Register(loader);
 }
 
 static void RegisterOdpFunctions(ExtensionLoader &loader)
 {
-    loader.RegisterFunction(erpl_web::CreateOdpODataShowFunction());
-    loader.RegisterFunction(erpl_web::CreateOdpODataReadFunction());
-    loader.RegisterFunction(erpl_web::CreateOdpListSubscriptionsFunction());
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateOdpODataShowFunction());
+        FunctionDescription desc;
+        desc.description = "List available SAP ODP (Operational Data Provisioning) contexts and extractors at a given OData service root URL.";
+        desc.parameter_names = {"url"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM odp_odata_show('https://<host>/sap/opu/odata/iwbep/GWSAMPLE_BASIC/')"};
+        desc.categories = {"sap", "odp"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateOdpODataReadFunction());
+        FunctionDescription desc;
+        desc.description = "Read data from a SAP ODP extractor via OData with delta token support for incremental/CDC loads.";
+        desc.parameter_names = {"url"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM odp_odata_read('https://<host>/sap/opu/odata/sap/ZEXTRACTOR_SRV/DataSet')"};
+        desc.categories = {"sap", "odp"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateOdpListSubscriptionsFunction());
+        FunctionDescription desc;
+        desc.description = "List all active ODP subscriptions with their status and current delta tokens.";
+        desc.parameter_names = {};
+        desc.parameter_types = {};
+        desc.examples = {"SELECT * FROM odp_odata_list_subscriptions()"};
+        desc.categories = {"sap", "odp"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
     loader.RegisterFunction(erpl_web::CreateOdpRemoveSubscriptionFunction());
 }
 
 static void RegisterSacFunctions(ExtensionLoader &loader)
 {
-    // Register catalog discovery functions
-    loader.RegisterFunction(erpl_web::CreateSacShowModelsFunction());
-    loader.RegisterFunction(erpl_web::CreateSacShowStoriesFunction());
-    loader.RegisterFunction(erpl_web::CreateSacGetModelInfoFunction());
-    loader.RegisterFunction(erpl_web::CreateSacGetStoryInfoFunction());
-
-    // Register data consumption functions
-    loader.RegisterFunction(erpl_web::CreateSacReadPlanningDataFunction());
-    loader.RegisterFunction(erpl_web::CreateSacReadAnalyticalFunction());
-    loader.RegisterFunction(erpl_web::CreateSacReadStoryDataFunction());
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateSacShowModelsFunction());
+        FunctionDescription desc;
+        desc.description = "List all planning and analytics models available in SAP Analytics Cloud.";
+        desc.parameter_names = {};
+        desc.parameter_types = {};
+        desc.examples = {"SELECT * FROM sac_show_models()"};
+        desc.categories = {"sap", "sac"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateSacShowStoriesFunction());
+        FunctionDescription desc;
+        desc.description = "List all stories (dashboards/reports) available in SAP Analytics Cloud.";
+        desc.parameter_names = {};
+        desc.parameter_types = {};
+        desc.examples = {"SELECT * FROM sac_show_stories()"};
+        desc.categories = {"sap", "sac"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateSacGetModelInfoFunction());
+        FunctionDescription desc;
+        desc.description = "Get detailed metadata and dimension/measure schema for a SAP Analytics Cloud model.";
+        desc.parameter_names = {"model_id"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM sac_get_model_info('t.2:MY_MODEL')"};
+        desc.categories = {"sap", "sac"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateSacGetStoryInfoFunction());
+        FunctionDescription desc;
+        desc.description = "Get detailed metadata for a SAP Analytics Cloud story.";
+        desc.parameter_names = {"story_id"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM sac_get_story_info('ABC12345')"};
+        desc.categories = {"sap", "sac"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateSacReadPlanningDataFunction());
+        FunctionDescription desc;
+        desc.description = "Read planning data from a SAP Analytics Cloud planning model.";
+        desc.parameter_names = {"model_id"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM sac_read_planning_data('t.2:MY_PLANNING_MODEL')"};
+        desc.categories = {"sap", "sac"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateSacReadAnalyticalFunction());
+        FunctionDescription desc;
+        desc.description = "Read analytical data from a SAP Analytics Cloud model with optional dimension and measure filtering.";
+        desc.parameter_names = {"model_id"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM sac_read_analytical('t.2:MY_ANALYTICAL_MODEL')"};
+        desc.categories = {"sap", "sac"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateSacReadStoryDataFunction());
+        FunctionDescription desc;
+        desc.description = "Extract underlying data from a SAP Analytics Cloud story's visualizations.";
+        desc.parameter_names = {"story_id"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM sac_read_story_data('ABC12345')"};
+        desc.categories = {"sap", "sac"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Register SAC storage extension (handles ATTACH support)
 #ifdef DUCKDB_HAS_EXTENSION_CALLBACK_MANAGER
@@ -321,36 +625,139 @@ static void RegisterSacFunctions(ExtensionLoader &loader)
 
 static void RegisterDeltaShareFunctions(ExtensionLoader &loader)
 {
-    // Register Delta Sharing table function
-    loader.RegisterFunction(erpl_web::CreateDeltaShareScanFunction());
-
-    // Register Delta Sharing discovery functions
-    loader.RegisterFunction(erpl_web::CreateDeltaShareShowSharesFunction());
-    loader.RegisterFunction(erpl_web::CreateDeltaShareShowSchemasFunction());
-    loader.RegisterFunction(erpl_web::CreateDeltaShareShowTablesFunction());
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateDeltaShareScanFunction());
+        FunctionDescription desc;
+        desc.description = "Read data from a Delta Sharing table using a profile file and share/schema/table path.";
+        desc.parameter_names = {"profile_path", "share", "schema", "table"};
+        desc.parameter_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM delta_share_scan('/path/to/profile.json', 'my_share', 'my_schema', 'my_table')"};
+        desc.categories = {"delta", "sharing"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateDeltaShareShowSharesFunction());
+        FunctionDescription desc;
+        desc.description = "List all shares available in a Delta Sharing server using a profile file.";
+        desc.parameter_names = {"profile_path"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM delta_share_show_shares('/path/to/profile.json')"};
+        desc.categories = {"delta", "sharing"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateDeltaShareShowSchemasFunction());
+        FunctionDescription desc;
+        desc.description = "List all schemas within a Delta Sharing share.";
+        desc.parameter_names = {"profile_path", "share"};
+        desc.parameter_types = {LogicalType::VARCHAR, LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM delta_share_show_schemas('/path/to/profile.json', 'my_share')"};
+        desc.categories = {"delta", "sharing"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateDeltaShareShowTablesFunction());
+        FunctionDescription desc;
+        desc.description = "List all tables within a Delta Sharing schema.";
+        desc.parameter_names = {"profile_path", "share", "schema"};
+        desc.parameter_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM delta_share_show_tables('/path/to/profile.json', 'my_share', 'my_schema')"};
+        desc.categories = {"delta", "sharing"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 static void RegisterBusinessCentralFunctions(ExtensionLoader &loader)
 {
-    // Register Business Central secret type
     erpl_web::CreateBusinessCentralSecretFunctions::Register(loader);
 
-    // Register Business Central table functions
-    loader.RegisterFunction(erpl_web::CreateBcShowCompaniesFunction());
-    loader.RegisterFunction(erpl_web::CreateBcShowEntitiesFunction());
-    loader.RegisterFunction(erpl_web::CreateBcDescribeFunction());
-    loader.RegisterFunction(erpl_web::CreateBcReadFunction());
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateBcShowCompaniesFunction());
+        FunctionDescription desc;
+        desc.description = "List all companies accessible in Microsoft Dynamics 365 Business Central.";
+        desc.parameter_names = {};
+        desc.parameter_types = {};
+        desc.examples = {"SELECT * FROM bc_show_companies()"};
+        desc.categories = {"microsoft", "business_central"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateBcShowEntitiesFunction());
+        FunctionDescription desc;
+        desc.description = "List all OData entity sets available in Microsoft Dynamics 365 Business Central.";
+        desc.parameter_names = {};
+        desc.parameter_types = {};
+        desc.examples = {"SELECT * FROM bc_show_entities()"};
+        desc.categories = {"microsoft", "business_central"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateBcDescribeFunction());
+        FunctionDescription desc;
+        desc.description = "Describe the schema (property names, types, keys) of a Business Central entity.";
+        desc.parameter_names = {"entity"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM bc_describe('customers')"};
+        desc.categories = {"microsoft", "business_central"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateBcReadFunction());
+        FunctionDescription desc;
+        desc.description = "Read data from a Business Central entity with filter and predicate pushdown support.";
+        desc.parameter_names = {"entity"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM bc_read('customers')"};
+        desc.categories = {"microsoft", "business_central"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 static void RegisterDataverseFunctions(ExtensionLoader &loader)
 {
-    // Register Dataverse/CRM secret type
     erpl_web::CreateDataverseSecretFunctions::Register(loader);
 
-    // Register Dataverse/CRM table functions
-    loader.RegisterFunction(erpl_web::CreateCrmShowEntitiesFunction());
-    loader.RegisterFunction(erpl_web::CreateCrmDescribeFunction());
-    loader.RegisterFunction(erpl_web::CreateCrmReadFunction());
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateCrmShowEntitiesFunction());
+        FunctionDescription desc;
+        desc.description = "List all entity types available in Microsoft Dataverse (Dynamics 365 CRM).";
+        desc.parameter_names = {};
+        desc.parameter_types = {};
+        desc.examples = {"SELECT * FROM crm_show_entities()"};
+        desc.categories = {"microsoft", "dataverse"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateCrmDescribeFunction());
+        FunctionDescription desc;
+        desc.description = "Describe the attribute schema (names, types, keys) of a Microsoft Dataverse entity.";
+        desc.parameter_names = {"entity"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM crm_describe('accounts')"};
+        desc.categories = {"microsoft", "dataverse"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        CreateTableFunctionInfo info(erpl_web::CreateCrmReadFunction());
+        FunctionDescription desc;
+        desc.description = "Read data from a Microsoft Dataverse entity with filter and predicate pushdown support.";
+        desc.parameter_names = {"entity"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM crm_read('accounts')"};
+        desc.categories = {"microsoft", "dataverse"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 static void RegisterGraphExcelFunctions(ExtensionLoader &loader)
@@ -410,6 +817,12 @@ static void RegisterTracingPragmas(ExtensionLoader &loader)
 
 static void LoadInternal(ExtensionLoader &loader) {
     auto &instance = loader.GetDatabaseInstance();
+
+    loader.SetDescription(
+        "HTTP/REST, OData v2/v4, SAP Datasphere, SAP Analytics Cloud, SAP ODP, "
+        "Delta Sharing, Microsoft 365 (Graph), Business Central, and Dataverse "
+        "data access functions for DuckDB."
+    );
 
     // Initialize telemetry with API key before capturing extension load
     PostHogTelemetry::Instance().SetAPIKey("phc_t3wwRLtpyEmLHYaZCSszG0MqVr74J6wnCrj9D41zk2t");

--- a/src/graph_entra_functions.cpp
+++ b/src/graph_entra_functions.cpp
@@ -2,6 +2,7 @@
 #include "graph_entra_client.hpp"
 #include "graph_excel_secret.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "tracing.hpp"
 #include "yyjson.hpp"
 
@@ -500,25 +501,58 @@ void GraphEntraFunctions::SignInLogsScan(
 // =============================================================================
 
 void GraphEntraFunctions::Register(ExtensionLoader &loader) {
-    // graph_users - no required params, optional secret named param
-    TableFunction users_func("graph_users", {}, UsersScan, UsersBind);
-    users_func.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(users_func);
-
-    // graph_groups - no required params, optional secret named param
-    TableFunction groups_func("graph_groups", {}, GroupsScan, GroupsBind);
-    groups_func.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(groups_func);
-
-    // graph_devices - no required params, optional secret named param
-    TableFunction devices_func("graph_devices", {}, DevicesScan, DevicesBind);
-    devices_func.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(devices_func);
-
-    // graph_signin_logs - no required params, optional secret named param
-    TableFunction signin_logs_func("graph_signin_logs", {}, SignInLogsScan, SignInLogsBind);
-    signin_logs_func.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(signin_logs_func);
+    {
+        TableFunction users_func("graph_users", {}, UsersScan, UsersBind);
+        users_func.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(users_func);
+        FunctionDescription desc;
+        desc.description = "List users from Microsoft Entra ID (Azure Active Directory).";
+        desc.parameter_names = {};
+        desc.parameter_types = {};
+        desc.examples = {"SELECT * FROM graph_users(secret := 'ms_entra')"};
+        desc.categories = {"microsoft", "graph", "entra"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        TableFunction groups_func("graph_groups", {}, GroupsScan, GroupsBind);
+        groups_func.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(groups_func);
+        FunctionDescription desc;
+        desc.description = "List groups from Microsoft Entra ID (Azure Active Directory).";
+        desc.parameter_names = {};
+        desc.parameter_types = {};
+        desc.examples = {"SELECT * FROM graph_groups(secret := 'ms_entra')"};
+        desc.categories = {"microsoft", "graph", "entra"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        TableFunction devices_func("graph_devices", {}, DevicesScan, DevicesBind);
+        devices_func.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(devices_func);
+        FunctionDescription desc;
+        desc.description = "List registered devices from Microsoft Entra ID (Azure Active Directory).";
+        desc.parameter_names = {};
+        desc.parameter_types = {};
+        desc.examples = {"SELECT * FROM graph_devices(secret := 'ms_entra')"};
+        desc.categories = {"microsoft", "graph", "entra"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        TableFunction signin_logs_func("graph_signin_logs", {}, SignInLogsScan, SignInLogsBind);
+        signin_logs_func.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(signin_logs_func);
+        FunctionDescription desc;
+        desc.description = "List sign-in logs from Microsoft Entra ID (requires Azure AD Premium P1 or P2).";
+        desc.parameter_names = {};
+        desc.parameter_types = {};
+        desc.examples = {"SELECT * FROM graph_signin_logs(secret := 'ms_entra')"};
+        desc.categories = {"microsoft", "graph", "entra"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 } // namespace erpl_web

--- a/src/graph_excel_functions.cpp
+++ b/src/graph_excel_functions.cpp
@@ -3,6 +3,7 @@
 #include "graph_excel_secret.hpp"
 #include "tracing.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "yyjson.hpp"
 
 using namespace duckdb_yyjson;
@@ -743,38 +744,79 @@ void GraphExcelFunctions::ExcelTableDataScan(
 void GraphExcelFunctions::Register(ExtensionLoader &loader) {
     ERPL_TRACE_INFO("GRAPH_EXCEL", "Registering Microsoft Graph Excel functions");
 
-    // graph_list_files(folder_path?) - optional secret named param
-    TableFunction list_files("graph_list_files", {}, ListFilesScan, ListFilesBind);
-    list_files.varargs = LogicalType::VARCHAR;
-    list_files.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(list_files);
-
-    // graph_excel_tables(file_path) - optional secret named param
-    TableFunction excel_tables("graph_excel_tables", {LogicalType::VARCHAR},
-                               ExcelTablesScan, ExcelTablesBind);
-    excel_tables.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(excel_tables);
-
-    // graph_excel_worksheets(file_path) - optional secret named param
-    TableFunction excel_worksheets("graph_excel_worksheets", {LogicalType::VARCHAR},
-                                   ExcelWorksheetsScan, ExcelWorksheetsBind);
-    excel_worksheets.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(excel_worksheets);
-
-    // graph_excel_range(file_path, sheet_name, range?) - optional secret named param
-    TableFunction excel_range("graph_excel_range",
-                              {LogicalType::VARCHAR, LogicalType::VARCHAR},
-                              ExcelRangeScan, ExcelRangeBind);
-    excel_range.varargs = LogicalType::VARCHAR;
-    excel_range.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(excel_range);
-
-    // graph_excel_table_data(file_path, table_name) - optional secret named param
-    TableFunction excel_table_data("graph_excel_table_data",
-                                   {LogicalType::VARCHAR, LogicalType::VARCHAR},
-                                   ExcelTableDataScan, ExcelTableDataBind);
-    excel_table_data.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(excel_table_data);
+    {
+        TableFunction list_files("graph_list_files", {}, ListFilesScan, ListFilesBind);
+        list_files.varargs = LogicalType::VARCHAR;
+        list_files.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(list_files);
+        FunctionDescription desc;
+        desc.description = "List files in OneDrive/SharePoint accessible via Microsoft Graph.";
+        desc.parameter_names = {};
+        desc.parameter_types = {};
+        desc.examples = {"SELECT * FROM graph_list_files(secret := 'ms_graph')"};
+        desc.categories = {"microsoft", "graph", "excel"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        TableFunction excel_tables("graph_excel_tables", {LogicalType::VARCHAR},
+                                   ExcelTablesScan, ExcelTablesBind);
+        excel_tables.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(excel_tables);
+        FunctionDescription desc;
+        desc.description = "List all named tables in a Microsoft Excel workbook stored in OneDrive/SharePoint.";
+        desc.parameter_names = {"file_path"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM graph_excel_tables('/path/to/workbook.xlsx', secret := 'ms_graph')"};
+        desc.categories = {"microsoft", "graph", "excel"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        TableFunction excel_worksheets("graph_excel_worksheets", {LogicalType::VARCHAR},
+                                       ExcelWorksheetsScan, ExcelWorksheetsBind);
+        excel_worksheets.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(excel_worksheets);
+        FunctionDescription desc;
+        desc.description = "List all worksheets in a Microsoft Excel workbook stored in OneDrive/SharePoint.";
+        desc.parameter_names = {"file_path"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM graph_excel_worksheets('/path/to/workbook.xlsx', secret := 'ms_graph')"};
+        desc.categories = {"microsoft", "graph", "excel"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        TableFunction excel_range("graph_excel_range",
+                                  {LogicalType::VARCHAR, LogicalType::VARCHAR},
+                                  ExcelRangeScan, ExcelRangeBind);
+        excel_range.varargs = LogicalType::VARCHAR;
+        excel_range.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(excel_range);
+        FunctionDescription desc;
+        desc.description = "Read a cell range from a worksheet in a Microsoft Excel workbook stored in OneDrive/SharePoint.";
+        desc.parameter_names = {"file_path", "sheet_name"};
+        desc.parameter_types = {LogicalType::VARCHAR, LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM graph_excel_range('/path/to/workbook.xlsx', 'Sheet1', secret := 'ms_graph')"};
+        desc.categories = {"microsoft", "graph", "excel"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        TableFunction excel_table_data("graph_excel_table_data",
+                                       {LogicalType::VARCHAR, LogicalType::VARCHAR},
+                                       ExcelTableDataScan, ExcelTableDataBind);
+        excel_table_data.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(excel_table_data);
+        FunctionDescription desc;
+        desc.description = "Read all rows from a named table in a Microsoft Excel workbook stored in OneDrive/SharePoint.";
+        desc.parameter_names = {"file_path", "table_name"};
+        desc.parameter_types = {LogicalType::VARCHAR, LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM graph_excel_table_data('/path/to/workbook.xlsx', 'SalesData', secret := 'ms_graph')"};
+        desc.categories = {"microsoft", "graph", "excel"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ERPL_TRACE_INFO("GRAPH_EXCEL", "Successfully registered Microsoft Graph Excel functions");
 }

--- a/src/graph_outlook_functions.cpp
+++ b/src/graph_outlook_functions.cpp
@@ -3,6 +3,7 @@
 #include "graph_excel_secret.hpp"
 #include "tracing.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "yyjson.hpp"
 
 using namespace duckdb_yyjson;
@@ -470,23 +471,48 @@ void GraphOutlookFunctions::MessagesScan(
 void GraphOutlookFunctions::Register(ExtensionLoader &loader) {
     ERPL_TRACE_INFO("GRAPH_OUTLOOK", "Registering Microsoft Graph Outlook functions");
 
-    // graph_calendar_events - no required params, optional secret named param
-    TableFunction calendar_events("graph_calendar_events", {},
-                                  CalendarEventsScan, CalendarEventsBind);
-    calendar_events.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(calendar_events);
-
-    // graph_contacts - no required params, optional secret named param
-    TableFunction contacts("graph_contacts", {},
-                           ContactsScan, ContactsBind);
-    contacts.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(contacts);
-
-    // graph_messages - no required params, optional secret named param
-    TableFunction messages("graph_messages", {},
-                           MessagesScan, MessagesBind);
-    messages.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(messages);
+    {
+        TableFunction calendar_events("graph_calendar_events", {},
+                                      CalendarEventsScan, CalendarEventsBind);
+        calendar_events.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(calendar_events);
+        FunctionDescription desc;
+        desc.description = "List calendar events from the authenticated user's Outlook calendar via Microsoft Graph.";
+        desc.parameter_names = {};
+        desc.parameter_types = {};
+        desc.examples = {"SELECT * FROM graph_calendar_events(secret := 'ms_graph')"};
+        desc.categories = {"microsoft", "graph", "outlook"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        TableFunction contacts("graph_contacts", {},
+                               ContactsScan, ContactsBind);
+        contacts.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(contacts);
+        FunctionDescription desc;
+        desc.description = "List contacts from the authenticated user's Outlook contacts via Microsoft Graph.";
+        desc.parameter_names = {};
+        desc.parameter_types = {};
+        desc.examples = {"SELECT * FROM graph_contacts(secret := 'ms_graph')"};
+        desc.categories = {"microsoft", "graph", "outlook"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        TableFunction messages("graph_messages", {},
+                               MessagesScan, MessagesBind);
+        messages.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(messages);
+        FunctionDescription desc;
+        desc.description = "List email messages (metadata only) from the authenticated user's Outlook inbox via Microsoft Graph.";
+        desc.parameter_names = {};
+        desc.parameter_types = {};
+        desc.examples = {"SELECT * FROM graph_messages(secret := 'ms_graph')"};
+        desc.categories = {"microsoft", "graph", "outlook"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ERPL_TRACE_INFO("GRAPH_OUTLOOK", "Successfully registered Microsoft Graph Outlook functions");
 }

--- a/src/graph_planner_functions.cpp
+++ b/src/graph_planner_functions.cpp
@@ -3,6 +3,7 @@
 #include "graph_excel_secret.hpp"
 #include "tracing.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "yyjson.hpp"
 
 using namespace duckdb_yyjson;
@@ -407,23 +408,48 @@ void GraphPlannerFunctions::TasksScan(
 void GraphPlannerFunctions::Register(ExtensionLoader &loader) {
     ERPL_TRACE_INFO("GRAPH_PLANNER", "Registering Microsoft Graph Planner functions");
 
-    // graph_planner_plans(group_id) - optional secret named param
-    TableFunction planner_plans("graph_planner_plans", {LogicalType::VARCHAR},
-                                PlansScan, PlansBind);
-    planner_plans.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(planner_plans);
-
-    // graph_planner_buckets(plan_id) - optional secret named param
-    TableFunction planner_buckets("graph_planner_buckets", {LogicalType::VARCHAR},
-                                  BucketsScan, BucketsBind);
-    planner_buckets.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(planner_buckets);
-
-    // graph_planner_tasks(plan_id) - optional secret named param
-    TableFunction planner_tasks("graph_planner_tasks", {LogicalType::VARCHAR},
-                                TasksScan, TasksBind);
-    planner_tasks.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(planner_tasks);
+    {
+        TableFunction planner_plans("graph_planner_plans", {LogicalType::VARCHAR},
+                                    PlansScan, PlansBind);
+        planner_plans.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(planner_plans);
+        FunctionDescription desc;
+        desc.description = "List all Microsoft Planner plans in a Microsoft 365 group.";
+        desc.parameter_names = {"group_id"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM graph_planner_plans('group-id-here', secret := 'ms_graph')"};
+        desc.categories = {"microsoft", "graph", "planner"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        TableFunction planner_buckets("graph_planner_buckets", {LogicalType::VARCHAR},
+                                      BucketsScan, BucketsBind);
+        planner_buckets.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(planner_buckets);
+        FunctionDescription desc;
+        desc.description = "List all buckets in a Microsoft Planner plan.";
+        desc.parameter_names = {"plan_id"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM graph_planner_buckets('plan-id-here', secret := 'ms_graph')"};
+        desc.categories = {"microsoft", "graph", "planner"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        TableFunction planner_tasks("graph_planner_tasks", {LogicalType::VARCHAR},
+                                    TasksScan, TasksBind);
+        planner_tasks.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(planner_tasks);
+        FunctionDescription desc;
+        desc.description = "List all tasks in a Microsoft Planner plan.";
+        desc.parameter_names = {"plan_id"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM graph_planner_tasks('plan-id-here', secret := 'ms_graph')"};
+        desc.categories = {"microsoft", "graph", "planner"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ERPL_TRACE_INFO("GRAPH_PLANNER", "Successfully registered Microsoft Graph Planner functions");
 }

--- a/src/graph_sharepoint_functions.cpp
+++ b/src/graph_sharepoint_functions.cpp
@@ -3,6 +3,7 @@
 #include "graph_excel_secret.hpp"
 #include "tracing.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "yyjson.hpp"
 
 using namespace duckdb_yyjson;
@@ -608,31 +609,64 @@ void GraphSharePointFunctions::ListItemsScan(
 void GraphSharePointFunctions::Register(ExtensionLoader &loader) {
     ERPL_TRACE_INFO("GRAPH_SHAREPOINT", "Registering Microsoft Graph SharePoint functions");
 
-    // graph_show_sites(search_query?) - optional secret named param
-    TableFunction show_sites("graph_show_sites", {}, ShowSitesScan, ShowSitesBind);
-    show_sites.varargs = LogicalType::VARCHAR;
-    show_sites.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(show_sites);
-
-    // graph_show_lists(site_id) - optional secret named param
-    TableFunction show_lists("graph_show_lists", {LogicalType::VARCHAR},
-                             ShowListsScan, ShowListsBind);
-    show_lists.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(show_lists);
-
-    // graph_describe_list(site_id, list_id) - optional secret named param
-    TableFunction describe_list("graph_describe_list",
-                                {LogicalType::VARCHAR, LogicalType::VARCHAR},
-                                DescribeListScan, DescribeListBind);
-    describe_list.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(describe_list);
-
-    // graph_list_items(site_id, list_id) - optional secret named param
-    TableFunction list_items("graph_list_items",
-                             {LogicalType::VARCHAR, LogicalType::VARCHAR},
-                             ListItemsScan, ListItemsBind);
-    list_items.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(list_items);
+    {
+        TableFunction show_sites("graph_show_sites", {}, ShowSitesScan, ShowSitesBind);
+        show_sites.varargs = LogicalType::VARCHAR;
+        show_sites.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(show_sites);
+        FunctionDescription desc;
+        desc.description = "Search and list SharePoint sites accessible via Microsoft Graph.";
+        desc.parameter_names = {};
+        desc.parameter_types = {};
+        desc.examples = {"SELECT * FROM graph_show_sites(secret := 'ms_graph')"};
+        desc.categories = {"microsoft", "graph", "sharepoint"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        TableFunction show_lists("graph_show_lists", {LogicalType::VARCHAR},
+                                 ShowListsScan, ShowListsBind);
+        show_lists.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(show_lists);
+        FunctionDescription desc;
+        desc.description = "List all lists in a SharePoint site.";
+        desc.parameter_names = {"site_id"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM graph_show_lists('site-id-here', secret := 'ms_graph')"};
+        desc.categories = {"microsoft", "graph", "sharepoint"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        TableFunction describe_list("graph_describe_list",
+                                    {LogicalType::VARCHAR, LogicalType::VARCHAR},
+                                    DescribeListScan, DescribeListBind);
+        describe_list.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(describe_list);
+        FunctionDescription desc;
+        desc.description = "Describe the column schema of a SharePoint list.";
+        desc.parameter_names = {"site_id", "list_id"};
+        desc.parameter_types = {LogicalType::VARCHAR, LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM graph_describe_list('site-id', 'list-id', secret := 'ms_graph')"};
+        desc.categories = {"microsoft", "graph", "sharepoint"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        TableFunction list_items("graph_list_items",
+                                 {LogicalType::VARCHAR, LogicalType::VARCHAR},
+                                 ListItemsScan, ListItemsBind);
+        list_items.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(list_items);
+        FunctionDescription desc;
+        desc.description = "Read all items from a SharePoint list.";
+        desc.parameter_names = {"site_id", "list_id"};
+        desc.parameter_types = {LogicalType::VARCHAR, LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM graph_list_items('site-id', 'list-id', secret := 'ms_graph')"};
+        desc.categories = {"microsoft", "graph", "sharepoint"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     ERPL_TRACE_INFO("GRAPH_SHAREPOINT", "Successfully registered Microsoft Graph SharePoint functions");
 }

--- a/src/graph_teams_functions.cpp
+++ b/src/graph_teams_functions.cpp
@@ -2,6 +2,7 @@
 #include "graph_teams_client.hpp"
 #include "graph_excel_secret.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "tracing.hpp"
 #include "yyjson.hpp"
 
@@ -494,25 +495,58 @@ void GraphTeamsFunctions::ChannelMessagesScan(
 // =============================================================================
 
 void GraphTeamsFunctions::Register(ExtensionLoader &loader) {
-    // graph_my_teams - no required params, optional secret named param
-    TableFunction my_teams_func("graph_my_teams", {}, MyTeamsScan, MyTeamsBind);
-    my_teams_func.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(my_teams_func);
-
-    // graph_team_channels(team_id) - optional secret named param
-    TableFunction team_channels_func("graph_team_channels", {LogicalType::VARCHAR}, TeamChannelsScan, TeamChannelsBind);
-    team_channels_func.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(team_channels_func);
-
-    // graph_team_members(team_id) - optional secret named param
-    TableFunction team_members_func("graph_team_members", {LogicalType::VARCHAR}, TeamMembersScan, TeamMembersBind);
-    team_members_func.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(team_members_func);
-
-    // graph_channel_messages(team_id, channel_id) - optional secret named param
-    TableFunction channel_messages_func("graph_channel_messages", {LogicalType::VARCHAR, LogicalType::VARCHAR}, ChannelMessagesScan, ChannelMessagesBind);
-    channel_messages_func.named_parameters["secret"] = LogicalType::VARCHAR;
-    loader.RegisterFunction(channel_messages_func);
+    {
+        TableFunction my_teams_func("graph_my_teams", {}, MyTeamsScan, MyTeamsBind);
+        my_teams_func.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(my_teams_func);
+        FunctionDescription desc;
+        desc.description = "List Microsoft Teams that the authenticated user is a member of.";
+        desc.parameter_names = {};
+        desc.parameter_types = {};
+        desc.examples = {"SELECT * FROM graph_my_teams(secret := 'ms_graph')"};
+        desc.categories = {"microsoft", "graph", "teams"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        TableFunction team_channels_func("graph_team_channels", {LogicalType::VARCHAR}, TeamChannelsScan, TeamChannelsBind);
+        team_channels_func.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(team_channels_func);
+        FunctionDescription desc;
+        desc.description = "List all channels in a Microsoft Teams team.";
+        desc.parameter_names = {"team_id"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM graph_team_channels('team-id-here', secret := 'ms_graph')"};
+        desc.categories = {"microsoft", "graph", "teams"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        TableFunction team_members_func("graph_team_members", {LogicalType::VARCHAR}, TeamMembersScan, TeamMembersBind);
+        team_members_func.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(team_members_func);
+        FunctionDescription desc;
+        desc.description = "List all members of a Microsoft Teams team.";
+        desc.parameter_names = {"team_id"};
+        desc.parameter_types = {LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM graph_team_members('team-id-here', secret := 'ms_graph')"};
+        desc.categories = {"microsoft", "graph", "teams"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        TableFunction channel_messages_func("graph_channel_messages", {LogicalType::VARCHAR, LogicalType::VARCHAR}, ChannelMessagesScan, ChannelMessagesBind);
+        channel_messages_func.named_parameters["secret"] = LogicalType::VARCHAR;
+        CreateTableFunctionInfo info(channel_messages_func);
+        FunctionDescription desc;
+        desc.description = "List messages in a Microsoft Teams channel.";
+        desc.parameter_names = {"team_id", "channel_id"};
+        desc.parameter_types = {LogicalType::VARCHAR, LogicalType::VARCHAR};
+        desc.examples = {"SELECT * FROM graph_channel_messages('team-id', 'channel-id', secret := 'ms_graph')"};
+        desc.categories = {"microsoft", "graph", "teams"};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 }
 
 } // namespace erpl_web


### PR DESCRIPTION
## Summary

- Adds `FunctionDescription` (description, parameter names, parameter types, examples, categories) to all 40+ public-facing table functions so `SELECT * FROM duckdb_functions()` returns complete documentation
- Sets the extension-level description visible via `SELECT * FROM duckdb_extensions()`
- Uses `CreateTableFunctionInfo` + `FunctionDescription` pattern on top of existing `TableFunctionSet` factory functions — no changes to function behaviour or signatures

## Coverage

```sql
SELECT function_type, count(*) AS total, count(description) AS has_desc
FROM duckdb_functions()
WHERE function_name LIKE ANY (['http_%','odata_%','datasphere_%','sac_%','odp_%','delta_share_%','bc_%','crm_%','graph_%'])
GROUP BY function_type;
-- table: 67/67  pragma: 0/1 (pragma functions don't support FunctionDescription)
```

## Test plan

- [x] `GEN=ninja make debug` — builds clean, 61/61 targets, no new warnings
- [x] Coverage query: all 67 table functions have `has_desc = total`
- [x] Spot checks: `http_get`, `datasphere_read_relational` (2 overloads), `graph_channel_messages`, `odata_read`, `sac_get_model_info` all show populated fields
- [x] `SELECT description FROM duckdb_extensions() WHERE extension_name = 'erpl_web'` returns the extension description