### PR TITLE
fix: find OData v2 __next inside d wrapper for SAP ODP pagination

### DIFF
--- a/src/odata_content.cpp
+++ b/src/odata_content.cpp
@@ -1079,12 +1079,23 @@ std::optional<std::string> ODataJsonContentMixin::GetNextUrl(yyjson_val* root) {
         return yyjson_get_str(next_link);
     }
     
-    // Check for v2 next link
+    // Check for OData v2 __next link at root level (non-standard placement)
     auto next_link_v2 = yyjson_obj_get(root, "__next");
     if (next_link_v2 && yyjson_is_str(next_link_v2)) {
         return yyjson_get_str(next_link_v2);
     }
-    
+
+    // Check for OData v2 __next link inside the "d" wrapper (standard SAP ODP placement).
+    // Per the OData v2 JSON verbose format specification and confirmed with real SAP ODP
+    // responses, __next lives inside d: {"d": {"results": [...], "__next": "..."}}.
+    auto d_obj = yyjson_obj_get(root, "d");
+    if (d_obj) {
+        auto next_link_in_d = yyjson_obj_get(d_obj, "__next");
+        if (next_link_in_d && yyjson_is_str(next_link_in_d)) {
+            return yyjson_get_str(next_link_in_d);
+        }
+    }
+
     return std::nullopt;
 }
 

--- a/test/cpp/test_odata_content.cpp
+++ b/test/cpp/test_odata_content.cpp
@@ -371,6 +371,66 @@ TEST_CASE("Test OData v2 Error handling - missing d wrapper", "[odata_content_v2
     REQUIRE_THROWS_AS(json_content_instance.ToRows(column_names, column_types), std::runtime_error);
 }
 
+TEST_CASE("Test OData v2 NextUrl - no next link returns nullopt", "[odata_content_v2]")
+{
+    std::cout << std::endl;
+
+    // Response without any pagination link
+    std::string json_content = R"({
+        "d": {
+            "results": [
+                {"ID": "1", "Name": "Foo"}
+            ],
+            "__delta": "https://example.com/sap/opu/odata/TYED/MySvc/MySet?!deltatoken='abc'"
+        }
+    })";
+
+    ODataEntitySetJsonContent instance(json_content);
+    REQUIRE_FALSE(instance.NextUrl().has_value());
+}
+
+TEST_CASE("Test OData v2 NextUrl - __next inside d wrapper (SAP ODP standard)", "[odata_content_v2]")
+{
+    std::cout << std::endl;
+
+    // Real SAP ODP OData v2 pagination response: __next lives inside d, not at root.
+    // Confirmed with production SAP PP_ADOPS_PRODUCTIONORDER_SR responses.
+    std::string json_content = R"({
+        "d": {
+            "results": [
+                {"ID": "1", "Name": "Foo"},
+                {"ID": "2", "Name": "Bar"}
+            ],
+            "__next": "https://example.com/sap/opu/odata/TYED/MySvc/MySet?$format=json&$skiptoken=D20260415084410_000038000_0000000001_0000000010_0000000001"
+        }
+    })";
+
+    ODataEntitySetJsonContent instance(json_content);
+    auto next_url = instance.NextUrl();
+    REQUIRE(next_url.has_value());
+    REQUIRE(next_url.value() == "https://example.com/sap/opu/odata/TYED/MySvc/MySet?$format=json&$skiptoken=D20260415084410_000038000_0000000001_0000000010_0000000001");
+}
+
+TEST_CASE("Test OData v2 NextUrl - __next at root level (backward compat)", "[odata_content_v2]")
+{
+    std::cout << std::endl;
+
+    // Non-standard placement: __next at root. Retained for backward compatibility.
+    std::string json_content = R"({
+        "d": {
+            "results": [
+                {"ID": "1", "Name": "Foo"}
+            ]
+        },
+        "__next": "https://example.com/sap/opu/odata/TYED/MySvc/MySet?$skiptoken=page2"
+    })";
+
+    ODataEntitySetJsonContent instance(json_content);
+    auto next_url = instance.NextUrl();
+    REQUIRE(next_url.has_value());
+    REQUIRE(next_url.value() == "https://example.com/sap/opu/odata/TYED/MySvc/MySet?$skiptoken=page2");
+}
+
 TEST_CASE("Test OData v2 Error handling - missing results array", "[odata_content_v2]")
 {
     std::cout << std::endl;


### PR DESCRIPTION
Fix for: https://github.com/DataZooDE/erpl-web/issues/27

Per OData v2 JSON verbose spec, __next lives inside d, not at root:
  {"d": {"results": [...], "__next": "...?$skiptoken=..."}}

GetNextUrl() only checked root level, so SAP ODP pagination links were silently missed, returning only the first page of large entity sets.

Root-level check is kept for backward compatibility.