### PR TITLE
Fix/odp initial load pagination accumulate rows

### DIFF
--- a/src/include/odp_request_orchestrator.hpp
+++ b/src/include/odp_request_orchestrator.hpp
@@ -30,12 +30,15 @@ public:
         bool has_more_pages;
         int http_status_code;
         size_t response_size_bytes;
-        
-        OdpRequestResult() 
+        // Merged JSON content from all pagination pages (set when server-driven paging
+        // was followed). Use instead of response->RawContent() when non-empty.
+        std::string accumulated_raw_content;
+
+        OdpRequestResult()
             : preference_applied(false)
             , has_more_pages(false)
             , http_status_code(0)
-            , response_size_bytes(0) 
+            , response_size_bytes(0)
         {}
     };
 
@@ -139,6 +142,11 @@ public:
     static std::string EnsureJsonFormat(const std::string& url);
     static bool HasJsonFormat(const std::string& url);
     static bool ValidatePreferenceApplied(const HttpResponse& response);
+
+    // Merge OData v2 JSON pages into a single response body containing all records.
+    // Extracts the "results" array from each page and combines them, preserving
+    // the __delta link from the final page. Public for testing.
+    static std::string MergeV2Pages(const std::vector<std::string>& page_contents);
 };
 
 } // namespace erpl_web

--- a/src/odp_odata_read_bind_data.cpp
+++ b/src/odp_odata_read_bind_data.cpp
@@ -288,10 +288,13 @@ bool OdpODataReadBindData::HandleInitialLoad() {
         // Process the result
         ProcessRequestResult(result, "initial_load");
         
-        // Update OData client with pre-fetched initial response
+        // Update OData client with pre-fetched initial response.
+        // Use accumulated_raw_content when pagination was followed (contains all pages'
+        // records merged into one response body); fall back to the last page otherwise.
         if (result.response) {
-            // For initial load, we use the original URL with pre-fetched content
-            std::string response_content = result.response->RawContent();
+            std::string response_content = !result.accumulated_raw_content.empty()
+                ? result.accumulated_raw_content
+                : result.response->RawContent();
             UpdateODataClientWithResponse(entity_set_url_, response_content);
             return true;
         }
@@ -327,12 +330,16 @@ bool OdpODataReadBindData::HandleDeltaFetch() {
         // Process the result
         ProcessRequestResult(result, "delta_fetch");
         
-        // Update OData client with pre-fetched delta response
+        // Update OData client with pre-fetched delta response.
+        // Use accumulated_raw_content when pagination was followed (contains all pages'
+        // records merged into one response body); fall back to the last page otherwise.
         if (result.response) {
             std::string delta_url = !result.extracted_delta_url.empty()
                 ? result.extracted_delta_url
                 : OdpRequestOrchestrator::BuildDeltaUrl(entity_set_url_, current_token);
-            std::string response_content = result.response->RawContent();
+            std::string response_content = !result.accumulated_raw_content.empty()
+                ? result.accumulated_raw_content
+                : result.response->RawContent();
             ERPL_TRACE_INFO("ODP_BIND_DATA", "Using constructed delta URL for response injection: " + delta_url);
             UpdateODataClientWithResponse(delta_url, response_content);
             return true;

--- a/src/odp_request_orchestrator.cpp
+++ b/src/odp_request_orchestrator.cpp
@@ -34,32 +34,43 @@ OdpRequestOrchestrator::OdpRequestResult OdpRequestOrchestrator::ExecuteInitialL
     
     auto result = ExecuteRequest(request, "initial_load");
 
-    // Diagnostic: follow pagination to last page to ensure we see the final delta link
+    // Follow server-driven pagination (__next inside d), accumulating rows from all
+    // pages. The last page's delta link is used for change tracking.
     try {
         if (result.response) {
+            std::vector<std::string> page_contents;
+            page_contents.push_back(result.response->RawContent());
+
             std::optional<std::string> next_url = result.response->NextUrl();
-            idx_t pages_followed = 0;
-            while (next_url.has_value() && !next_url->empty() && pages_followed < 1000) {
+            while (next_url.has_value() && !next_url->empty()) {
                 ERPL_TRACE_INFO("ODP_ORCHESTRATOR", "Following next page: " + next_url.value());
                 auto next_res = ExecuteNextPage(next_url.value());
                 if (!next_res.response) {
                     break;
                 }
-                // Replace with the latest page so that token extraction uses the last page
+                page_contents.push_back(next_res.response->RawContent());
+
+                // Keep latest page in result for delta token/link extraction
                 result.response = next_res.response;
                 result.http_status_code = next_res.http_status_code;
                 result.response_size_bytes += next_res.response_size_bytes;
                 result.has_more_pages = next_res.has_more_pages;
 
                 next_url = next_res.response->NextUrl();
-                pages_followed++;
             }
 
-            // Re-extract token and delta link from the last page
+            // Merge all pages into a single response body when pagination was followed
+            if (page_contents.size() > 1) {
+                result.accumulated_raw_content = MergeV2Pages(page_contents);
+                ERPL_TRACE_INFO("ODP_ORCHESTRATOR", duckdb::StringUtil::Format(
+                    "Merged %zu pagination pages into single response (%zu bytes)",
+                    page_contents.size(), result.accumulated_raw_content.size()));
+            }
+
+            // Extract token and delta link from the last page
             auto raw_token = ExtractDeltaToken(*result.response);
             auto delta_link_url = ExtractDeltaUrl(*result.response);
             if (!raw_token.empty()) {
-                // Log raw token and normalized token (strip surrounding quotes if present)
                 std::string normalized = raw_token;
                 if (!normalized.empty() && (normalized.front() == '\'' || normalized.front() == '"') &&
                     normalized.back() == normalized.front()) {
@@ -82,7 +93,7 @@ OdpRequestOrchestrator::OdpRequestResult OdpRequestOrchestrator::ExecuteInitialL
             }
         }
     } catch (const std::exception &e) {
-        ERPL_TRACE_WARN("ODP_ORCHESTRATOR", std::string("Pagination diagnostic failed: ") + e.what());
+        ERPL_TRACE_WARN("ODP_ORCHESTRATOR", std::string("Pagination accumulation failed: ") + e.what());
     }
 
     return result;
@@ -110,8 +121,54 @@ OdpRequestOrchestrator::OdpRequestResult OdpRequestOrchestrator::ExecuteDeltaFet
     
     // Create delta fetch request
     HttpRequest request = http_factory_->CreateDeltaFetchRequest(delta_url, max_page_size);
-    
-    return ExecuteRequest(request, "delta_fetch");
+
+    auto result = ExecuteRequest(request, "delta_fetch");
+
+    // Follow server-driven pagination (__next inside d), accumulating rows from all pages.
+    // Large delta batches can be paginated by SAP just like initial loads.
+    try {
+        if (result.response) {
+            std::vector<std::string> page_contents;
+            page_contents.push_back(result.response->RawContent());
+
+            std::optional<std::string> next_url = result.response->NextUrl();
+            while (next_url.has_value() && !next_url->empty()) {
+                ERPL_TRACE_INFO("ODP_ORCHESTRATOR", "Delta fetch following next page: " + next_url.value());
+                auto next_res = ExecuteNextPage(next_url.value());
+                if (!next_res.response) {
+                    break;
+                }
+                page_contents.push_back(next_res.response->RawContent());
+                result.response = next_res.response;
+                result.http_status_code = next_res.http_status_code;
+                result.response_size_bytes += next_res.response_size_bytes;
+                result.has_more_pages = next_res.has_more_pages;
+                next_url = next_res.response->NextUrl();
+            }
+
+            if (page_contents.size() > 1) {
+                result.accumulated_raw_content = MergeV2Pages(page_contents);
+                ERPL_TRACE_INFO("ODP_ORCHESTRATOR", duckdb::StringUtil::Format(
+                    "Delta fetch merged %zu pagination pages (%zu bytes)",
+                    page_contents.size(), result.accumulated_raw_content.size()));
+            }
+
+            // Re-extract delta token from last page
+            auto raw_token = ExtractDeltaToken(*result.response);
+            if (!raw_token.empty()) {
+                std::string normalized = raw_token;
+                if (!normalized.empty() && (normalized.front() == '\'' || normalized.front() == '"') &&
+                    normalized.back() == normalized.front()) {
+                    normalized = normalized.substr(1, normalized.size() - 2);
+                }
+                result.extracted_delta_token = normalized;
+            }
+        }
+    } catch (const std::exception& e) {
+        ERPL_TRACE_WARN("ODP_ORCHESTRATOR", std::string("Delta fetch pagination failed: ") + e.what());
+    }
+
+    return result;
 }
 
 OdpRequestOrchestrator::OdpRequestResult OdpRequestOrchestrator::ExecuteNextPage(const std::string& next_url) {
@@ -473,6 +530,77 @@ std::string OdpRequestOrchestrator::EnsureJsonFormat(const std::string& url) {
 
 bool OdpRequestOrchestrator::HasJsonFormat(const std::string& url) {
     return url.find("$format=json") != std::string::npos;
+}
+
+std::string OdpRequestOrchestrator::MergeV2Pages(const std::vector<std::string>& page_contents) {
+    if (page_contents.empty()) {
+        return R"({"d":{"results":[]}})";
+    }
+    if (page_contents.size() == 1) {
+        return page_contents[0];
+    }
+
+    // Accumulate "results" arrays from all pages.
+    // All non-pagination properties from the last page (e.g. __delta, __count) are
+    // copied into the merged output. __count is repeated on every page with the same
+    // total value, so taking it from the last page is correct. __next is intentionally
+    // excluded as it is a per-page navigation link that must not appear in merged output.
+    duckdb_yyjson::yyjson_mut_doc* merged_doc = duckdb_yyjson::yyjson_mut_doc_new(nullptr);
+    duckdb_yyjson::yyjson_mut_val* merged_root = duckdb_yyjson::yyjson_mut_obj(merged_doc);
+    duckdb_yyjson::yyjson_mut_doc_set_root(merged_doc, merged_root);
+    duckdb_yyjson::yyjson_mut_val* merged_d = duckdb_yyjson::yyjson_mut_obj(merged_doc);
+    duckdb_yyjson::yyjson_mut_obj_add_val(merged_doc, merged_root, "d", merged_d);
+    duckdb_yyjson::yyjson_mut_val* merged_results = duckdb_yyjson::yyjson_mut_arr(merged_doc);
+    duckdb_yyjson::yyjson_mut_obj_add_val(merged_doc, merged_d, "results", merged_results);
+
+    for (size_t i = 0; i < page_contents.size(); ++i) {
+        const auto& content = page_contents[i];
+        auto doc = duckdb_yyjson::yyjson_read(content.c_str(), content.size(), 0);
+        if (!doc) {
+            continue;
+        }
+        auto root = duckdb_yyjson::yyjson_doc_get_root(doc);
+        auto d_obj = root ? duckdb_yyjson::yyjson_obj_get(root, "d") : nullptr;
+        if (d_obj) {
+            // Append all records from this page's results array
+            auto results = duckdb_yyjson::yyjson_obj_get(d_obj, "results");
+            if (results && duckdb_yyjson::yyjson_is_arr(results)) {
+                size_t idx = 0, max_idx = 0;
+                duckdb_yyjson::yyjson_val* item = nullptr;
+                yyjson_arr_foreach(results, idx, max_idx, item) {
+                    duckdb_yyjson::yyjson_mut_arr_append(merged_results,
+                        duckdb_yyjson::yyjson_val_mut_copy(merged_doc, item));
+                }
+            }
+            // On the last page: copy all d-level properties except results and __next.
+            // Properties like __delta and __count carry global (not per-page) values and
+            // are present on every page — taking them from the last page is correct.
+            if (i == page_contents.size() - 1) {
+                size_t obj_idx = 0, obj_max = 0;
+                duckdb_yyjson::yyjson_val* key = nullptr;
+                duckdb_yyjson::yyjson_val* val = nullptr;
+                yyjson_obj_foreach(d_obj, obj_idx, obj_max, key, val) {
+                    const char* key_str = duckdb_yyjson::yyjson_get_str(key);
+                    if (!key_str) continue;
+                    if (strcmp(key_str, "results") == 0) continue;
+                    if (strcmp(key_str, "__next") == 0) continue;
+                    duckdb_yyjson::yyjson_mut_obj_add_val(merged_doc, merged_d, key_str,
+                        duckdb_yyjson::yyjson_val_mut_copy(merged_doc, val));
+                }
+            }
+        }
+        duckdb_yyjson::yyjson_doc_free(doc);
+    }
+
+    size_t json_len = 0;
+    char* json_str = duckdb_yyjson::yyjson_mut_write(merged_doc, 0, &json_len);
+    std::string merged_json(json_str ? json_str : R"({"d":{"results":[]}})");
+    if (json_str) {
+        free(json_str);
+    }
+    duckdb_yyjson::yyjson_mut_doc_free(merged_doc);
+
+    return merged_json;
 }
 
 } // namespace erpl_web

--- a/test/cpp/test_odp_request_orchestrator.cpp
+++ b/test/cpp/test_odp_request_orchestrator.cpp
@@ -216,13 +216,14 @@ TEST_CASE("OdpRequestOrchestrator - HTTP Response Validation", "[odp_validation]
 TEST_CASE("OdpRequestOrchestrator - Request Result Structure", "[odp_result_structure]") {
     SECTION("Default request result") {
         OdpRequestOrchestrator::OdpRequestResult result;
-        
+
         REQUIRE(!result.response);
         REQUIRE(result.extracted_delta_token.empty());
         REQUIRE(!result.preference_applied);
         REQUIRE(!result.has_more_pages);
         REQUIRE(result.http_status_code == 0);
         REQUIRE(result.response_size_bytes == 0);
+        REQUIRE(result.accumulated_raw_content.empty());
     }
     
     SECTION("Request result with data") {
@@ -238,6 +239,88 @@ TEST_CASE("OdpRequestOrchestrator - Request Result Structure", "[odp_result_stru
         REQUIRE(result.has_more_pages);
         REQUIRE(result.http_status_code == 200);
         REQUIRE(result.response_size_bytes == 1024);
+    }
+}
+
+TEST_CASE("OdpRequestOrchestrator - MergeV2Pages", "[odp_merge_pages]") {
+    SECTION("Single page returns unchanged") {
+        std::string page = R"({"d":{"results":[{"ID":"1","Name":"Foo"}],"__delta":"https://example.com/EntitySet?!deltatoken=tok1"}})";
+        std::string merged = OdpRequestOrchestrator::MergeV2Pages({page});
+        REQUIRE(merged == page);
+    }
+
+    SECTION("Empty page list returns empty results") {
+        std::string merged = OdpRequestOrchestrator::MergeV2Pages({});
+        REQUIRE(merged.find("\"results\"") != std::string::npos);
+    }
+
+    SECTION("Two pages — records from both pages are present in merged output") {
+        std::string page1 = R"({"d":{"results":[{"ID":"REC001","Name":"A"},{"ID":"REC002","Name":"B"},{"ID":"REC003","Name":"C"}],"__next":"https://example.com/EntitySet?$skiptoken=MOCK_3"}})";
+        std::string page2 = R"({"d":{"results":[{"ID":"REC004","Name":"D"},{"ID":"REC005","Name":"E"},{"ID":"REC006","Name":"F"}],"__delta":"https://example.com/EntitySet?!deltatoken=final-token"}})";
+
+        std::string merged = OdpRequestOrchestrator::MergeV2Pages({page1, page2});
+
+        // All 6 records must be present
+        REQUIRE(merged.find("REC001") != std::string::npos);
+        REQUIRE(merged.find("REC002") != std::string::npos);
+        REQUIRE(merged.find("REC003") != std::string::npos);
+        REQUIRE(merged.find("REC004") != std::string::npos);
+        REQUIRE(merged.find("REC005") != std::string::npos);
+        REQUIRE(merged.find("REC006") != std::string::npos);
+
+        // Delta link from last page must be preserved
+        REQUIRE(merged.find("final-token") != std::string::npos);
+        REQUIRE(merged.find("__delta") != std::string::npos);
+
+        // Intermediate __next must not bleed through
+        REQUIRE(merged.find("__next") == std::string::npos);
+    }
+
+    SECTION("Three pages — all records accumulated, delta from last page") {
+        std::string page1 = R"({"d":{"results":[{"ID":"REC001"},{"ID":"REC002"},{"ID":"REC003"}],"__next":"https://example.com/EntitySet?$skiptoken=MOCK_3"}})";
+        std::string page2 = R"({"d":{"results":[{"ID":"REC004"},{"ID":"REC005"},{"ID":"REC006"}],"__next":"https://example.com/EntitySet?$skiptoken=MOCK_6"}})";
+        std::string page3 = R"({"d":{"results":[{"ID":"REC007"},{"ID":"REC008"},{"ID":"REC009"}],"__delta":"https://example.com/EntitySet?!deltatoken=abc-123"}})";
+
+        std::string merged = OdpRequestOrchestrator::MergeV2Pages({page1, page2, page3});
+
+        for (int i = 1; i <= 9; ++i) {
+            std::string id = "REC00" + std::to_string(i);
+            REQUIRE(merged.find(id) != std::string::npos);
+        }
+        REQUIRE(merged.find("abc-123") != std::string::npos);
+        REQUIRE(merged.find("__delta") != std::string::npos);
+        REQUIRE(merged.find("__next") == std::string::npos);
+    }
+
+    SECTION("Last page without delta link — no __delta in merged output") {
+        std::string page1 = R"({"d":{"results":[{"ID":"REC001"}],"__next":"https://example.com/EntitySet?$skiptoken=MOCK_1"}})";
+        std::string page2 = R"({"d":{"results":[{"ID":"REC002"}]}})";
+
+        std::string merged = OdpRequestOrchestrator::MergeV2Pages({page1, page2});
+
+        REQUIRE(merged.find("REC001") != std::string::npos);
+        REQUIRE(merged.find("REC002") != std::string::npos);
+        REQUIRE(merged.find("__delta") == std::string::npos);
+    }
+
+    SECTION("__count from last page is preserved in merged output") {
+        // OData v2 $inlinecount=allpages repeats __count on every page with the same
+        // total value. The merged output must carry it through from the last page.
+        std::string page1 = R"({"d":{"results":[{"ID":"REC001"},{"ID":"REC002"}],"__count":"4","__next":"https://example.com/EntitySet?$skiptoken=MOCK_2"}})";
+        std::string page2 = R"({"d":{"results":[{"ID":"REC003"},{"ID":"REC004"}],"__count":"4","__delta":"https://example.com/EntitySet?!deltatoken=tok-final"}})";
+
+        std::string merged = OdpRequestOrchestrator::MergeV2Pages({page1, page2});
+
+        // All records present
+        REQUIRE(merged.find("REC001") != std::string::npos);
+        REQUIRE(merged.find("REC004") != std::string::npos);
+
+        // __count must be preserved
+        REQUIRE(merged.find("__count") != std::string::npos);
+        REQUIRE(merged.find("\"4\"") != std::string::npos);
+
+        // __next must not bleed through
+        REQUIRE(merged.find("__next") == std::string::npos);
     }
 }
 

--- a/test/sql/odata_v2.test
+++ b/test/sql/odata_v2.test
@@ -25,10 +25,19 @@ SELECT 1 FROM odata_read('https://services.odata.org/V2/Northwind/Northwind.svc/
 1
 
 # Test v2 endpoint without explicit version path (default $count disabled)
+# NOTE: this endpoint paginates at 20 records per page but does NOT follow __next,
+# so it intentionally returns only the first page (server behaviour without Prefer header).
 query I
 SELECT COUNT(*) FROM odata_read('https://services.odata.org/northwind/northwind.svc/Customers');
 ----
 20
+
+# Test that all pagination pages are accumulated: Northwind V2 Customers has 91 records
+# served in pages of 20 via __next inside d. Without accumulation only 20 are returned.
+query I
+SELECT COUNT(*) FROM odata_read('https://services.odata.org/V2/Northwind/Northwind.svc/Customers');
+----
+91
 
 # Test expand on V2 entity set
 query I

--- a/test/sql/sap/odp_odata_read.test
+++ b/test/sql/sap/odp_odata_read.test
@@ -37,6 +37,16 @@ SELECT COUNT(*) FROM odp_odata_read('${ERPL_SAP_BASE_URL}/sap/opu/odata/sap/Z_OD
 ----
 132
 
+# Verify that all pagination pages are accumulated during initial load.
+# This entity set must span more than one SAP server page (use an entity set
+# with > page_size records, e.g. one that SAP returns with __next inside d).
+# Without accumulation only the last page's records are returned.
+# Run against ABAP Trial: ERPL_SAP_BASE_URL=http://localhost:50000 ERPL_SAP_PASSWORD=ABAPtr2023#00
+query I
+SELECT COUNT(*) FROM odp_odata_read('${ERPL_SAP_BASE_URL}/sap/opu/odata/sap/Z_ODP_BW_1_SRV/FactsOf0D_NW_C01', secret='odp_odata_read', max_page_size=50);
+----
+132
+
 
 
 


### PR DESCRIPTION
## Fix: accumulate rows from all OData v2 pagination pages in ODP reads

### Problem

`odp_odata_read` failed to return all records when the SAP server split a response across multiple pages via `__next`. Two separate issues:

1. **`ExecuteInitialLoad()`** followed `__next` links but overwrote `result.response` on each iteration, discarding all but the last page's records before they could be parsed into rows.
2. **`ExecuteDeltaFetch()`** did not follow `__next` at all — large delta batches were silently truncated to the first page.

### Solution

Both methods now collect the raw JSON body from every page into a `std::vector<std::string>`. When more than one page was fetched, the new `MergeV2Pages()` utility merges them into a single OData v2 JSON document before row parsing:

- All `results` arrays are concatenated in order
- All non-pagination properties from the last page (`__delta`, `__count`, …) are copied into the merged output — `__next` is the only excluded property, as it is a per-page navigation link
- `__count` (from `$inlinecount=allpages`) is present on every page with the same total value, so taking it from the last page is correct

The merged content is stored in the new `accumulated_raw_content` field on `OdpRequestResult`. `HandleInitialLoad()` and `HandleDeltaFetch()` in `odp_odata_read_bind_data.cpp` use this field when non-empty, falling back to the single-page response otherwise.

The hardcoded 1000-page guard was also removed — pagination stops naturally when the server no longer returns a `__next` link.

`MergeV2Pages()` is exposed as a public static method for unit testability.

### Limitation

All raw page JSON is buffered simultaneously before any row is emitted. For very large entity sets served across many pages this increases peak memory usage proportionally to the total response size. The alternative — holding a `pending_next_url` across `FetchNextResult()` calls and streaming pages lazily — avoids this but requires a more significant refactor of the bind-data state machine. That is left as a follow-up.

### Tests

- **C++ unit tests** (`test_odp_request_orchestrator.cpp`): 6 new `MergeV2Pages` cases covering single page, empty list, two/three pages with full record accumulation, last page without `__delta`, and `__count` preservation
- **SQL integration test** (`test/sql/sap/odp_odata_read.test`): `max_page_size=50` against ABAP Trial forces multi-page fetch and asserts all 132 records are returned (requires `ERPL_SAP_BASE_URL`). I do not have access to SAP on my dev machine - so they are not verified! 
  -> **Would be good if someone with access to a dev system could test them.**
- **SQL regression test** (`test/sql/odata_v2.test`): asserts all 91 Northwind V2 Customers are returned end-to-end (covers the related `__next`-inside-`d` fix on which this branch builds)
