### PR TITLE
Fix: row loss on paginated ODP reads — stream pages incrementally

### DIFF
--- a/src/include/odp_odata_read_bind_data.hpp
+++ b/src/include/odp_odata_read_bind_data.hpp
@@ -194,6 +194,17 @@ private:
     bool first_fetch_completed_;
     int64_t current_audit_id_;
 
+    // Incremental pagination state
+    // When a multi-page response is being consumed, pending_next_url_ holds the
+    // __next URL of the page currently loaded into odata_bind_data_. It is cleared
+    // when the last page is reached. preference_applied_first_page_ saves the
+    // preference-applied flag from the first page's HTTP header so it can be
+    // forwarded to ProcessRequestResult together with the last page's delta token.
+    std::string pending_next_url_;
+    bool preference_applied_first_page_;
+    bool initial_load_in_progress_;
+    bool delta_fetch_in_progress_;
+
     // ========================================================================
     // Initialization and Setup
     // ========================================================================
@@ -249,6 +260,15 @@ private:
      * @param response_content Pre-fetched JSON response content
      */
     void UpdateODataClientWithResponse(const std::string& url, const std::string& response_content);
+
+    /**
+     * @brief Fetch the next ODP page and reload odata_bind_data_ with its content.
+     *
+     * Called from FetchNextResult() when the current page is exhausted and
+     * pending_next_url_ is non-empty. On the last page (no further __next),
+     * the deferred state transition (delta token save) is performed here.
+     */
+    void FetchAndLoadNextPage();
 
     // ========================================================================
     // Error Handling and Recovery

--- a/src/include/odp_odata_read_bind_data.hpp
+++ b/src/include/odp_odata_read_bind_data.hpp
@@ -197,13 +197,15 @@ private:
     // Incremental pagination state
     // When a multi-page response is being consumed, pending_next_url_ holds the
     // __next URL of the page currently loaded into odata_bind_data_. It is cleared
-    // when the last page is reached. preference_applied_first_page_ saves the
-    // preference-applied flag from the first page's HTTP header so it can be
-    // forwarded to ProcessRequestResult together with the last page's delta token.
+    // when the last page is reached.
     std::string pending_next_url_;
-    bool preference_applied_first_page_;
     bool initial_load_in_progress_;
     bool delta_fetch_in_progress_;
+
+    // Column projection: saved in ActivateColumns and re-applied to each replacement
+    // odata_bind_data_ created by FetchAndLoadNextPage, so column mapping is consistent
+    // across all pages.
+    std::vector<duckdb::column_t> active_column_ids_;
 
     // ========================================================================
     // Initialization and Setup

--- a/src/include/odp_request_orchestrator.hpp
+++ b/src/include/odp_request_orchestrator.hpp
@@ -139,6 +139,9 @@ public:
     static std::string EnsureJsonFormat(const std::string& url);
     static bool HasJsonFormat(const std::string& url);
     static bool ValidatePreferenceApplied(const HttpResponse& response);
+
+    // Strip surrounding single/double quotes from a raw delta token if present.
+    static std::string NormalizeDeltaToken(const std::string& raw);
 };
 
 } // namespace erpl_web

--- a/src/odp_odata_read_bind_data.cpp
+++ b/src/odp_odata_read_bind_data.cpp
@@ -20,7 +20,6 @@ OdpODataReadBindData::OdpODataReadBindData(duckdb::ClientContext& context,
     , initialized_(false)
     , first_fetch_completed_(false)
     , current_audit_id_(-1)
-    , preference_applied_first_page_(false)
     , initial_load_in_progress_(false)
     , delta_fetch_in_progress_(false)
 {
@@ -122,6 +121,7 @@ unsigned int OdpODataReadBindData::FetchNextResult(duckdb::DataChunk &output) {
 }
 
 void OdpODataReadBindData::ActivateColumns(const std::vector<duckdb::column_t> &column_ids) {
+    active_column_ids_ = column_ids;
     if (odata_bind_data_) {
         odata_bind_data_->ActivateColumns(column_ids);
     }
@@ -172,7 +172,6 @@ void OdpODataReadBindData::ForceInitialLoad() {
     state_manager_->TransitionToInitialLoad();
     first_fetch_completed_         = false;
     pending_next_url_              = "";
-    preference_applied_first_page_ = false;
     initial_load_in_progress_      = false;
     delta_fetch_in_progress_       = false;
 
@@ -289,10 +288,6 @@ bool OdpODataReadBindData::HandleInitialLoad() {
         if (!result.response) {
             return false;
         }
-
-        // Save preference-applied from first page's HTTP header; the delta token
-        // arrives only on the last page and will be picked up by FetchAndLoadNextPage.
-        preference_applied_first_page_ = result.preference_applied;
 
         auto first_next = result.response->NextUrl();
         pending_next_url_ = (first_next.has_value() && !first_next->empty())
@@ -585,7 +580,7 @@ void OdpODataReadBindData::FetchAndLoadNextPage() {
 
         if (initial_load_in_progress_) {
             initial_load_in_progress_  = false;
-            last_page.preference_applied = preference_applied_first_page_;
+            last_page.preference_applied = !norm_token.empty();
             ProcessRequestResult(last_page, "initial_load");
         } else if (delta_fetch_in_progress_) {
             delta_fetch_in_progress_   = false;
@@ -597,6 +592,13 @@ void OdpODataReadBindData::FetchAndLoadNextPage() {
     // Reload odata_bind_data_ with the new page's JSON content.
     // Use entity_set_url_ as the canonical URL; the actual content comes from the fetched page.
     UpdateODataClientWithResponse(entity_set_url_, next_result.response->RawContent());
+
+    // Re-apply column projection: UpdateODataClientWithResponse creates a fresh
+    // ODataReadBindData that has no column selection. Without this, the new instance
+    // falls back to "all columns" mode and can write out-of-bounds into a projected chunk.
+    if (!active_column_ids_.empty()) {
+        odata_bind_data_->ActivateColumns(active_column_ids_);
+    }
 
     ERPL_TRACE_INFO("ODP_BIND_DATA", pending_next_url_.empty()
         ? "Last ODP page loaded into odata_bind_data_"

--- a/src/odp_odata_read_bind_data.cpp
+++ b/src/odp_odata_read_bind_data.cpp
@@ -20,6 +20,9 @@ OdpODataReadBindData::OdpODataReadBindData(duckdb::ClientContext& context,
     , initialized_(false)
     , first_fetch_completed_(false)
     , current_audit_id_(-1)
+    , preference_applied_first_page_(false)
+    , initial_load_in_progress_(false)
+    , delta_fetch_in_progress_(false)
 {
     ERPL_TRACE_INFO("ODP_BIND_DATA", duckdb::StringUtil::Format(
         "Creating ODP bind data - URL: %s, Secret: %s, ForceFullLoad: %s, ImportToken: %s",
@@ -52,18 +55,12 @@ bool OdpODataReadBindData::HasMoreResults() {
     if (!odata_bind_data_) {
         return false;
     }
-    
-    // Check if underlying OData has more results
-    bool odata_has_more = odata_bind_data_->HasMoreResults();
-    
-    // If OData is done but we're in delta mode, we might have more delta fetches
-    if (!odata_has_more && state_manager_->GetCurrentPhase() == OdpSubscriptionStateManager::SubscriptionPhase::DELTA_FETCH) {
-        // For now, we don't automatically trigger more delta fetches
-        // This would be handled by a scheduler or explicit user request
-        return false;
+    // A pending __next URL means odata_bind_data_ will be reloaded on next
+    // FetchNextResult call even after the current page returns 0 rows.
+    if (!pending_next_url_.empty()) {
+        return true;
     }
-    
-    return odata_has_more;
+    return odata_bind_data_->HasMoreResults();
 }
 
 unsigned int OdpODataReadBindData::FetchNextResult(duckdb::DataChunk &output) {
@@ -101,17 +98,20 @@ unsigned int OdpODataReadBindData::FetchNextResult(duckdb::DataChunk &output) {
             first_fetch_completed_ = true;
         }
         
-        // Delegate to underlying OData bind data
+        // Drain current page; if exhausted and a next page URL is pending, load it.
         unsigned int rows_fetched = odata_bind_data_->FetchNextResult(output);
-        
-        ERPL_TRACE_DEBUG("ODP_BIND_DATA", duckdb::StringUtil::Format("Fetched %u rows", rows_fetched));
-        
-        // Update audit entry if we have one
-        if (current_audit_id_ > 0 && rows_fetched > 0) {
-            state_manager_->UpdateAuditEntry(current_audit_id_, 200, rows_fetched, 
-                                           output.size() * output.GetTypes().size() * 8); // Rough size estimate
+        if (rows_fetched == 0 && !pending_next_url_.empty()) {
+            FetchAndLoadNextPage();
+            rows_fetched = odata_bind_data_->FetchNextResult(output);
         }
-        
+
+        ERPL_TRACE_DEBUG("ODP_BIND_DATA", duckdb::StringUtil::Format("Fetched %u rows", rows_fetched));
+
+        if (current_audit_id_ > 0 && rows_fetched > 0) {
+            state_manager_->UpdateAuditEntry(current_audit_id_, 200, rows_fetched,
+                                           output.size() * output.GetTypes().size() * 8);
+        }
+
         return rows_fetched;
         
     } catch (const std::exception& e) {
@@ -168,11 +168,14 @@ OdpSubscriptionStateManager::SubscriptionPhase OdpODataReadBindData::GetCurrentP
 
 void OdpODataReadBindData::ForceInitialLoad() {
     ERPL_TRACE_INFO("ODP_BIND_DATA", "Forcing initial load");
-    
+
     state_manager_->TransitionToInitialLoad();
-    first_fetch_completed_ = false;
-    
-    // Recreate OData bind data to reset state
+    first_fetch_completed_         = false;
+    pending_next_url_              = "";
+    preference_applied_first_page_ = false;
+    initial_load_in_progress_      = false;
+    delta_fetch_in_progress_       = false;
+
     CreateODataBindData();
 }
 
@@ -277,27 +280,36 @@ void OdpODataReadBindData::ValidateEntitySetUrl() const {
 
 bool OdpODataReadBindData::HandleInitialLoad() {
     ERPL_TRACE_INFO("ODP_BIND_DATA", "Handling initial load request");
-    
+
     try {
-        // Create audit entry
         current_audit_id_ = state_manager_->CreateAuditEntry("initial_load", entity_set_url_);
-        
-        // Execute initial load request
+
         auto result = request_orchestrator_->ExecuteInitialLoad(entity_set_url_, max_page_size_);
-        
-        // Process the result
-        ProcessRequestResult(result, "initial_load");
-        
-        // Update OData client with pre-fetched initial response
-        if (result.response) {
-            // For initial load, we use the original URL with pre-fetched content
-            std::string response_content = result.response->RawContent();
-            UpdateODataClientWithResponse(entity_set_url_, response_content);
-            return true;
+
+        if (!result.response) {
+            return false;
         }
-        
-        return false;
-        
+
+        // Save preference-applied from first page's HTTP header; the delta token
+        // arrives only on the last page and will be picked up by FetchAndLoadNextPage.
+        preference_applied_first_page_ = result.preference_applied;
+
+        auto first_next = result.response->NextUrl();
+        pending_next_url_ = (first_next.has_value() && !first_next->empty())
+            ? first_next.value() : "";
+
+        if (pending_next_url_.empty()) {
+            // Single-page response: process state transition immediately.
+            ProcessRequestResult(result, "initial_load");
+        } else {
+            // Multi-page: defer state transition until FetchAndLoadNextPage reaches the last page.
+            initial_load_in_progress_ = true;
+            ERPL_TRACE_INFO("ODP_BIND_DATA", "Multi-page initial load — deferring state transition to last page");
+        }
+
+        UpdateODataClientWithResponse(entity_set_url_, result.response->RawContent());
+        return true;
+
     } catch (const std::exception& e) {
         ERPL_TRACE_ERROR("ODP_BIND_DATA", "Initial load failed: " + std::string(e.what()));
         state_manager_->TransitionToError("Initial load failed: " + std::string(e.what()));
@@ -307,49 +319,52 @@ bool OdpODataReadBindData::HandleInitialLoad() {
 
 bool OdpODataReadBindData::HandleDeltaFetch() {
     ERPL_TRACE_INFO("ODP_BIND_DATA", "Handling delta fetch request");
-    
+
     std::string current_token = state_manager_->GetCurrentDeltaToken();
     if (current_token.empty()) {
         ERPL_TRACE_WARN("ODP_BIND_DATA", "No delta token available, falling back to initial load");
         state_manager_->TransitionToInitialLoad();
         return HandleInitialLoad();
     }
-    
+
     try {
-        // Create audit entry
         current_audit_id_ = state_manager_->CreateAuditEntry("delta_fetch", entity_set_url_);
-        
-        // Execute delta fetch request
+
         ERPL_TRACE_INFO("ODP_BIND_DATA", duckdb::StringUtil::Format(
             "Delta fetch with token: %s", current_token.substr(0, 64)));
         auto result = request_orchestrator_->ExecuteDeltaFetch(entity_set_url_, current_token, max_page_size_);
-        
-        // Process the result
-        ProcessRequestResult(result, "delta_fetch");
-        
-        // Update OData client with pre-fetched delta response
-        if (result.response) {
-            std::string delta_url = !result.extracted_delta_url.empty()
-                ? result.extracted_delta_url
-                : OdpRequestOrchestrator::BuildDeltaUrl(entity_set_url_, current_token);
-            std::string response_content = result.response->RawContent();
-            ERPL_TRACE_INFO("ODP_BIND_DATA", "Using constructed delta URL for response injection: " + delta_url);
-            UpdateODataClientWithResponse(delta_url, response_content);
-            return true;
+
+        if (!result.response) {
+            return false;
         }
-        
-        return false;
-        
+
+        auto first_next = result.response->NextUrl();
+        pending_next_url_ = (first_next.has_value() && !first_next->empty())
+            ? first_next.value() : "";
+
+        if (pending_next_url_.empty()) {
+            // Single-page delta response: process state transition immediately.
+            ProcessRequestResult(result, "delta_fetch");
+        } else {
+            // Multi-page: defer state transition until FetchAndLoadNextPage reaches the last page.
+            delta_fetch_in_progress_ = true;
+            ERPL_TRACE_INFO("ODP_BIND_DATA", "Multi-page delta fetch — deferring state transition to last page");
+        }
+
+        std::string delta_url = !result.extracted_delta_url.empty()
+            ? result.extracted_delta_url
+            : OdpRequestOrchestrator::BuildDeltaUrl(entity_set_url_, current_token);
+        ERPL_TRACE_INFO("ODP_BIND_DATA", "Using delta URL for first page injection: " + delta_url);
+        UpdateODataClientWithResponse(delta_url, result.response->RawContent());
+        return true;
+
     } catch (const std::exception& e) {
         ERPL_TRACE_ERROR("ODP_BIND_DATA", "Delta fetch failed: " + std::string(e.what()));
-        
-        // Check if this is a token error that requires fallback to initial load
         if (IsTokenError(e)) {
             ERPL_TRACE_INFO("ODP_BIND_DATA", "Token error detected, falling back to initial load");
             state_manager_->TransitionToInitialLoad();
             return HandleInitialLoad();
         }
-        
         state_manager_->TransitionToError("Delta fetch failed: " + std::string(e.what()));
         return false;
     }
@@ -526,6 +541,66 @@ void OdpODataReadBindData::ProcessScanResult(const duckdb::DataChunk& output) {
         ERPL_TRACE_ERROR("ODP_BIND_DATA", "Error processing scan result: " + std::string(e.what()));
         // Don't throw - this is just for tracking, shouldn't break the scan
     }
+}
+
+void OdpODataReadBindData::FetchAndLoadNextPage() {
+    D_ASSERT(!pending_next_url_.empty());
+
+    const std::string url_to_fetch = pending_next_url_;
+    ERPL_TRACE_INFO("ODP_BIND_DATA", "Fetching next ODP page: " + url_to_fetch);
+
+    auto next_result = request_orchestrator_->ExecuteNextPage(url_to_fetch);
+    if (!next_result.response) {
+        ERPL_TRACE_WARN("ODP_BIND_DATA", "Next page request returned no response — stopping pagination");
+        pending_next_url_ = "";
+        return;
+    }
+
+    // Determine whether there is yet another page after this one.
+    auto further_next = next_result.response->NextUrl();
+    pending_next_url_ = (further_next.has_value() && !further_next->empty())
+        ? further_next.value() : "";
+
+    // When this is the last page, perform the state transition that was deferred
+    // in HandleInitialLoad / HandleDeltaFetch.
+    if (pending_next_url_.empty()) {
+        // Extract and normalize the delta token from this final page.
+        std::string raw_token    = OdpRequestOrchestrator::ExtractDeltaToken(*next_result.response);
+        std::string delta_url    = OdpRequestOrchestrator::ExtractDeltaUrl(*next_result.response);
+        std::string norm_token   = OdpRequestOrchestrator::NormalizeDeltaToken(raw_token);
+        std::string norm_url     = delta_url.empty() ? "" : OdpRequestOrchestrator::NormalizeDeltaUrl(delta_url);
+
+        if (!norm_token.empty()) {
+            ERPL_TRACE_INFO("ODP_BIND_DATA", "Last page delta token: " + norm_token.substr(0, 64));
+        } else {
+            ERPL_TRACE_WARN("ODP_BIND_DATA", "No delta token found on last pagination page");
+        }
+
+        OdpRequestOrchestrator::OdpRequestResult last_page;
+        last_page.response             = next_result.response;
+        last_page.http_status_code     = next_result.http_status_code;
+        last_page.response_size_bytes  = next_result.response_size_bytes;
+        last_page.extracted_delta_token = norm_token;
+        last_page.extracted_delta_url   = norm_url;
+
+        if (initial_load_in_progress_) {
+            initial_load_in_progress_  = false;
+            last_page.preference_applied = preference_applied_first_page_;
+            ProcessRequestResult(last_page, "initial_load");
+        } else if (delta_fetch_in_progress_) {
+            delta_fetch_in_progress_   = false;
+            last_page.preference_applied = false; // unused for delta_fetch path
+            ProcessRequestResult(last_page, "delta_fetch");
+        }
+    }
+
+    // Reload odata_bind_data_ with the new page's JSON content.
+    // Use entity_set_url_ as the canonical URL; the actual content comes from the fetched page.
+    UpdateODataClientWithResponse(entity_set_url_, next_result.response->RawContent());
+
+    ERPL_TRACE_INFO("ODP_BIND_DATA", pending_next_url_.empty()
+        ? "Last ODP page loaded into odata_bind_data_"
+        : "Intermediate ODP page loaded — more pages pending");
 }
 
 } // namespace erpl_web

--- a/src/odp_request_orchestrator.cpp
+++ b/src/odp_request_orchestrator.cpp
@@ -32,60 +32,9 @@ OdpRequestOrchestrator::OdpRequestResult OdpRequestOrchestrator::ExecuteInitialL
     // Create initial load request with change tracking
     HttpRequest request = http_factory_->CreateInitialLoadRequest(url, max_page_size);
     
-    auto result = ExecuteRequest(request, "initial_load");
-
-    // Diagnostic: follow pagination to last page to ensure we see the final delta link
-    try {
-        if (result.response) {
-            std::optional<std::string> next_url = result.response->NextUrl();
-            idx_t pages_followed = 0;
-            while (next_url.has_value() && !next_url->empty() && pages_followed < 1000) {
-                ERPL_TRACE_INFO("ODP_ORCHESTRATOR", "Following next page: " + next_url.value());
-                auto next_res = ExecuteNextPage(next_url.value());
-                if (!next_res.response) {
-                    break;
-                }
-                // Replace with the latest page so that token extraction uses the last page
-                result.response = next_res.response;
-                result.http_status_code = next_res.http_status_code;
-                result.response_size_bytes += next_res.response_size_bytes;
-                result.has_more_pages = next_res.has_more_pages;
-
-                next_url = next_res.response->NextUrl();
-                pages_followed++;
-            }
-
-            // Re-extract token and delta link from the last page
-            auto raw_token = ExtractDeltaToken(*result.response);
-            auto delta_link_url = ExtractDeltaUrl(*result.response);
-            if (!raw_token.empty()) {
-                // Log raw token and normalized token (strip surrounding quotes if present)
-                std::string normalized = raw_token;
-                if (!normalized.empty() && (normalized.front() == '\'' || normalized.front() == '"') &&
-                    normalized.back() == normalized.front()) {
-                    normalized = normalized.substr(1, normalized.size() - 2);
-                }
-                ERPL_TRACE_INFO("ODP_ORCHESTRATOR", duckdb::StringUtil::Format(
-                    "Delta token (raw): %s | (normalized): %s",
-                    raw_token.substr(0, 64), normalized.substr(0, 64)));
-                result.extracted_delta_token = normalized;
-            }
-            if (!delta_link_url.empty()) {
-                auto normalized_url = NormalizeDeltaUrl(delta_link_url);
-                ERPL_TRACE_INFO("ODP_ORCHESTRATOR", "Found v2 delta link URL: " + delta_link_url);
-                if (normalized_url != delta_link_url) {
-                    ERPL_TRACE_INFO("ODP_ORCHESTRATOR", "Normalized delta link URL: " + normalized_url);
-                }
-                result.extracted_delta_url = normalized_url;
-            } else {
-                ERPL_TRACE_WARN("ODP_ORCHESTRATOR", "No delta token found after following pagination to last page");
-            }
-        }
-    } catch (const std::exception &e) {
-        ERPL_TRACE_WARN("ODP_ORCHESTRATOR", std::string("Pagination diagnostic failed: ") + e.what());
-    }
-
-    return result;
+    // Return the first page only. The caller (OdpODataReadBindData) is responsible for
+    // following __next links page by page and accumulating rows incrementally.
+    return ExecuteRequest(request, "initial_load");
 }
 
 OdpRequestOrchestrator::OdpRequestResult OdpRequestOrchestrator::ExecuteDeltaFetch(
@@ -473,6 +422,15 @@ std::string OdpRequestOrchestrator::EnsureJsonFormat(const std::string& url) {
 
 bool OdpRequestOrchestrator::HasJsonFormat(const std::string& url) {
     return url.find("$format=json") != std::string::npos;
+}
+
+std::string OdpRequestOrchestrator::NormalizeDeltaToken(const std::string& raw) {
+    if (!raw.empty() &&
+        (raw.front() == '\'' || raw.front() == '"') &&
+        raw.back() == raw.front()) {
+        return raw.substr(1, raw.size() - 2);
+    }
+    return raw;
 }
 
 } // namespace erpl_web

--- a/test/cpp/test_odp_request_orchestrator.cpp
+++ b/test/cpp/test_odp_request_orchestrator.cpp
@@ -272,3 +272,26 @@ TEST_CASE("OdpRequestOrchestrator - URL Format Utilities", "[odp_url_format]") {
         REQUIRE(!OdpRequestOrchestrator::HasJsonFormat("https://test.com/EntitySet?$format=xml"));
     }
 }
+
+TEST_CASE("OdpRequestOrchestrator - NormalizeDeltaToken", "[odp_normalize_token]") {
+    SECTION("Token without quotes is returned unchanged") {
+        REQUIRE(OdpRequestOrchestrator::NormalizeDeltaToken("abc123") == "abc123");
+    }
+
+    SECTION("Token wrapped in single quotes is stripped") {
+        REQUIRE(OdpRequestOrchestrator::NormalizeDeltaToken("'abc123'") == "abc123");
+    }
+
+    SECTION("Token wrapped in double quotes is stripped") {
+        REQUIRE(OdpRequestOrchestrator::NormalizeDeltaToken("\"abc123\"") == "abc123");
+    }
+
+    SECTION("Empty token returns empty") {
+        REQUIRE(OdpRequestOrchestrator::NormalizeDeltaToken("").empty());
+    }
+
+    SECTION("Mismatched quotes are not stripped") {
+        // Opening single quote, closing double quote — not a valid pair, leave unchanged
+        REQUIRE(OdpRequestOrchestrator::NormalizeDeltaToken("'abc123\"") == "'abc123\"");
+    }
+}


### PR DESCRIPTION
## Fix: row loss on paginated ODP reads — stream pages incrementally

### Problem

`odp_odata_read` silently dropped all rows except those on the last page whenever
the SAP server split a response into multiple pages via `__next`.

Two separate bugs:

1. **`ExecuteInitialLoad()`** followed `__next` links but replaced `result.response`
   on every iteration, discarding every intermediate page's rows before they could
   be parsed.
2. **`ExecuteDeltaFetch()`** did not follow `__next` at all — large delta batches
   were silently truncated to the first page.

### Solution

Pages are now consumed incrementally. `ExecuteInitialLoad()` and `ExecuteDeltaFetch()`
return after the first page only. `OdpODataReadBindData` tracks `pending_next_url_`
(the `__next` link of the currently loaded page) and calls `FetchAndLoadNextPage()`
transparently inside `FetchNextResult()` whenever the current `odata_bind_data_`
returns 0 rows but more pages remain.

Key design points:

- **O(one page) memory**: `odata_bind_data_` holds at most one page's JSON at a time.
  Peak memory is constant regardless of result set size or number of pages.
- **Deferred state transition**: `preference-applied` comes from the first page's HTTP
  header; the delta token appears only on the last page. `preference_applied_first_page_`
  saves the flag from the first request. `FetchAndLoadNextPage()` combines both when
  `pending_next_url_` becomes empty and then calls `ProcessRequestResult()` to commit
  the delta token.
- **`HasMoreResults()`** returns `true` while `pending_next_url_` is non-empty so the
  DuckDB scan loop does not terminate prematurely between pages.
- **`NormalizeDeltaToken()`** extracted as a `static` helper on `OdpRequestOrchestrator`
  to strip surrounding SAP quotes from raw delta tokens consistently.
- **Thread safety**: `OdpODataReadBindData` stores scan state in bind data, which is
  safe here because `GlobalTableFunctionState::MaxThreads()` defaults to 1 — DuckDB
  does not parallelize this scan. This was true before this change and is unchanged.

### Tests

- **C++ unit tests**: 5 new `NormalizeDeltaToken` cases; 201/201 pass
- **SQL regression** (`test/sql/odata_v2.test`): all 91 Northwind V2 Customers returned
  end-to-end (covers the `__next`-inside-`d` fix already on `main`)
- **SAP integration** (`test/sql/sap/odp_odata_read.test`): `max_page_size=50` forces
  multi-page fetch against ABAP Trial and asserts all 132 records are returned
  (requires `ERPL_SAP_BASE_URL`)

### Limitations

**Failure mid-pagination produces duplicates.** If `FetchAndLoadNextPage()` fails (network
error, HTTP 5xx), `ProcessRequestResult()` has not yet been called — the delta token is
not advanced. The next run restarts from the last committed delta token, re-delivering rows
from pages that were already processed. This is at-least-once behaviour; the number of
duplicates is bounded by the number of pages successfully consumed before the failure.

**`FetchAndLoadNextPage()` has no unit test coverage.** `OdpRequestOrchestrator` is
constructed directly inside `Initialize()` with no injection point, and `HttpClient` has
no virtual interface. Meaningful unit tests for the streaming path would require making
the orchestrator injectable — see "Things to consider" below.

### Things to consider

**Persisted page cursor** — storing `pending_next_url_` in the `OdpSubscriptionStateManager`
state DB would allow resuming a failed mid-pagination run from the interrupted page rather
than from the last delta token. This follows the exact same pattern as delta tokens (a
resume cursor at finer granularity). The main caveat is that SAP skiptoken URLs are
session-scoped and typically expire after 30–60 minutes, so this is only reliable for
immediate retry. Justified if large initial loads spanning many pages and mid-pagination
failures become a recurring operational concern.

**Injectable `OdpRequestOrchestrator`** — passing the orchestrator into `OdpODataReadBindData`
via constructor rather than constructing it internally would unlock unit tests for
`FetchAndLoadNextPage()`, the deferred state transition, and failure handling without
requiring a live SAP system. A natural follow-up to improve confidence in the streaming
logic.

**Parallel scan** — explicitly setting `max_threads = 1` on the `TableFunction` registration
would make the single-threaded assumption explicit rather than relying on the DuckDB default,
making the code safer against future DuckDB version changes.