### PR TITLE
fix: prevent duplicate column crash in graph_list_items (SharePoint #8)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,15 @@ test_debug_sap: ${EXTENSION_CONFIG_STEP}
 	ERPL_SAP_BASE_URL='http://localhost:50000' ERPL_SAP_PASSWORD='ABAPtr2023#00' ./build/debug/test/unittest "[sap]"
 
 # Run Microsoft 365 / Graph API integration tests against a real tenant.
-# Requires three environment variables sourced from an Azure App Registration
-# with application permissions granted and admin-consented:
-#   ERPL_MS_TENANT_ID    - Directory (tenant) ID from the App Registration overview
-#   ERPL_MS_CLIENT_ID    - Application (client) ID from the App Registration overview
-#   ERPL_MS_CLIENT_SECRET - Client secret value (not the secret ID)
+# Requires environment variables sourced from an Azure App Registration with
+# application permissions granted and admin-consented. See .env.microsoft.
+#   ERPL_MS_TENANT_ID           - Directory (tenant) ID
+#   ERPL_MS_CLIENT_ID           - Application (client) ID
+#   ERPL_MS_CLIENT_SECRET       - Client secret value (not the secret ID)
+#   ERPL_MS_SHAREPOINT_SITE_ID  - SharePoint site composite ID for SP tests
+#   ERPL_MS_SHAREPOINT_LIST_ID  - SharePoint list ID within that site for SP tests
 # Usage:
-#   export ERPL_MS_TENANT_ID=<guid> ERPL_MS_CLIENT_ID=<guid> ERPL_MS_CLIENT_SECRET=<value>
-#   make test_debug_ms
+#   source .env.microsoft && make test_debug_ms
 test_debug_ms: ${EXTENSION_CONFIG_STEP}
 	./build/debug/test/unittest "test/sql/graph_entra_integration.test"
 	./build/debug/test/unittest "test/sql/graph_planner_integration.test"

--- a/src/graph_sharepoint_functions.cpp
+++ b/src/graph_sharepoint_functions.cpp
@@ -5,6 +5,8 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "yyjson.hpp"
+#include <algorithm>
+#include <unordered_set>
 
 using namespace duckdb_yyjson;
 
@@ -474,6 +476,9 @@ unique_ptr<FunctionData> GraphSharePointFunctions::ListItemsBind(
     return_types.push_back(LogicalType::VARCHAR);
     bind_data->column_names.push_back("id");
 
+    // Track seen names (lowercase) to prevent duplicate column errors
+    std::unordered_set<std::string> seen_names = {"id"};
+
     if (col_arr && yyjson_is_arr(col_arr)) {
         size_t idx, max;
         yyjson_val *col;
@@ -491,6 +496,11 @@ unique_ptr<FunctionData> GraphSharePointFunctions::ListItemsBind(
                     col_name == "AppAuthor" || col_name == "AppEditor") {
                     continue;
                 }
+
+                // Skip case-insensitive duplicates (e.g. "ID" collides with "id")
+                std::string lower_name = col_name;
+                std::transform(lower_name.begin(), lower_name.end(), lower_name.begin(), ::tolower);
+                if (!seen_names.insert(lower_name).second) continue;
 
                 names.push_back(col_name);
                 return_types.push_back(LogicalType::VARCHAR);

--- a/test/sql/graph_sharepoint_integration.test
+++ b/test/sql/graph_sharepoint_integration.test
@@ -1,7 +1,6 @@
 # name: test/sql/graph_sharepoint_integration.test
-# description: Integration tests for Microsoft Graph SharePoint
+# description: Integration tests for Microsoft Graph SharePoint Lists
 # group: [erpl_web]
-# note: Requires Sites.Read.All application permission in Azure AD
 
 require erpl_web
 
@@ -11,9 +10,13 @@ require-env ERPL_MS_CLIENT_ID
 
 require-env ERPL_MS_CLIENT_SECRET
 
+require-env ERPL_MS_SHAREPOINT_SITE_ID
+
+require-env ERPL_MS_SHAREPOINT_LIST_ID
+
 # Create secret with real credentials
 statement ok
-CREATE SECRET ms_graph_sharepoint_test (
+CREATE SECRET ms_graph_sp_test (
     TYPE microsoft_graph,
     PROVIDER client_credentials,
     tenant_id '${ERPL_MS_TENANT_ID}',
@@ -21,13 +24,13 @@ CREATE SECRET ms_graph_sharepoint_test (
     client_secret '${ERPL_MS_CLIENT_SECRET}'
 );
 
-# Test: graph_show_sites can be called (may return 0 rows if no sites)
+# Test: graph_show_sites returns at least one site
 query I
-SELECT COUNT(*) >= 0 FROM graph_show_sites();
+SELECT COUNT(*) > 0 FROM graph_show_sites();
 ----
 true
 
-# Test: graph_show_sites has expected columns
+# Test: graph_show_sites returns expected columns
 query I
 SELECT COUNT(*) FROM (
     SELECT column_name FROM (DESCRIBE SELECT * FROM graph_show_sites())
@@ -36,39 +39,72 @@ SELECT COUNT(*) FROM (
 ----
 5
 
-# Test: graph_show_sites with search query can be called
+# Test: all sites have a non-empty id
 query I
-SELECT COUNT(*) >= 0 FROM graph_show_sites('test');
+SELECT COUNT(*) = 0 FROM graph_show_sites() WHERE id IS NULL OR id = '';
 ----
 true
 
-# Test: graph_show_lists function exists (requires site_id to call)
+# Test: graph_show_lists returns data for the test site
 query I
-SELECT COUNT(*) FROM duckdb_functions() WHERE function_name = 'graph_show_lists';
+SELECT COUNT(*) > 0 FROM graph_show_lists('${ERPL_MS_SHAREPOINT_SITE_ID}');
 ----
-1
+true
 
-# Test: graph_show_lists has expected columns (using describe with dummy values)
+# Test: graph_show_lists returns expected columns
 query I
 SELECT COUNT(*) FROM (
-    SELECT column_name FROM (DESCRIBE SELECT * FROM graph_show_lists('dummy-site-id'))
+    SELECT column_name FROM (DESCRIBE SELECT * FROM graph_show_lists('${ERPL_MS_SHAREPOINT_SITE_ID}'))
     WHERE column_name IN ('id', 'name', 'display_name', 'description', 'web_url', 'created_at', 'modified_at')
 );
 ----
 7
 
-# Test: graph_describe_list function exists
+# Test: graph_describe_list returns column schema for the test list
 query I
-SELECT COUNT(*) FROM duckdb_functions() WHERE function_name = 'graph_describe_list';
+SELECT COUNT(*) > 0 FROM graph_describe_list(
+    '${ERPL_MS_SHAREPOINT_SITE_ID}',
+    '${ERPL_MS_SHAREPOINT_LIST_ID}'
+);
 ----
-1
+true
 
-# Test: graph_list_items function exists
+# Test: graph_describe_list returns expected columns
 query I
-SELECT COUNT(*) FROM duckdb_functions() WHERE function_name = 'graph_list_items';
+SELECT COUNT(*) FROM (
+    SELECT column_name FROM (
+        DESCRIBE SELECT * FROM graph_describe_list(
+            '${ERPL_MS_SHAREPOINT_SITE_ID}',
+            '${ERPL_MS_SHAREPOINT_LIST_ID}'
+        )
+    )
+    WHERE column_name IN ('name', 'display_name', 'column_type', 'description', 'required')
+);
+----
+5
+
+# Test: graph_list_items works without duplicate-column error
+# (regression test: SharePoint returns field "ID" which collides case-insensitively with "id")
+query I
+SELECT COUNT(*) >= 0 FROM graph_list_items(
+    '${ERPL_MS_SHAREPOINT_SITE_ID}',
+    '${ERPL_MS_SHAREPOINT_LIST_ID}'
+);
+----
+true
+
+# Test: graph_list_items result always has an id column (not a duplicate col1/col2)
+query I
+SELECT COUNT(*) FROM (
+    DESCRIBE SELECT * FROM graph_list_items(
+        '${ERPL_MS_SHAREPOINT_SITE_ID}',
+        '${ERPL_MS_SHAREPOINT_LIST_ID}'
+    )
+)
+WHERE column_name = 'id';
 ----
 1
 
 # Cleanup
 statement ok
-DROP SECRET ms_graph_sharepoint_test;
+DROP SECRET ms_graph_sp_test;


### PR DESCRIPTION
## Summary

Fixes a crash in `graph_list_items` caused by a case-insensitive duplicate column name.

### Root cause

`graph_list_items` always prepends an `"id"` column, then iterates the SharePoint list schema from the Graph API. SharePoint's standard schema includes a field named `"ID"` (uppercase). DuckDB's column-name comparison is case-insensitive, so `"id"` and `"ID"` are treated as duplicates — resulting in:

```
Binder Error: table "graph_list_items" has duplicate column name "ID"
```

This made `graph_list_items` unusable on any real SharePoint list.

### Fix

Track already-registered column names (lowercased) in an `unordered_set` during the bind phase. Skip any incoming column whose lowercase name is already present.

```cpp
std::unordered_set<std::string> seen_names = {"id"};
// ...
std::string lower_name = col_name;
std::transform(lower_name.begin(), lower_name.end(), lower_name.begin(), ::tolower);
if (!seen_names.insert(lower_name).second) continue;
```

### Testing

`test/sql/graph_sharepoint_integration.test` rewritten with real API calls against the developer tenant. All four SharePoint functions are now exercised end-to-end:

- `graph_show_sites()` — verified returns data with correct columns
- `graph_show_lists(site_id)` — verified returns lists for a real site
- `graph_describe_list(site_id, list_id)` — verified returns column schema
- `graph_list_items(site_id, list_id)` — regression test confirms no crash and exactly one `id` column

All 11 assertions pass against a real Microsoft 365 developer tenant.

Closes #8