### PR TITLE
fix(odp): prevent N × count row duplication on paginated full loads

### DIFF
--- a/src/include/odata_read_functions.hpp
+++ b/src/include/odata_read_functions.hpp
@@ -79,6 +79,16 @@ public:
     void UpdateUrlFromPredicatePushdown();
     void PrefetchFirstPage();
 
+    // Pre-buffer rows from already-fetched content so PrefetchFirstPage() does
+    // not issue a redundant bare HTTP GET. Called by ODP code where the outer
+    // orchestrator owns all HTTP requests and the first-page content is already
+    // available from the ODQ tracking response.
+    void PreBufferFirstPage(const std::string& content, ODataVersion version);
+
+    // Returns true when the first page has been fetched or pre-buffered.
+    // Exposed for testing.
+    bool IsFirstPageCached() const { return first_page_cached_; }
+
     // Progress reporting
     double GetProgressFraction() const;
 

--- a/src/odata_read_functions.cpp
+++ b/src/odata_read_functions.cpp
@@ -2628,6 +2628,90 @@ void ODataReadBindData::PrefetchFirstPage() {
                        row_buffer->HasNextPage() ? "true" : "false"));
 }
 
+void ODataReadBindData::PreBufferFirstPage(const std::string &content,
+                                           ODataVersion version) {
+  if (content.empty()) return;
+
+  // Extract column names directly from the JSON payload — no HTTP calls.
+  // ParseODataV2/V4Response delegate to the OData client for navigation-
+  // property filtering, which triggers a $metadata request and would defeat
+  // the purpose of pre-buffering (avoiding extra HTTP calls).
+  std::vector<std::string> col_names;
+  try {
+    auto doc =
+        duckdb_yyjson::yyjson_read(content.c_str(), content.length(), 0);
+    if (doc) {
+      auto root = duckdb_yyjson::yyjson_doc_get_root(doc);
+      if (root) {
+        duckdb_yyjson::yyjson_val *first_row = nullptr;
+        if (version == ODataVersion::V4) {
+          // v4: {"value": [{...}, ...]}
+          auto value_arr = duckdb_yyjson::yyjson_obj_get(root, "value");
+          if (value_arr && duckdb_yyjson::yyjson_is_arr(value_arr) &&
+              duckdb_yyjson::yyjson_arr_size(value_arr) > 0) {
+            first_row = duckdb_yyjson::yyjson_arr_get_first(value_arr);
+          }
+        } else {
+          // v2: {"d": {"results": [{...}, ...]}}
+          auto d_obj = duckdb_yyjson::yyjson_obj_get(root, "d");
+          if (d_obj) {
+            auto results = duckdb_yyjson::yyjson_obj_get(d_obj, "results");
+            if (results && duckdb_yyjson::yyjson_is_arr(results) &&
+                duckdb_yyjson::yyjson_arr_size(results) > 0) {
+              first_row = duckdb_yyjson::yyjson_arr_get_first(results);
+            }
+          }
+        }
+        if (first_row && duckdb_yyjson::yyjson_is_obj(first_row)) {
+          size_t idx, max;
+          duckdb_yyjson::yyjson_val *key, *val;
+          yyjson_obj_foreach(first_row, idx, max, key, val) {
+            col_names.emplace_back(duckdb_yyjson::yyjson_get_str(key));
+          }
+        }
+      }
+      duckdb_yyjson::yyjson_doc_free(doc);
+    }
+  } catch (...) {}
+
+  if (col_names.empty()) {
+    ERPL_TRACE_WARN("ODATA_READ_BIND",
+                    "PreBufferFirstPage: no rows in content, skipping");
+    return;
+  }
+
+  // Store so that subsequent GetResultNames() returns them without HTTP.
+  SetExtractedColumnNames(col_names);
+
+  // ODP delivers all fields as Edm.String; VARCHAR avoids a $metadata
+  // round-trip solely for type resolution.
+  std::vector<duckdb::LogicalType> all_types(col_names.size(),
+                                             duckdb::LogicalTypeId::VARCHAR);
+  try {
+    auto fake_resp = std::make_shared<ODataEntitySetResponse>(
+        std::make_unique<HttpResponse>(HttpMethod::GET, HttpUrl(""), 200,
+                                      "application/json", content),
+        version);
+
+    auto page_rows = fake_resp->ToRows(col_names, all_types);
+    row_buffer->AddRows(std::move(page_rows));
+    // The outer OdpODataReadBindData orchestrator owns all __next following;
+    // prevent FetchAdditionalPagesIfNeeded() from issuing inner GETs.
+    row_buffer->SetHasNextPage(false);
+    first_page_cached_ = true;
+
+    ERPL_TRACE_DEBUG("ODATA_READ_BIND",
+                     duckdb::StringUtil::Format(
+                         "PreBufferFirstPage: buffered %d rows, "
+                         "PrefetchFirstPage suppressed",
+                         (int)row_buffer->Size()));
+  } catch (const std::exception &e) {
+    ERPL_TRACE_WARN("ODATA_READ_BIND",
+                    std::string("PreBufferFirstPage: failed to buffer rows: ") +
+                        e.what());
+  }
+}
+
 void ODataReadBindData::SetExtractedColumnNames(
     const std::vector<std::string> &column_names) {
     extracted_column_names = column_names;

--- a/src/odp_odata_read_bind_data.cpp
+++ b/src/odp_odata_read_bind_data.cpp
@@ -432,11 +432,16 @@ void OdpODataReadBindData::UpdateODataClientWithResponse(const std::string& url,
         
         // Create bind data with pre-fetched content
         odata_bind_data_ = ODataReadBindData::FromEntitySetClient(client, response_content);
-        
+
         if (!odata_bind_data_) {
             throw duckdb::InternalException("Failed to update OData client with response");
         }
-        
+
+        // Pre-buffer the rows already received so PrefetchFirstPage() does not
+        // issue a stateless bare GET to the entity-set URL. Without this, every
+        // ODQ tracking package causes a full re-read of the entity set.
+        odata_bind_data_->PreBufferFirstPage(response_content, ODataVersion::V2);
+
         ERPL_TRACE_DEBUG("ODP_BIND_DATA", "OData client updated successfully with pre-fetched response");
         
     } catch (const std::exception& e) {

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -36,6 +36,7 @@ list(APPEND TEST_SOURCES
     test_odp_subscription_repository.cpp
     test_odp_subscription_state_manager.cpp
     test_odp_request_orchestrator.cpp
+    test_odp_prebuffer.cpp
     test_datasphere_integration.cpp
     test_datasphere_oauth2_consolidated.cpp
     test_datasphere_discovery.cpp

--- a/test/cpp/test_odp_prebuffer.cpp
+++ b/test/cpp/test_odp_prebuffer.cpp
@@ -1,0 +1,74 @@
+#include "catch.hpp"
+#include "odata_read_functions.hpp"
+#include "odata_client.hpp"
+#include "http_client.hpp"
+
+using namespace erpl_web;
+
+// Minimal OData v2 ODP tracking-response with 2 records (no __next, no __delta).
+static const std::string kOdpPage = R"({
+  "d": {
+    "results": [
+      {"ID": "REC001", "COL_A": "alpha", "COL_B": "1"},
+      {"ID": "REC002", "COL_A": "beta",  "COL_B": "2"}
+    ]
+  }
+})";
+
+// Helper: create an ODataReadBindData whose HTTP client points at an
+// unreachable address. PrefetchFirstPage() on this bind data fires a real
+// GET that immediately fails — so any test that allows PrefetchFirstPage() to
+// run will throw, and any test that suppresses it will not.
+static duckdb::unique_ptr<ODataReadBindData> make_bind_data() {
+    HttpParams params;
+    params.url_encode = false;
+    auto http  = std::make_shared<HttpClient>(params);
+    auto url   = HttpUrl("http://127.0.0.1:0/sap/opu/odata/NS/SRV/FactsOfI_ENTITY");
+    auto client = std::make_shared<ODataEntitySetClient>(http, url);
+    client->SetODataVersionDirectly(ODataVersion::V2);
+    return ODataReadBindData::FromEntitySetClient(client, kOdpPage);
+}
+
+// ---------------------------------------------------------------------------
+// Red test: demonstrates the problem
+// ---------------------------------------------------------------------------
+TEST_CASE("ODP bare-GET duplication: FromEntitySetClient leaves first page uncached",
+          "[odp_prebuffer]") {
+
+    auto bind_data = make_bind_data();
+
+    // Without PreBufferFirstPage the flag must be false — meaning the next
+    // FetchNextResult() call will trigger PrefetchFirstPage() → bare HTTP GET.
+    REQUIRE(!bind_data->IsFirstPageCached());
+}
+
+// ---------------------------------------------------------------------------
+// Green test: describes the desired fix behaviour
+// ---------------------------------------------------------------------------
+TEST_CASE("ODP bare-GET duplication: PreBufferFirstPage suppresses bare GET",
+          "[odp_prebuffer]") {
+
+    SECTION("PreBufferFirstPage marks first page as cached") {
+        auto bind_data = make_bind_data();
+        bind_data->PreBufferFirstPage(kOdpPage, ODataVersion::V2);
+        REQUIRE(bind_data->IsFirstPageCached());
+    }
+
+    SECTION("PrefetchFirstPage is a no-op after PreBufferFirstPage (no HTTP call)") {
+        auto bind_data = make_bind_data();
+        bind_data->PreBufferFirstPage(kOdpPage, ODataVersion::V2);
+        // If first_page_cached_ is true, PrefetchFirstPage returns immediately
+        // without touching the HTTP client — even though the URL is unreachable.
+        REQUIRE_NOTHROW(bind_data->PrefetchFirstPage());
+    }
+
+    SECTION("column names are extracted from the pre-buffered content") {
+        auto bind_data = make_bind_data();
+        bind_data->PreBufferFirstPage(kOdpPage, ODataVersion::V2);
+        auto names = bind_data->GetResultNames(true);
+        REQUIRE(names.size() >= 3);
+        REQUIRE(std::find(names.begin(), names.end(), "ID")    != names.end());
+        REQUIRE(std::find(names.begin(), names.end(), "COL_A") != names.end());
+        REQUIRE(std::find(names.begin(), names.end(), "COL_B") != names.end());
+    }
+}


### PR DESCRIPTION
## Problem

Targets: https://github.com/DataZooDE/erpl-web/issues/37+

`odp_odata_read` returns N × count records on entity sets whose full load spans
multiple ODQ tracking pages (SAP responds with `__next` skiptokens).

Each time `UpdateODataClientWithResponse()` is called — once per ODQ page —
it reconstructs the inner `ODataReadBindData` via `FromEntitySetClient()`.
The fresh bind data has `first_page_cached_ = false`, so the next
`FetchNextResult()` call triggers `PrefetchFirstPage()`, which issues a
stateless bare `GET <entity_set_url>` with no `Prefer` header and no
`$skiptoken`. SAP's bare URL returns the full dataset on every call, so with
N ODQ pages the total returned row count becomes N × actual_count.

The bare GET also bypasses the `max_page_size` constraint set by the ODP
orchestrator, and on systems without a server-side page limit it would
attempt to load the entire entity set in a single unbounded request.

## Fix

Add `ODataReadBindData::PreBufferFirstPage(content, version)` — a new public
method that buffers the already-fetched page content and sets
`first_page_cached_ = true` without making any HTTP request.

Column names are extracted directly from the JSON payload (raw yyjson) to
avoid the `$metadata` round-trip that `ParseODataV2/V4Response` would
trigger via the OData client.

`UpdateODataClientWithResponse()` calls `PreBufferFirstPage()` immediately
after `FromEntitySetClient()`, so `PrefetchFirstPage()` is a no-op for the
ODP path.

`SetHasNextPage(false)` is set on the inner row buffer so that
`FetchAdditionalPagesIfNeeded()` does not follow inner `__next` links — the
outer `OdpODataReadBindData` orchestrator owns all pagination.

## Scope

The fix is intentionally confined to `odp_odata_read_bind_data.cpp`.
`FromEntitySetClient()` is unchanged. Dataverse, Business Central, and all
other plain OData callers continue to rely on `PrefetchFirstPage()` firing
with the correct filter- and projection-aware URL assembled during the DuckDB
bind phase.

## Tests

`test/cpp/test_odp_prebuffer.cpp` (Catch2):

- `FromEntitySetClient leaves first page uncached` — confirms the problem:
  `first_page_cached_` is false after `FromEntitySetClient()` alone
- `PreBufferFirstPage marks first page as cached` — confirms the fix sets the flag
- `PrefetchFirstPage is a no-op after PreBufferFirstPage` — confirms no HTTP
  call is made even with an unreachable URL
- `column names are extracted from the pre-buffered content` — confirms schema
  is available without a `$metadata` request
