### PR TITLE
Avoid redundant GET requests when pre-fetched OData pages are provided

### DIFF
--- a/src/include/odata_read_functions.hpp
+++ b/src/include/odata_read_functions.hpp
@@ -136,7 +136,16 @@ private:
 
     // Helper methods
     void InitializeComponents(bool service_root_mode = false);
-    
+
+    // Buffer the rows of an already-fetched first page into row_buffer and
+    // mark first_page_cached_. Shared by PrefetchFirstPage (response from
+    // odata_client->Get()) and FromEntitySetClient (response synthesised from
+    // pre-fetched initial_content). Without this, callers that hand a page's
+    // content into FromEntitySetClient would later trigger a redundant bare
+    // GET inside PrefetchFirstPage — which against SAP ODP returns the entire
+    // dataset and inflates the result by N×.
+    void BufferFirstPageFromResponse(std::shared_ptr<ODataEntitySetResponse> response);
+
     // FetchNextResult helper methods
     void EnsureInitialized();
     SchemaInfo PrepareSchemaInfo();

--- a/src/odata_read_functions.cpp
+++ b/src/odata_read_functions.cpp
@@ -1642,6 +1642,25 @@ duckdb::unique_ptr<ODataReadBindData> ODataReadBindData::FromEntitySetClient(
           "ODATA_READ_BIND",
           "Failed to parse initial content, will use metadata approach");
     }
+
+    // Buffer the rows from initial_content so the next FetchNextResult does
+    // not issue a redundant bare GET. Without this, callers that hand a
+    // pre-fetched page in (e.g. the ODP streaming path) trigger
+    // PrefetchFirstPage → odata_client->Get() with no query string, which
+    // SAP ODP answers with the entire dataset, inflating results N×.
+    try {
+      auto synthetic = std::make_shared<ODataEntitySetResponse>(
+          std::make_unique<HttpResponse>(HttpMethod::GET, HttpUrl(client->Url()),
+                                         200, "application/json", initial_content),
+          client->GetODataVersion());
+      bind_data->BufferFirstPageFromResponse(synthetic);
+    } catch (const std::exception &e) {
+      ERPL_TRACE_DEBUG(
+          "ODATA_READ_BIND",
+          std::string("Failed to buffer initial content; "
+                      "PrefetchFirstPage will refetch: ") +
+              e.what());
+    }
   }
 
   return bind_data;
@@ -2578,24 +2597,36 @@ void ODataReadBindData::PrefetchFirstPage() {
     }
 
     auto response = odata_client->Get();
+    BufferFirstPageFromResponse(response);
+
+  ERPL_TRACE_DEBUG("ODATA_READ_BIND",
+                   duckdb::StringUtil::Format(
+        "PrefetchFirstPage: buffered %d rows, has_next_page=%s",
+                       (int)row_buffer->Size(),
+                       row_buffer->HasNextPage() ? "true" : "false"));
+}
+
+void ODataReadBindData::BufferFirstPageFromResponse(
+    std::shared_ptr<ODataEntitySetResponse> response) {
     if (!response) {
-    ERPL_TRACE_WARN("ODATA_READ_BIND",
-                    "PrefetchFirstPage: no response received");
+        ERPL_TRACE_WARN("ODATA_READ_BIND",
+                        "BufferFirstPageFromResponse: no response received");
         first_page_cached_ = true;
         row_buffer->SetHasNextPage(false);
         return;
     }
-    
+
     // Extract expanded data if we have expand clauses
     if (HasExpandedData() && !data_extractor->GetExpandedDataSchema().empty()) {
         try {
-      ERPL_TRACE_DEBUG("ODATA_READ_BIND",
-                       "Extracting expanded data from first page");
+            ERPL_TRACE_DEBUG("ODATA_READ_BIND",
+                             "Extracting expanded data from buffered first page");
             data_extractor->ExtractExpandedDataFromResponse(response->RawContent());
-    } catch (const std::exception &e) {
-      ERPL_TRACE_WARN("ODATA_READ_BIND",
-                      "Failed to extract expanded data from first page: " +
-                          std::string(e.what()));
+        } catch (const std::exception &e) {
+            ERPL_TRACE_WARN("ODATA_READ_BIND",
+                            std::string("Failed to extract expanded data from "
+                                        "buffered first page: ") +
+                                e.what());
         }
     }
 
@@ -2604,28 +2635,22 @@ void ODataReadBindData::PrefetchFirstPage() {
         auto total = response->Content()->TotalCount();
         if (total.has_value()) {
             progress_tracker->SetTotalCount(total.value());
-      ERPL_TRACE_INFO(
-          "ODATA_READ_BIND",
-          duckdb::StringUtil::Format(
-                "Service reported total row count: %llu",
-                (unsigned long long)progress_tracker->GetTotalCount()));
+            ERPL_TRACE_INFO(
+                "ODATA_READ_BIND",
+                duckdb::StringUtil::Format(
+                    "Service reported total row count: %llu",
+                    (unsigned long long)progress_tracker->GetTotalCount()));
         }
     }
 
     // Buffer full schema rows to keep indices stable across projections
-    auto all_result_names = GetResultNames(true);
-    auto all_result_types = GetResultTypes(true);
+    auto all_result_names_local = GetResultNames(true);
+    auto all_result_types_local = GetResultTypes(true);
 
-    auto page_rows = response->ToRows(all_result_names, all_result_types);
+    auto page_rows = response->ToRows(all_result_names_local, all_result_types_local);
     row_buffer->AddRows(std::move(page_rows));
     row_buffer->SetHasNextPage(response->NextUrl().has_value());
     first_page_cached_ = true;
-
-  ERPL_TRACE_DEBUG("ODATA_READ_BIND",
-                   duckdb::StringUtil::Format(
-        "PrefetchFirstPage: buffered %d rows, has_next_page=%s",
-                       (int)row_buffer->Size(),
-                       row_buffer->HasNextPage() ? "true" : "false"));
 }
 
 void ODataReadBindData::SetExtractedColumnNames(

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -30,6 +30,7 @@ list(APPEND TEST_SOURCES
     test_odata_client.cpp
     test_odata_content.cpp
     test_odata_row_buffer.cpp
+    test_odata_from_entity_set_buffering.cpp
     test_odata_url_helpers.cpp
     test_odp_parsing.cpp
     test_odp_http_request_factory.cpp

--- a/test/cpp/test_odata_from_entity_set_buffering.cpp
+++ b/test/cpp/test_odata_from_entity_set_buffering.cpp
@@ -1,0 +1,141 @@
+#include "catch.hpp"
+#include "odata_read_functions.hpp"
+#include "odata_client.hpp"
+#include "odata_edm.hpp"
+#include "http_client.hpp"
+#include <algorithm>
+
+using namespace erpl_web;
+
+// Minimal OData V4 EDM for a Customers entity set with id (String) and name (String).
+// Pre-populated in EdmCache so GetResultTypes() never needs a real metadata HTTP request.
+static const std::string MINIMAL_EDM_XML = R"(<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Test" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Customer">
+        <Key><PropertyRef Name="id"/></Key>
+        <Property Name="id" Type="Edm.String" Nullable="false"/>
+        <Property Name="name" Type="Edm.String"/>
+      </EntityType>
+      <EntityContainer Name="Container">
+        <EntitySet Name="Customers" EntityType="Test.Customer"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>)";
+
+// Use loopback on a port that is almost certainly closed. Any HTTP attempt would
+// get ECONNREFUSED immediately, so a test that mistakenly triggers a network
+// call fails fast rather than hanging.
+static const std::string TEST_URL = "http://127.0.0.1:65534/TestService/Customers";
+static const std::string METADATA_URL = "http://127.0.0.1:65534/TestService/$metadata";
+
+// Two-row OData V4 payload.
+static const std::string TWO_ROW_V4_JSON =
+    R"({"value":[{"id":"1","name":"Alice"},{"id":"2","name":"Bob"}]})";
+
+// Two-row OData V2 payload (the "d.results" envelope format used by SAP systems).
+static const std::string TWO_ROW_V2_JSON =
+    R"({"d":{"results":[{"id":"1","name":"Alice"},{"id":"2","name":"Bob"}]}})";
+
+// Populate the global EdmCache singleton for the test metadata URL.
+static void SeedEdmCache() {
+    auto edmx = Edmx::FromXml(MINIMAL_EDM_XML);
+    EdmCache::GetInstance().Set(METADATA_URL, edmx);
+}
+
+static std::shared_ptr<ODataEntitySetClient> MakeClient(ODataVersion version) {
+    auto http_client = std::make_shared<HttpClient>();
+    HttpUrl url(TEST_URL);
+    auto auth_params = std::make_shared<HttpAuthParams>();
+    auto client = std::make_shared<ODataEntitySetClient>(http_client, url, auth_params);
+    client->SetODataVersionDirectly(version);
+    return client;
+}
+
+// ============================================================================
+// Column-name extraction from initial_content
+// ============================================================================
+
+TEST_CASE("FromEntitySetClient - extracts column names from OData V4 initial_content") {
+    SeedEdmCache();
+    auto bind_data = ODataReadBindData::FromEntitySetClient(MakeClient(ODataVersion::V4), TWO_ROW_V4_JSON);
+
+    auto names = bind_data->GetResultNames();
+    REQUIRE_FALSE(names.empty());
+    bool has_id   = std::find(names.begin(), names.end(), "id")   != names.end();
+    bool has_name = std::find(names.begin(), names.end(), "name") != names.end();
+    REQUIRE(has_id);
+    REQUIRE(has_name);
+}
+
+TEST_CASE("FromEntitySetClient - extracts column names from OData V2 initial_content") {
+    SeedEdmCache();
+    auto bind_data = ODataReadBindData::FromEntitySetClient(MakeClient(ODataVersion::V2), TWO_ROW_V2_JSON);
+
+    auto names = bind_data->GetResultNames();
+    REQUIRE_FALSE(names.empty());
+    bool has_id   = std::find(names.begin(), names.end(), "id")   != names.end();
+    bool has_name = std::find(names.begin(), names.end(), "name") != names.end();
+    REQUIRE(has_id);
+    REQUIRE(has_name);
+}
+
+// ============================================================================
+// Rows are pre-buffered (HasMoreResults is true immediately, no HTTP needed)
+// ============================================================================
+
+TEST_CASE("FromEntitySetClient - HasMoreResults is true after initial_content buffered") {
+    SeedEdmCache();
+    auto bind_data = ODataReadBindData::FromEntitySetClient(MakeClient(ODataVersion::V4), TWO_ROW_V4_JSON);
+    REQUIRE(bind_data->HasMoreResults());
+}
+
+// ============================================================================
+// Regression test (Issue #37): first_page_cached_ must be true so that the
+// next EnsureInitialized() call skips PrefetchFirstPage() and does not issue
+// a redundant GET. Against SAP ODP that GET returns the full dataset, causing
+// N rows to become 2N (or more) in the query result.
+//
+// Observable proof: calling PrefetchFirstPage() on a bind_data whose
+// first_page_cached_ is already true is a documented no-op. If first_page_cached_
+// were false (the pre-fix behaviour), PrefetchFirstPage() would call
+// odata_client->Get() which connects to 127.0.0.1:65534. That port is closed
+// → ECONNREFUSED → std::runtime_error. REQUIRE_NOTHROW catches the regression.
+// ============================================================================
+
+TEST_CASE("FromEntitySetClient - regression: first_page_cached_ set after initial_content") {
+    SeedEdmCache();
+    auto bind_data = ODataReadBindData::FromEntitySetClient(MakeClient(ODataVersion::V4), TWO_ROW_V4_JSON);
+
+    // Must not throw: first_page_cached_ is true, so PrefetchFirstPage returns immediately.
+    REQUIRE_NOTHROW(bind_data->PrefetchFirstPage());
+
+    // Result names must still be correct after the redundant call.
+    auto names = bind_data->GetResultNames();
+    bool has_id   = std::find(names.begin(), names.end(), "id")   != names.end();
+    bool has_name = std::find(names.begin(), names.end(), "name") != names.end();
+    REQUIRE(has_id);
+    REQUIRE(has_name);
+}
+
+TEST_CASE("FromEntitySetClient - regression: OData V2 path also sets first_page_cached_") {
+    SeedEdmCache();
+    auto bind_data = ODataReadBindData::FromEntitySetClient(MakeClient(ODataVersion::V2), TWO_ROW_V2_JSON);
+
+    REQUIRE_NOTHROW(bind_data->PrefetchFirstPage());
+}
+
+// ============================================================================
+// Empty initial_content: no pre-buffering, but HasMoreResults is still true
+// because first_page_cached_ is false (data will be fetched on demand).
+// ============================================================================
+
+TEST_CASE("FromEntitySetClient - empty initial_content leaves data to be fetched") {
+    // No EdmCache seeding needed here: with empty initial_content the JSON
+    // parsing branch is skipped entirely and HasMoreResults() returns true
+    // via the !first_page_cached_ check, without any metadata fetch.
+    auto bind_data = ODataReadBindData::FromEntitySetClient(MakeClient(ODataVersion::V4), "");
+    REQUIRE(bind_data->HasMoreResults());
+}


### PR DESCRIPTION
## Summary
This change prevents redundant OData GET requests when callers provide pre-fetched page content (e.g., the ODP streaming path). Previously, `PrefetchFirstPage()` would always issue a bare GET request even when initial content was already available, causing SAP ODP to return the entire dataset and inflating results by N×.

## Key Changes
- **Extracted `BufferFirstPageFromResponse()` method**: Refactored the page buffering logic from `PrefetchFirstPage()` into a reusable helper method that processes an `ODataEntitySetResponse` and populates the row buffer.

- **Buffer initial content in `FromEntitySetClient()`**: When `initial_content` is provided, synthesize an `ODataEntitySetResponse` and buffer it immediately via `BufferFirstPageFromResponse()`. This marks the first page as cached before `PrefetchFirstPage()` is called, preventing the redundant GET.

- **Updated `PrefetchFirstPage()`**: Now calls the extracted `BufferFirstPageFromResponse()` method to process the response, reducing code duplication.

- **Improved error handling**: Both code paths gracefully handle buffering failures with debug/warning traces, allowing the system to fall back to refetching if needed.

- **Code cleanup**: Fixed indentation and variable naming (`all_result_names` → `all_result_names_local`) for consistency.

## Implementation Details
- The synthetic response created from `initial_content` uses the same HTTP metadata (method, URL, status code, content type) as a real GET response, ensuring consistent processing.
- Error handling is defensive: if buffering the initial content fails, the system logs a debug message and allows `PrefetchFirstPage()` to proceed normally.
- The `first_page_cached_` flag is set in `BufferFirstPageFromResponse()`, preventing duplicate work when both paths are involved.

https://claude.ai/code/session_0178GtCEuggLSGZgfCcudFaV