### PR TITLE
chore: update DuckDB to v1.5.3

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -19,32 +19,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  duckdb-v152-build:
-    name: Build extension binaries (v1.5.2)
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@ef15a2a7453db5b4f85b7c668a545ae2f1193ff6
+  duckdb-v153-build:
+    name: Build extension binaries (v1.5.3)
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@4b3b37b0c9de00da54e1765d65abfea3f94617f4
     with:
-      duckdb_version: v1.5.2
+      duckdb_version: v1.5.3
       extension_name: erpl_web
-      ci_tools_version: ef15a2a7453db5b4f85b7c668a545ae2f1193ff6
+      ci_tools_version: 4b3b37b0c9de00da54e1765d65abfea3f94617f4
       vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
       exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads;'
 
-  duckdb-v152-smoke-test:
-    name: Smoke test (v1.5.2)
-    needs: duckdb-v152-build
+  duckdb-v153-smoke-test:
+    name: Smoke test (v1.5.3)
+    needs: duckdb-v153-build
     uses: ./.github/workflows/_extension_smoke_test.yml
     with:
-      duckdb_version: v1.5.2
+      duckdb_version: v1.5.3
       extension_name: erpl_web
       exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads;'
 
-  duckdb-v152-deploy:
-    name: Deploy extension binaries (v1.5.2)
-    needs: [duckdb-v152-build, duckdb-v152-smoke-test]
+  duckdb-v153-deploy:
+    name: Deploy extension binaries (v1.5.3)
+    needs: [duckdb-v153-build, duckdb-v153-smoke-test]
     uses: ./.github/workflows/_extension_deploy.yml
     secrets: inherit
     with:
-      duckdb_version: v1.5.2
+      duckdb_version: v1.5.3
       extension_name: erpl_web
       exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads;'
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -511,7 +511,7 @@ This extension uses **extension-ci-tools** reusable workflows for automated mult
 
 **Primary workflow:** `.github/workflows/MainDistributionPipeline.yml`
 - Calls `duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main`
-- Builds for DuckDB v1.4.4 and v1.5.2 (configured via `duckdb_version` parameter)
+- Builds for DuckDB v1.4.4 and v1.5.3 (configured via `duckdb_version` parameter)
 - Generates platform-specific binaries as GitHub Actions artifacts
 - Deploys to S3 for distribution
 
@@ -602,7 +602,7 @@ Checkout repo → Setup Docker → Build in container → Test → Upload artifa
 ```
 - Uses ccache for compilation speed
 - VCPKG dependencies cached in S3
-- Produces `erpl_web-v1.5.2-extension-linux_amd64.duckdb_extension`
+- Produces `erpl_web-v1.5.3-extension-linux_amd64.duckdb_extension`
 
 #### **3. macOS Build** (Conditional on Linux success)
 ```
@@ -610,7 +610,7 @@ Setup Homebrew → Install ninja/ccache → Configure VCPKG → Build → Test �
 ```
 - Builds both x86_64 and ARM64 variants
 - Uses native runners (no emulation)
-- Produces `erpl_web-v1.5.2-extension-osx_{amd64,arm64}.duckdb_extension`
+- Produces `erpl_web-v1.5.3-extension-osx_{amd64,arm64}.duckdb_extension`
 
 #### **4. Windows Build** (Conditional on Linux success)
 ```
@@ -618,7 +618,7 @@ Setup MSVC → Configure VCPKG → Build with Ninja/MSBuild → Test → Upload
 ```
 - Static linking to avoid DLL dependencies
 - VS2019 compatibility mode for broader Windows support
-- Produces `erpl_web-v1.5.2-extension-windows_amd64.duckdb_extension`
+- Produces `erpl_web-v1.5.3-extension-windows_amd64.duckdb_extension`
 
 #### **5. Deployment** (S3 Upload)
 ```
@@ -913,7 +913,7 @@ The extension-ci-tools repository provides centralized CI/CD:
 - **Automatic updates** when DuckDB changes build system
 - **Phased deprecation:** Old versions removed systematically
 
-This project currently targets **DuckDB v1.4.4 and v1.5.2** (check `.github/workflows/` and `extension-ci-tools` branch).
+This project currently targets **DuckDB v1.4.4 and v1.5.3** (check `.github/workflows/` and `extension-ci-tools` branch).
 
 ## Codebase Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <a name="top"></a>
 
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL%201.1-blue.svg)](LICENSE)
-[![DuckDB](https://img.shields.io/badge/DuckDB-1.5.2+-green.svg)](https://duckdb.org)
+[![DuckDB](https://img.shields.io/badge/DuckDB-1.5.3+-green.svg)](https://duckdb.org)
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)]()
 
 # ERPL Web — DuckDB HTTP + OData + Delta Sharing + SAP + Microsoft 365 Extension


### PR DESCRIPTION
## Summary

Bumps the DuckDB v1.5.x build slot from **v1.5.2** to **v1.5.3** (released 2026-05-20, a bugfix release on the "Variegata" line). The **v1.4.4 LTS** build slot is intentionally left untouched.

### Changes
- `duckdb` submodule → `v1.5.3` (`14eca11bd9d4a0de2ea0f078be588a9c1c5b279c`)
- `.github/workflows/MainDistributionPipeline.yml`: rename `duckdb-v152-*` jobs to `duckdb-v153-*`, point the v1.5.x slot at `extension-ci-tools` branch `v1.5.3` (`4b3b37b0c9de00da54e1765d65abfea3f94617f4`); vcpkg commit unchanged
- `README.md`: badge `DuckDB-1.5.2+` → `DuckDB-1.5.3+`
- `CLAUDE.md`: five literal `v1.5.2` → `v1.5.3` references in the CI/distribution section

### Intentionally NOT changed
- v1.4.4 LTS jobs (pinned ci-tools `e39f9dc5…` workaround for Windows static CRT mismatch kept as-is)
- `CMakeLists.txt` — v1.5.3 is a bugfix on the same v1.5 line, so the install(EXPORT) shape from v1.5.2 should carry over. If CI surfaces a regression, fix as a follow-up commit on this branch.
- `extension-ci-tools` submodule pointer (CI references ci-tools commits explicitly per-job; the prior v1.5.2 bump also left this untouched)

## Test plan

- [ ] `Build extension binaries (v1.5.3)` matrix green (linux_amd64, osx_amd64, osx_arm64, windows_amd64)
- [ ] `Smoke test (v1.5.3)` green
- [ ] `Deploy extension binaries (v1.5.3)` succeeds on main / tags
- [ ] `Build extension binaries (v1.4.4)` + smoke test remain green (LTS regression check)
- [ ] No new CMake install(EXPORT) breakage on v1.5.3 (would surface as a Linux build failure mid-config; address with a CMakeLists.txt fixup on this branch if needed)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EebkQKmfdq7HwLq8yEpLsT)_