### PR TITLE
fix: don't fire bare entity-set GET during odp_odata_read scan init (GitHub #47)

### DIFF
--- a/src/odp_odata_read_functions.cpp
+++ b/src/odp_odata_read_functions.cpp
@@ -121,10 +121,14 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> OdpODataReadInitGlobalState
     odata_bind_data.ActivateColumns(column_ids);
     odata_bind_data.AddFilters(input.filters);
     odata_bind_data.UpdateUrlFromPredicatePushdown();
-    
-    // Prefetch first page after URL is finalized
-    odata_bind_data.PrefetchFirstPage();
-    
+
+    // Do NOT call PrefetchFirstPage() here. The ODP first fetch must be orchestrator-owned:
+    // it is the only path that applies the required Prefer: odata.track-changes /
+    // odata.maxpagesize=N headers and buffers the response (HandleInitialLoad ->
+    // ExecuteInitialLoad -> UpdateODataClientWithResponse, during the scan phase). A bare GET
+    // here carries none of those headers, so SAP ODP ignores max_page_size and returns the whole
+    // entity set in one response, exceeding the 30 s HTTP read timeout. See GitHub #47.
+
     return duckdb::make_uniq<duckdb::GlobalTableFunctionState>();
 }
 


### PR DESCRIPTION
## Summary

Fixes #47.

`OdpODataReadInitGlobalState` (`src/odp_odata_read_functions.cpp`) called
`odata_bind_data.PrefetchFirstPage()` on the inner `ODataReadBindData` during DuckDB's
**init** phase. `PrefetchFirstPage()` issues a bare `odata_client->Get()` that carries
**none** of the ODP `Prefer` headers (`odata.track-changes`, `odata.maxpagesize=N`),
bypassing the ODP orchestrator entirely. Against SAP ODP the server answers a bare GET with
the **entire** entity set in a single response, which exceeds the 30 s HTTP read timeout —
so `max_page_size` is silently ignored for the initial load and large reads fail
unconditionally.

## Fix

Remove the init-phase `PrefetchFirstPage()` call. For ODP the first page is fetched by the
**orchestrator** during the scan phase:

`OdpODataReadScan` → `FetchNextResult()` → (first fetch) `HandleInitialLoad()` →
`OdpRequestOrchestrator::ExecuteInitialLoad()` (applies `Prefer: odata.track-changes,
odata.maxpagesize=N`) → `UpdateODataClientWithResponse()` → `ODataReadBindData::FromEntitySetClient(...)`,
which buffers the first page (`BufferFirstPageFromResponse`, `first_page_cached_ = true`).

So the scan no longer needs — and must not have — an init-phase prefetch.

## Scope

Only the ODP path routes through an orchestrator with required `Prefer` headers, so only it
was buggy. The other `PrefetchFirstPage()` call sites — generic `odata_read`
(`ODataReadTableInitGlobalState`), `business_central`, and `dataverse` — have no ODP
orchestrator and are intentionally unchanged.

## Testing

- `make test_cpp` — all 226 C++ unit test cases pass (incl. ODP factory/orchestrator/parsing,
  and the `FromEntitySetClient` first-page buffering invariant the ODP scan now relies on).
- Full SQL suite (`./build/debug/test/unittest`) — all 42 test cases / 700 assertions pass
  (SAP/ODP integration tests skip without `ERPL_SAP_BASE_URL`).

A live SAP ODP endpoint is required to exercise the timeout path end-to-end; the SAP
integration test `test/sql/sap/odp_odata_read.test` covers it where credentials are present.

## Follow-up (not in this PR)

The pre-existing "column re-activation after page replacement is a no-op" concern noted in
the issue (init activates columns on the inner instance, not the wrapper, so
`active_column_ids_` stays empty and re-projection after page replacement is skipped) is
tracked separately. It is harmless today because SAP ODP ignores `$select` and always
returns all columns.