### PR TITLE
feat(telemetry): adopt schema-2 telemetry

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,86 @@
+# ERPL Web Telemetry
+
+ERPL Web collects **anonymous, privacy-preserving usage telemetry** so we can see
+which capabilities are used, on which platforms, and where they fail — and
+prioritise accordingly. It is **on by default** and **trivial to turn off**.
+
+Telemetry is emitted through the shared
+[`DataZooDE/posthog-telemetry`](https://github.com/DataZooDE/posthog-telemetry)
+library and follows the cross-product **`telemetry_schema: 2`** envelope
+(`posthog-telemetry/TELEMETRY-SCHEMA.md`). Ingestion is the EU PostHog cloud.
+
+## How to turn it off
+
+Any one of these fully short-circuits telemetry — when disabled, **nothing
+leaves the machine** (the opt-out is enforced at the transport, not just at the
+call sites):
+
+```sql
+SET erpl_telemetry_enabled = false;   -- DuckDB setting (per session)
+```
+
+```bash
+export DATAZOO_DISABLE_TELEMETRY=1     # environment (1|true|yes)
+```
+
+## The guarantee: bounded, enumerated, non-PII
+
+Every property we send is **either** a constant drawn from a small,
+code-controlled enumeration **or** a pure number (durations, counts). The
+library additionally clamps every outgoing string to 512 bytes as a backstop.
+
+We **never** send: URLs, host names, service roots, entity/table/column names,
+OData `$filter`/query text, SQL text, request/response bodies, row or result
+data, credentials, tokens, secret names, or error messages.
+
+The instrumentation is centralised in one small, auditable header —
+`src/include/telemetry.hpp` (the vendored `posthog-telemetry` library) — and
+the only per-function capture is a single `RecordFunctionCall(<constant>)` at
+each function's **bind** step.
+
+## What is collected
+
+### Envelope (attached to every event)
+
+`product` (`erpl_web`), `product_version`, `product_edition` (`oss`),
+`telemetry_schema` (`2`), `duckdb_version`, `os`, `arch`, `platform`, `is_ci`,
+`is_container`, a per-process `$session_id`, and — once associated — the
+`deployment` group. `distinct_id` is the SHA-256 of a machine id: a **stable,
+pseudonymous** identifier, not tied to any personal data.
+
+### Events
+
+| Event | When | Properties (beyond the envelope) |
+|---|---|---|
+| `extension_loaded` | the `erpl_web` extension loads | — |
+| `function_executed` | a DuckDB function runs — **aggregated** per function per session (not per row) | `function_name`, `call_count`, `duration_ms_p50` |
+
+`function_name` is always one of a fixed, code-controlled set of ERPL Web
+function names, for example: `http_get`, `http_head`, `http_post`, `http_put`,
+`http_patch`, `http_delete`, `odata_read`, `odata_describe`, `odata_attach`,
+`odata_sap_show`, `odp_odata_show`, `odp_odata_read`, `odp_list_subscriptions`,
+`odp_remove_subscription`, `datasphere_show_spaces`, `datasphere_show_assets`,
+`datasphere_describe_space`, `datasphere_describe_asset`,
+`datasphere_read_relational`, `datasphere_read_analytical`, `sac_show_models`,
+`sac_show_stories`, `sac_describe_model`, `sac_describe_story`,
+`sac_read_planning_data`, `sac_read_analytical`, `sac_read_story_data`,
+`delta_share_scan`, `delta_share_show_shares`, `delta_share_show_schemas`,
+`delta_share_show_tables`. The name identifies *which* function ran — never its
+arguments.
+
+This repository does **not** currently emit `feature_used` or `$exception`
+events; those are reserved in the shared schema for a later per-repo
+instrumentation pass.
+
+## Function-call aggregation
+
+DuckDB function calls are recorded via `RecordFunctionCall(function_name)`, which
+aggregates in-process into a single `function_executed` event per function per
+session (carrying `call_count` and `duration_ms_p50`). The call sites live at
+each function's bind step, never on a per-row `GetChunk` path, so a
+million-row scan produces O(1) telemetry rows, not a firehose.
+
+## Enterprise / account analytics
+
+OSS ERPL Web associates only the `deployment` group (keyed on the pseudonymous
+`distinct_id`). It has no license key, so no `account` group is associated.

--- a/src/datasphere_catalog.cpp
+++ b/src/datasphere_catalog.cpp
@@ -1027,7 +1027,7 @@ static duckdb::unique_ptr<duckdb::FunctionData> DatasphereDescribeSpaceBind(duck
                                                                            duckdb::TableFunctionBindInput &input,
                                                                            duckdb::vector<duckdb::LogicalType> &return_types,
                                                                            duckdb::vector<std::string> &names) {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("datasphere_describe_space");
+    PostHogTelemetry::Instance().RecordFunctionCall("datasphere_describe_space");
     // Extract space_id from input
     auto space_id = input.inputs[0].GetValue<std::string>();
     
@@ -1073,7 +1073,7 @@ static duckdb::unique_ptr<duckdb::FunctionData> DatasphereDescribeAssetBind(duck
                                                                            duckdb::TableFunctionBindInput &input,
                                                                            duckdb::vector<duckdb::LogicalType> &return_types,
                                                                            duckdb::vector<std::string> &names) {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("datasphere_describe_asset");
+    PostHogTelemetry::Instance().RecordFunctionCall("datasphere_describe_asset");
     // Extract space_id and asset_id from input
     auto space_id = input.inputs[0].GetValue<std::string>();
     auto asset_id = input.inputs[1].GetValue<std::string>();
@@ -1267,7 +1267,7 @@ duckdb::TableFunctionSet CreateDatasphereShowSpacesFunction() {
         },
         // bind
         [](duckdb::ClientContext &context, duckdb::TableFunctionBindInput &input, duckdb::vector<duckdb::LogicalType> &return_types, duckdb::vector<std::string> &names) -> duckdb::unique_ptr<duckdb::FunctionData> {
-            PostHogTelemetry::Instance().CaptureFunctionExecution("datasphere_show_spaces");
+            PostHogTelemetry::Instance().RecordFunctionCall("datasphere_show_spaces");
             return_types = {duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR)};
             names = {"name"};
 
@@ -1337,7 +1337,7 @@ duckdb::TableFunctionSet CreateDatasphereShowAssetsFunction() {
         },
         // bind
         [](duckdb::ClientContext &context, duckdb::TableFunctionBindInput &input, duckdb::vector<duckdb::LogicalType> &return_types, duckdb::vector<std::string> &names) -> duckdb::unique_ptr<duckdb::FunctionData> {
-            PostHogTelemetry::Instance().CaptureFunctionExecution("datasphere_show_assets");
+            PostHogTelemetry::Instance().RecordFunctionCall("datasphere_show_assets");
             return_types = {duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR), duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR), duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR)};
             names = {"name", "object_type", "technical_name"};
 

--- a/src/datasphere_read.cpp
+++ b/src/datasphere_read.cpp
@@ -120,7 +120,7 @@ static duckdb::unique_ptr<duckdb::FunctionData> DatasphereReadRelationalBind(duc
                                                                            duckdb::TableFunctionBindInput &input,
                                                                            duckdb::vector<duckdb::LogicalType> &return_types,
                                                                            duckdb::vector<std::string> &names) {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("datasphere_read_relational");
+    PostHogTelemetry::Instance().RecordFunctionCall("datasphere_read_relational");
     ERPL_TRACE_DEBUG("DATASPHERE_RELATIONAL_BIND", "=== DATASPHERE_RELATIONAL_BIND CALLED ===");
     
     // Extract basic parameters
@@ -262,7 +262,7 @@ static duckdb::unique_ptr<duckdb::FunctionData> DatasphereReadAnalyticalBind(duc
                                                                              duckdb::TableFunctionBindInput &input,
                                                                              duckdb::vector<duckdb::LogicalType> &return_types,
                                                                              duckdb::vector<std::string> &names) {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("datasphere_read_analytical");
+    PostHogTelemetry::Instance().RecordFunctionCall("datasphere_read_analytical");
     ERPL_TRACE_DEBUG("DATASPHERE_ANALYTICAL_BIND", "=== DATASPHERE_ANALYTICAL_BIND CALLED ===");
 
     // Extract basic parameters

--- a/src/delta_share_catalog.cpp
+++ b/src/delta_share_catalog.cpp
@@ -116,7 +116,7 @@ static void DeltaShareShowSharesScan(ClientContext &context, TableFunctionInput 
 static duckdb::unique_ptr<FunctionData>
 DeltaShareShowSharesBind(ClientContext &context, TableFunctionBindInput &input,
 						vector<LogicalType> &return_types, vector<string> &names) {
-	PostHogTelemetry::Instance().CaptureFunctionExecution("delta_share_show_shares");
+	PostHogTelemetry::Instance().RecordFunctionCall("delta_share_show_shares");
 	// Validate input
 	if (input.inputs.empty()) {
 		throw InvalidInputException("delta_share_list_shares requires profile_path parameter");
@@ -190,7 +190,7 @@ static void DeltaShareShowSchemasScan(ClientContext &context, TableFunctionInput
 static duckdb::unique_ptr<FunctionData>
 DeltaShareShowSchemasBind(ClientContext &context, TableFunctionBindInput &input,
 						vector<LogicalType> &return_types, vector<string> &names) {
-	PostHogTelemetry::Instance().CaptureFunctionExecution("delta_share_show_schemas");
+	PostHogTelemetry::Instance().RecordFunctionCall("delta_share_show_schemas");
 	// Validate input
 	if (input.inputs.size() < 2) {
 		throw InvalidInputException(
@@ -275,7 +275,7 @@ static void DeltaShareShowTablesScan(ClientContext &context, TableFunctionInput 
 static duckdb::unique_ptr<FunctionData>
 DeltaShareShowTablesBind(ClientContext &context, TableFunctionBindInput &input,
 						vector<LogicalType> &return_types, vector<string> &names) {
-	PostHogTelemetry::Instance().CaptureFunctionExecution("delta_share_show_tables");
+	PostHogTelemetry::Instance().RecordFunctionCall("delta_share_show_tables");
 	// Validate input
 	if (input.inputs.size() < 3) {
 		throw InvalidInputException("delta_share_list_tables requires profile_path, share, and "

--- a/src/delta_share_scan.cpp
+++ b/src/delta_share_scan.cpp
@@ -17,7 +17,7 @@ static unique_ptr<FunctionData> DeltaShareScanBind(ClientContext& context,
                                                    TableFunctionBindInput& input,
                                                    vector<LogicalType>& return_types,
                                                    vector<string>& names) {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("delta_share_scan");
+    PostHogTelemetry::Instance().RecordFunctionCall("delta_share_scan");
     ERPL_TRACE_DEBUG("DELTA_SHARE_SCAN", "Bind phase starting");
 
     auto bind_data = make_uniq<DeltaShareScanBindData>();

--- a/src/erpl_web_extension.cpp
+++ b/src/erpl_web_extension.cpp
@@ -900,7 +900,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 
     // Initialize telemetry with API key before capturing extension load
     PostHogTelemetry::Instance().SetAPIKey("phc_t3wwRLtpyEmLHYaZCSszG0MqVr74J6wnCrj9D41zk2t");
-    PostHogTelemetry::Instance().CaptureExtensionLoad("erpl_web", "0.1.0");
+    PostHogTelemetry::Instance().SetProduct("erpl_web", "2026.06.17", "oss");
+    PostHogTelemetry::Instance().AssociateGroup("deployment", PostHogTelemetry::GetDistinctId());
+    PostHogTelemetry::Instance().CaptureExtensionLoad("erpl_web", "2026.06.17");
 
     RegisterConfiguration(instance);
     RegisterWebFunctions(loader);

--- a/src/odata_attach_functions.cpp
+++ b/src/odata_attach_functions.cpp
@@ -135,7 +135,7 @@ static unique_ptr<FunctionData> ODataAttachBind(ClientContext &context,
                                                vector<LogicalType> &return_types,
                                                vector<string> &names)
 {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("odata_attach");
+    PostHogTelemetry::Instance().RecordFunctionCall("odata_attach");
     auto auth_params = AuthParamsFromInput(context, input);
     auto url = input.inputs[0].GetValue<std::string>();
     auto bind_data = ODataAttachBindData::FromUrl(url, auth_params);

--- a/src/odata_describe_functions.cpp
+++ b/src/odata_describe_functions.cpp
@@ -202,7 +202,7 @@ static unique_ptr<FunctionData> ODataDescribeBind(
     vector<LogicalType> &return_types,
     vector<string> &names
 ) {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("odata_describe");
+    PostHogTelemetry::Instance().RecordFunctionCall("odata_describe");
     ERPL_TRACE_INFO("ODATA_DESCRIBE_BIND", "Starting OData describe bind");
 
     // Reuse authentication handling from ODataReadBind

--- a/src/odata_odp_functions.cpp
+++ b/src/odata_odp_functions.cpp
@@ -122,7 +122,7 @@ static duckdb::unique_ptr<duckdb::FunctionData> SapODataShowBind(duckdb::ClientC
                                                                  duckdb::TableFunctionBindInput &input,
                                                                  duckdb::vector<duckdb::LogicalType> &return_types,
                                                                  duckdb::vector<std::string> &names) {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("odata_sap_show");
+    PostHogTelemetry::Instance().RecordFunctionCall("odata_sap_show");
     auto base_url = input.inputs[0].GetValue<std::string>();
 
     // Get HTTP client and auth params from DuckDB secrets
@@ -203,7 +203,7 @@ static duckdb::unique_ptr<duckdb::FunctionData> OdpODataShowBind(duckdb::ClientC
                                                                  duckdb::TableFunctionBindInput &input,
                                                                  duckdb::vector<duckdb::LogicalType> &return_types,
                                                                  duckdb::vector<std::string> &names) {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("odp_odata_show");
+    PostHogTelemetry::Instance().RecordFunctionCall("odp_odata_show");
     auto base_url = input.inputs[0].GetValue<std::string>();
 
     // Get HTTP client and auth params from DuckDB secrets

--- a/src/odata_read_functions.cpp
+++ b/src/odata_read_functions.cpp
@@ -2011,7 +2011,7 @@ duckdb::InvalidInputException ConvertHttpErrorToUserFriendly(const std::runtime_
 duckdb::unique_ptr<FunctionData>
 ODataReadBind(ClientContext &context, TableFunctionBindInput &input,
               vector<LogicalType> &return_types, vector<string> &names) {
-  PostHogTelemetry::Instance().CaptureFunctionExecution("odata_read");
+  PostHogTelemetry::Instance().RecordFunctionCall("odata_read");
   auto auth_params = AuthParamsFromInput(context, input);
   auto url = input.inputs[0].GetValue<std::string>();
 

--- a/src/odp_odata_read_functions.cpp
+++ b/src/odp_odata_read_functions.cpp
@@ -17,7 +17,7 @@ duckdb::unique_ptr<duckdb::FunctionData> OdpODataReadBind(duckdb::ClientContext 
                                                           duckdb::TableFunctionBindInput &input,
                                                           duckdb::vector<duckdb::LogicalType> &return_types,
                                                           duckdb::vector<std::string> &names) {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("odp_odata_read");
+    PostHogTelemetry::Instance().RecordFunctionCall("odp_odata_read");
     ERPL_TRACE_DEBUG("ODP_ODATA_READ_BIND", "=== BINDING ODP_ODATA_READ FUNCTION ===");
     
     // Extract required parameter: entity_set_url

--- a/src/odp_pragma_functions.cpp
+++ b/src/odp_pragma_functions.cpp
@@ -16,7 +16,7 @@ duckdb::unique_ptr<duckdb::FunctionData> OdpListSubscriptionsBind(duckdb::Client
                                                                   duckdb::TableFunctionBindInput &input,
                                                                   duckdb::vector<duckdb::LogicalType> &return_types,
                                                                   duckdb::vector<std::string> &names) {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("odp_list_subscriptions");
+    PostHogTelemetry::Instance().RecordFunctionCall("odp_list_subscriptions");
     ERPL_TRACE_DEBUG("ODP_LIST_SUBSCRIPTIONS_BIND", "=== BINDING ODP_LIST_SUBSCRIPTIONS FUNCTION ===");
     
     // Set up return schema
@@ -107,7 +107,7 @@ void OdpListSubscriptionsScan(duckdb::ClientContext &context, duckdb::TableFunct
 // ============================================================================
 
 void OdpRemoveSubscriptionPragma(duckdb::ClientContext &context, const duckdb::FunctionParameters &parameters) {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("odp_remove_subscription");
+    PostHogTelemetry::Instance().RecordFunctionCall("odp_remove_subscription");
     ERPL_TRACE_DEBUG("ODP_REMOVE_SUBSCRIPTION", "=== EXECUTING ODP_REMOVE_SUBSCRIPTION PRAGMA ===");
     
     if (parameters.values.empty()) {

--- a/src/sac_catalog.cpp
+++ b/src/sac_catalog.cpp
@@ -295,7 +295,7 @@ static duckdb::unique_ptr<duckdb::FunctionData> SacShowModelsBind(
     duckdb::TableFunctionBindInput &input,
     duckdb::vector<duckdb::LogicalType> &return_types,
     duckdb::vector<std::string> &names) {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("sac_show_models");
+    PostHogTelemetry::Instance().RecordFunctionCall("sac_show_models");
 
     // Extract and resolve credentials
     auto secret_name = SacCatalogBindHelper::ExtractSecretName(input);
@@ -368,7 +368,7 @@ static duckdb::unique_ptr<duckdb::FunctionData> SacShowStoriesBind(
     duckdb::TableFunctionBindInput &input,
     duckdb::vector<duckdb::LogicalType> &return_types,
     duckdb::vector<std::string> &names) {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("sac_show_stories");
+    PostHogTelemetry::Instance().RecordFunctionCall("sac_show_stories");
 
     // Extract and resolve credentials
     auto secret_name = SacCatalogBindHelper::ExtractSecretName(input);
@@ -452,7 +452,7 @@ static duckdb::unique_ptr<duckdb::FunctionData> SacGetModelInfoBind(
     duckdb::TableFunctionBindInput &input,
     duckdb::vector<duckdb::LogicalType> &return_types,
     duckdb::vector<std::string> &names) {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("sac_describe_model");
+    PostHogTelemetry::Instance().RecordFunctionCall("sac_describe_model");
 
     // Extract and validate parameters
     auto model_id = SacCatalogBindHelper::ExtractPositionalString(input, 0, "model_id");
@@ -538,7 +538,7 @@ static duckdb::unique_ptr<duckdb::FunctionData> SacGetStoryInfoBind(
     duckdb::TableFunctionBindInput &input,
     duckdb::vector<duckdb::LogicalType> &return_types,
     duckdb::vector<std::string> &names) {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("sac_describe_story");
+    PostHogTelemetry::Instance().RecordFunctionCall("sac_describe_story");
 
     // Extract and validate parameters
     auto story_id = SacCatalogBindHelper::ExtractPositionalString(input, 0, "story_id");

--- a/src/sac_read_functions.cpp
+++ b/src/sac_read_functions.cpp
@@ -23,7 +23,7 @@ static duckdb::unique_ptr<duckdb::FunctionData> SacReadPlanningDataBind(
     duckdb::TableFunctionBindInput &input,
     duckdb::vector<duckdb::LogicalType> &return_types,
     duckdb::vector<std::string> &names) {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("sac_read_planning_data");
+    PostHogTelemetry::Instance().RecordFunctionCall("sac_read_planning_data");
 
     if (input.inputs.empty()) {
         throw duckdb::InvalidInputException("sac_read_planning_data requires a model_id parameter");
@@ -101,7 +101,7 @@ static duckdb::unique_ptr<duckdb::FunctionData> SacReadAnalyticalBind(
     duckdb::TableFunctionBindInput &input,
     duckdb::vector<duckdb::LogicalType> &return_types,
     duckdb::vector<std::string> &names) {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("sac_read_analytical");
+    PostHogTelemetry::Instance().RecordFunctionCall("sac_read_analytical");
 
     if (input.inputs.empty()) {
         throw duckdb::InvalidInputException("sac_read_analytical requires a model_id parameter");
@@ -198,7 +198,7 @@ static duckdb::unique_ptr<duckdb::FunctionData> SacReadStoryDataBind(
     duckdb::TableFunctionBindInput &input,
     duckdb::vector<duckdb::LogicalType> &return_types,
     duckdb::vector<std::string> &names) {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("sac_read_story_data");
+    PostHogTelemetry::Instance().RecordFunctionCall("sac_read_story_data");
 
     if (input.inputs.empty()) {
         throw duckdb::InvalidInputException("sac_read_story_data requires a story_id parameter");

--- a/src/web_functions.cpp
+++ b/src/web_functions.cpp
@@ -250,7 +250,7 @@ static unique_ptr<FunctionData> HttpGetBind(ClientContext &context,
                                             vector<LogicalType> &return_types, 
                                             vector<string> &names) 
 {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("http_get");
+    PostHogTelemetry::Instance().RecordFunctionCall("http_get");
     auto auth_params = AuthParamsFromInput(context, input);
     HttpParams http_params;
     if (HasParam(input.named_parameters, "timeout")) {
@@ -272,7 +272,7 @@ static unique_ptr<FunctionData> HttpHeadBind(ClientContext &context,
                                             vector<LogicalType> &return_types, 
                                             vector<string> &names) 
 {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("http_head");
+    PostHogTelemetry::Instance().RecordFunctionCall("http_head");
     auto auth_params = AuthParamsFromInput(context, input);
     HttpParams http_params;
     if (HasParam(input.named_parameters, "timeout")) {
@@ -316,7 +316,7 @@ static unique_ptr<FunctionData> HttpPostBind(ClientContext &context,
                                              vector<LogicalType> &return_types, 
                                              vector<string> &names) 
 {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("http_post");
+    PostHogTelemetry::Instance().RecordFunctionCall("http_post");
     return HttpMutatingBind(context, input, return_types, names, HttpMethod::POST);
 }
 
@@ -325,7 +325,7 @@ static unique_ptr<FunctionData> HttpPutBind(ClientContext &context,
                                              vector<LogicalType> &return_types, 
                                              vector<string> &names) 
 {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("http_put");
+    PostHogTelemetry::Instance().RecordFunctionCall("http_put");
     return HttpMutatingBind(context, input, return_types, names, HttpMethod::PUT);
 }
 
@@ -334,7 +334,7 @@ static unique_ptr<FunctionData> HttpPatchBind(ClientContext &context,
                                              vector<LogicalType> &return_types, 
                                              vector<string> &names) 
 {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("http_patch");
+    PostHogTelemetry::Instance().RecordFunctionCall("http_patch");
     return HttpMutatingBind(context, input, return_types, names, HttpMethod::PATCH);
 }
 
@@ -343,7 +343,7 @@ static unique_ptr<FunctionData> HttpDeleteBind(ClientContext &context,
                                               vector<LogicalType> &return_types, 
                                               vector<string> &names) 
 {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("http_delete");
+    PostHogTelemetry::Instance().RecordFunctionCall("http_delete");
     return HttpMutatingBind(context, input, return_types, names, HttpMethod::_DELETE);
 }
 


### PR DESCRIPTION
## Summary

Adopts the cross-product `telemetry_schema: 2` envelope from the shared `DataZooDE/posthog-telemetry` library, moving ERPL Web onto the analysis-first telemetry API.

- Bump the vendored `posthog-telemetry` submodule to the analysis-first API.
- Call `SetProduct` and register the `deployment` group at extension load.
- Migrate every per-function call site from `CaptureFunctionExecution` to `RecordFunctionCall`, which aggregates in-process into one `function_executed` event per function per session (`call_count`, `duration_ms_p50`) at the bind step — not on the per-row path.
- Add `TELEMETRY.md` documenting the schema, what is collected, and how to opt out.

## Privacy guarantee

Only bounded, enumerated, non-PII data leaves the machine: every property is **either** a constant drawn from a small, code-controlled enumeration (e.g. `function_name`, `os`, `arch`) **or** a pure number (durations, counts). The library additionally clamps any outgoing string to 512 bytes as a backstop.

We never send URLs, host names, service roots, entity/table/column names, `$filter`/query/SQL text, request/response bodies, row data, credentials, tokens, secret names, or error messages. `distinct_id` is a SHA-256 of a machine id (stable, pseudonymous).

Telemetry stays on by default and is trivially disabled (`SET erpl_telemetry_enabled = false` or `DATAZOO_DISABLE_TELEMETRY=1`), enforced at the transport so nothing leaves the machine when off.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786477094&installation_id=142929061&pr_number=53&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F53&signature=8571a8f5e436b53ecdea7806d0333180cc350eb85d16c0a8acfd6e30dd67ceb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->