### PR TITLE
chore: bump DuckDB to v1.5.5 (keep v1.4 LTS)

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -19,32 +19,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  duckdb-v154-build:
-    name: Build extension binaries (v1.5.4)
+  duckdb-v155-build:
+    name: Build extension binaries (v1.5.5)
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5-variegata
     with:
-      duckdb_version: v1.5.4
+      duckdb_version: v1.5.5
       extension_name: erpl_web
       ci_tools_version: v1.5-variegata
       vcpkg_commit: 84bab45d415d22042bd0b9081aea57f362da3f35
       exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads;'
 
-  duckdb-v154-smoke-test:
-    name: Smoke test (v1.5.4)
-    needs: duckdb-v154-build
+  duckdb-v155-smoke-test:
+    name: Smoke test (v1.5.5)
+    needs: duckdb-v155-build
     uses: ./.github/workflows/_extension_smoke_test.yml
     with:
-      duckdb_version: v1.5.4
+      duckdb_version: v1.5.5
       extension_name: erpl_web
       exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads;'
 
-  duckdb-v154-deploy:
-    name: Deploy extension binaries (v1.5.4)
-    needs: [duckdb-v154-build, duckdb-v154-smoke-test]
+  duckdb-v155-deploy:
+    name: Deploy extension binaries (v1.5.5)
+    needs: [duckdb-v155-build, duckdb-v155-smoke-test]
     uses: ./.github/workflows/_extension_deploy.yml
     secrets: inherit
     with:
-      duckdb_version: v1.5.4
+      duckdb_version: v1.5.5
       extension_name: erpl_web
       exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads;'
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
## Summary
- Bumps the `duckdb` submodule from **v1.5.4** to **v1.5.5**.
- Updates `.github/workflows/MainDistributionPipeline.yml`:
  - `duckdb_version: v1.5.4` -> `v1.5.5` on the stable job (build/smoke-test/deploy).
  - Job ids/names `duckdb-v154-*` -> `duckdb-v155-*` for consistency with the new version.
  - `ci_tools_version`/`uses:` ref on the stable line stays pinned to the rolling branch `v1.5-variegata` (unchanged — auto-tracks).
  - v1.4 LTS jobs (`duckdb-v145-*`) were already targeting `v1.4.5`; left unchanged (already normalized), still on rolling `v1.4-andium` tooling.
- No other pinned duckdb-version references found in the Makefile, vcpkg.json, or `_extension_build.yml`/`_extension_smoke_test.yml`/`_extension_deploy.yml` that needed updating.
- Dual v1.4/v1.5 release matrix (build/smoke-test/deploy jobs for both lines) is preserved.

## Local verification on bigfox
- **Build:** pass — `make release` (GEN=ninja) completed cleanly; `build/release/extension/erpl_web/erpl_web.duckdb_extension` produced.
- **Tests:** pass — `make test_release`: 47/47 test cases passed (46 skipped, requiring live integration credentials not available locally).

## Test plan
- [x] Local release build on bigfox (GCC-16) succeeded
- [x] Local `make test_release` — all non-skipped assertions passed
- [ ] CI (GitHub Actions) green on both v1.4.5 and v1.5.5 matrices

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787475260&installation_model_id=425457&pr_number=55&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F55&signature=94adb46e473a6156cbf9090e328bcb06d564c329187ed707397d127027b6a680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->