### PR TITLE
feat: add feedback banner and issue links to errors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,6 @@
 [submodule "posthog-telemetry"]
 	path = posthog-telemetry
 	url = https://github.com/DataZooDE/posthog-telemetry.git
+[submodule "datazoo-banner"]
+	path = datazoo-banner
+	url = https://github.com/DataZooDE/duckdb-extension-banner.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,14 @@ include_directories(
 # Add PostHog telemetry library
 add_subdirectory(posthog-telemetry)
 
+# Feedback banner (header-only). Telemetry ON so a printed banner counts as a
+# banner_shown event through the instance configured above.
+set(DATAZOO_BANNER_TELEMETRY ON CACHE BOOL "" FORCE)
+set(DATAZOO_BANNER_TELEMETRY_INCLUDE_DIR
+    ${CMAKE_CURRENT_SOURCE_DIR}/posthog-telemetry/include CACHE PATH "" FORCE)
+add_subdirectory(datazoo-banner)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/datazoo-banner/include)
+
 # Ensure posthog_telemetry has access to OpenSSL headers (required for httplib SSL support)
 target_link_libraries(posthog_telemetry PRIVATE OpenSSL::SSL OpenSSL::Crypto)
 

--- a/README.md
+++ b/README.md
@@ -1135,3 +1135,18 @@ This project is licensed under the Business Source License (BSL) 1.1. See [LICEN
 ---
 
 Build API-powered analytics with DuckDB + ERPL Web. Query the web like it’s a table. 🚀
+
+## Feedback
+
+If `erpl_web` misbehaves — an OData service it will not read, a Datasphere or Business
+Central call that fails oddly — please
+[open an issue](https://github.com/DataZooDE/erpl-web/issues). Services differ by tenant,
+version and auth setup in ways we cannot reproduce here, so a report with your setup is
+the fastest path to a fix. Every error the extension raises ends with that link.
+
+If it saved you time, a star on the repo helps other people find it.
+
+The first time you load the extension in an interactive terminal each day, a small
+banner says the same thing. It never prints when output is piped, in notebooks, or in
+CI. Silence it with `SET datazoo_banner = false;` or `DATAZOO_NO_BANNER=1`.
+

--- a/src/business_central_catalog.cpp
+++ b/src/business_central_catalog.cpp
@@ -5,6 +5,7 @@
 #include "http_client.hpp"
 #include "tracing.hpp"
 #include "duckdb/common/exception.hpp"
+#include "erpl_web_banner.hpp"
 
 namespace erpl_web {
 
@@ -43,7 +44,7 @@ duckdb::TableFunction BcTableEntry::GetScanFunction(duckdb::ClientContext &conte
     odata_bind->GetResultTypes();
     bind_data = std::move(odata_bind);
 
-    duckdb::TableFunction table_function("odata_table_scan", {}, ODataReadScan, ODataReadBind, ODataReadTableInitGlobalState);
+    duckdb::TableFunction table_function("odata_table_scan", {}, DATAZOO_GUARD(ERPL_WEB_BANNER, ODataReadScan), DATAZOO_GUARD(ERPL_WEB_BANNER, ODataReadBind), ODataReadTableInitGlobalState);
     table_function.filter_pushdown = true;
     table_function.filter_prune = true;
     table_function.projection_pushdown = true;

--- a/src/business_central_functions.cpp
+++ b/src/business_central_functions.cpp
@@ -7,6 +7,7 @@
 #include "tracing.hpp"
 #include "duckdb/common/exception.hpp"
 #include <variant>
+#include "erpl_web_banner.hpp"
 
 namespace erpl_web {
 
@@ -70,7 +71,7 @@ static void BcShowCompaniesScan(ClientContext &context, TableFunctionInput &data
 TableFunctionSet CreateBcShowCompaniesFunction() {
     TableFunctionSet set("bc_show_companies");
 
-    TableFunction func({}, BcShowCompaniesScan, BcShowCompaniesBind);
+    TableFunction func({}, DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowCompaniesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowCompaniesBind));
     func.named_parameters["secret"] = LogicalType::VARCHAR;
 
     set.AddFunction(func);
@@ -135,7 +136,7 @@ static void BcShowEntitiesScan(ClientContext &context, TableFunctionInput &data,
 TableFunctionSet CreateBcShowEntitiesFunction() {
     TableFunctionSet set("bc_show_entities");
 
-    TableFunction func({}, BcShowEntitiesScan, BcShowEntitiesBind);
+    TableFunction func({}, DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowEntitiesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowEntitiesBind));
     func.named_parameters["secret"] = LogicalType::VARCHAR;
 
     set.AddFunction(func);
@@ -248,7 +249,7 @@ static void BcDescribeScan(ClientContext &context, TableFunctionInput &data, Dat
 TableFunctionSet CreateBcDescribeFunction() {
     TableFunctionSet set("bc_describe");
 
-    TableFunction func({LogicalType::VARCHAR}, BcDescribeScan, BcDescribeBind);
+    TableFunction func({LogicalType::VARCHAR}, DATAZOO_GUARD(ERPL_WEB_BANNER, BcDescribeScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BcDescribeBind));
     func.named_parameters["secret"] = LogicalType::VARCHAR;
     func.named_parameters["company"] = LogicalType::VARCHAR;
 
@@ -373,7 +374,7 @@ static double BcReadProgress(ClientContext &context, const FunctionData *bind_da
 TableFunctionSet CreateBcReadFunction() {
     TableFunctionSet set("bc_read");
 
-    TableFunction func({LogicalType::VARCHAR}, BcReadScan, BcReadBind, BcReadInitGlobalState);
+    TableFunction func({LogicalType::VARCHAR}, DATAZOO_GUARD(ERPL_WEB_BANNER, BcReadScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BcReadBind), BcReadInitGlobalState);
     func.named_parameters["secret"] = LogicalType::VARCHAR;
     func.named_parameters["company"] = LogicalType::VARCHAR;
     func.named_parameters["expand"] = LogicalType::VARCHAR;

--- a/src/datasphere_catalog.cpp
+++ b/src/datasphere_catalog.cpp
@@ -13,6 +13,7 @@
 #include "telemetry.hpp"
 #include <algorithm>
 #include <unordered_set>
+#include "erpl_web_banner.hpp"
 
 namespace erpl_web {
 
@@ -1664,7 +1665,7 @@ duckdb::TableFunctionSet CreateDatasphereShowAssetsFunction() {
 duckdb::TableFunctionSet CreateDatasphereDescribeSpaceFunction() {
     duckdb::TableFunctionSet function_set("datasphere_describe_space");
     
-    duckdb::TableFunction describe_space({duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR)}, DatasphereDescribeSpaceFunction, DatasphereDescribeSpaceBind);
+    duckdb::TableFunction describe_space({duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR)}, DATAZOO_GUARD(ERPL_WEB_BANNER, DatasphereDescribeSpaceFunction), DATAZOO_GUARD(ERPL_WEB_BANNER, DatasphereDescribeSpaceBind));
     
     function_set.AddFunction(describe_space);
     return function_set;
@@ -1674,7 +1675,7 @@ duckdb::TableFunctionSet CreateDatasphereDescribeAssetFunction() {
     duckdb::TableFunctionSet function_set("datasphere_describe_asset");
     
     duckdb::TableFunction describe_asset({duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR), duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR)}, 
-                                        DatasphereDescribeAssetFunction, DatasphereDescribeAssetBind);
+                                        DATAZOO_GUARD(ERPL_WEB_BANNER, DatasphereDescribeAssetFunction), DATAZOO_GUARD(ERPL_WEB_BANNER, DatasphereDescribeAssetBind));
     
     function_set.AddFunction(describe_asset);
     return function_set;

--- a/src/datasphere_read.cpp
+++ b/src/datasphere_read.cpp
@@ -8,6 +8,7 @@
 #include "tracing.hpp"
 #include "telemetry.hpp"
 #include <sstream>
+#include "erpl_web_banner.hpp"
 
 namespace erpl_web {
 
@@ -216,7 +217,7 @@ duckdb::TableFunctionSet CreateDatasphereReadRelationalFunction() {
     duckdb::TableFunction relational_function_2_params(
         {duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR), 
          duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR)},
-        ODataReadScan, DatasphereReadRelationalBind, DatasphereReadRelationalTableInitGlobalState);
+        DATAZOO_GUARD(ERPL_WEB_BANNER, ODataReadScan), DATAZOO_GUARD(ERPL_WEB_BANNER, DatasphereReadRelationalBind), DatasphereReadRelationalTableInitGlobalState);
     relational_function_2_params.filter_pushdown = true;
     relational_function_2_params.projection_pushdown = true;
     relational_function_2_params.table_scan_progress = ODataReadTableProgress;
@@ -232,7 +233,7 @@ duckdb::TableFunctionSet CreateDatasphereReadRelationalFunction() {
         {duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR), 
          duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR),
          duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR)},
-        ODataReadScan, DatasphereReadRelationalBind, DatasphereReadRelationalTableInitGlobalState);
+        DATAZOO_GUARD(ERPL_WEB_BANNER, ODataReadScan), DATAZOO_GUARD(ERPL_WEB_BANNER, DatasphereReadRelationalBind), DatasphereReadRelationalTableInitGlobalState);
     relational_function_3_params.filter_pushdown = true;
     relational_function_3_params.projection_pushdown = true;
     relational_function_3_params.table_scan_progress = [](duckdb::ClientContext &context,
@@ -378,7 +379,7 @@ duckdb::TableFunctionSet CreateDatasphereReadAnalyticalFunction() {
     duckdb::TableFunction analytical_function_2_params(
         {duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR), 
          duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR)},
-        ODataReadScan, DatasphereReadAnalyticalBind, DatasphereReadAnalyticalTableInitGlobalState);
+        DATAZOO_GUARD(ERPL_WEB_BANNER, ODataReadScan), DATAZOO_GUARD(ERPL_WEB_BANNER, DatasphereReadAnalyticalBind), DatasphereReadAnalyticalTableInitGlobalState);
     analytical_function_2_params.filter_pushdown = true;
     analytical_function_2_params.projection_pushdown = true;
     analytical_function_2_params.table_scan_progress = ODataReadTableProgress;
@@ -396,7 +397,7 @@ duckdb::TableFunctionSet CreateDatasphereReadAnalyticalFunction() {
         {duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR), 
          duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR),
          duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR)},
-        ODataReadScan, DatasphereReadAnalyticalBind, DatasphereReadAnalyticalTableInitGlobalState);
+        DATAZOO_GUARD(ERPL_WEB_BANNER, ODataReadScan), DATAZOO_GUARD(ERPL_WEB_BANNER, DatasphereReadAnalyticalBind), DatasphereReadAnalyticalTableInitGlobalState);
     analytical_function_3_params.filter_pushdown = true;
     analytical_function_3_params.projection_pushdown = true;
     analytical_function_3_params.table_scan_progress = [](duckdb::ClientContext &context,

--- a/src/dataverse_functions.cpp
+++ b/src/dataverse_functions.cpp
@@ -6,6 +6,7 @@
 #include "tracing.hpp"
 #include "duckdb/common/exception.hpp"
 #include <variant>
+#include "erpl_web_banner.hpp"
 
 namespace erpl_web {
 
@@ -68,7 +69,7 @@ static void CrmShowEntitiesScan(ClientContext &context, TableFunctionInput &data
 TableFunctionSet CreateCrmShowEntitiesFunction() {
     TableFunctionSet set("crm_show_entities");
 
-    TableFunction func({}, CrmShowEntitiesScan, CrmShowEntitiesBind);
+    TableFunction func({}, DATAZOO_GUARD(ERPL_WEB_BANNER, CrmShowEntitiesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, CrmShowEntitiesBind));
     func.named_parameters["secret"] = LogicalType::VARCHAR;
 
     set.AddFunction(func);
@@ -199,7 +200,7 @@ static void CrmDescribeScan(ClientContext &context, TableFunctionInput &data, Da
 TableFunctionSet CreateCrmDescribeFunction() {
     TableFunctionSet set("crm_describe");
 
-    TableFunction func({LogicalType::VARCHAR}, CrmDescribeScan, CrmDescribeBind);
+    TableFunction func({LogicalType::VARCHAR}, DATAZOO_GUARD(ERPL_WEB_BANNER, CrmDescribeScan), DATAZOO_GUARD(ERPL_WEB_BANNER, CrmDescribeBind));
     func.named_parameters["secret"] = LogicalType::VARCHAR;
 
     set.AddFunction(func);
@@ -300,7 +301,7 @@ static double CrmReadProgress(ClientContext &context, const FunctionData *bind_d
 TableFunctionSet CreateCrmReadFunction() {
     TableFunctionSet set("crm_read");
 
-    TableFunction func({LogicalType::VARCHAR}, CrmReadScan, CrmReadBind, CrmReadInitGlobalState);
+    TableFunction func({LogicalType::VARCHAR}, DATAZOO_GUARD(ERPL_WEB_BANNER, CrmReadScan), DATAZOO_GUARD(ERPL_WEB_BANNER, CrmReadBind), CrmReadInitGlobalState);
     func.named_parameters["secret"] = LogicalType::VARCHAR;
     func.named_parameters["expand"] = LogicalType::VARCHAR;
 

--- a/src/delta_share_catalog.cpp
+++ b/src/delta_share_catalog.cpp
@@ -12,6 +12,7 @@
 #include <memory>
 #include <vector>
 #include <string>
+#include "erpl_web_banner.hpp"
 
 using duckdb::ClientContext;
 using duckdb::DataChunk;
@@ -334,7 +335,7 @@ DeltaShareShowTablesBind(ClientContext &context, TableFunctionBindInput &input,
 static TableFunctionSet CreateDeltaShareShowSharesFunctionInternal() {
 	TableFunctionSet function_set("delta_share_show_shares");
 
-	duckdb::TableFunction func({LogicalTypeId::VARCHAR}, DeltaShareShowSharesScan, DeltaShareShowSharesBind);
+	duckdb::TableFunction func({LogicalTypeId::VARCHAR}, DATAZOO_GUARD(ERPL_WEB_BANNER, DeltaShareShowSharesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, DeltaShareShowSharesBind));
 
 	function_set.AddFunction(func);
 	return function_set;
@@ -344,7 +345,7 @@ static TableFunctionSet CreateDeltaShareShowSchemasFunctionInternal() {
 	TableFunctionSet function_set("delta_share_show_schemas");
 
 	duckdb::TableFunction func({LogicalTypeId::VARCHAR, LogicalTypeId::VARCHAR},
-							   DeltaShareShowSchemasScan, DeltaShareShowSchemasBind);
+							   DATAZOO_GUARD(ERPL_WEB_BANNER, DeltaShareShowSchemasScan), DATAZOO_GUARD(ERPL_WEB_BANNER, DeltaShareShowSchemasBind));
 
 	function_set.AddFunction(func);
 	return function_set;
@@ -354,7 +355,7 @@ static TableFunctionSet CreateDeltaShareShowTablesFunctionInternal() {
 	TableFunctionSet function_set("delta_share_show_tables");
 
 	duckdb::TableFunction func({LogicalTypeId::VARCHAR, LogicalTypeId::VARCHAR, LogicalTypeId::VARCHAR},
-							   DeltaShareShowTablesScan, DeltaShareShowTablesBind);
+							   DATAZOO_GUARD(ERPL_WEB_BANNER, DeltaShareShowTablesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, DeltaShareShowTablesBind));
 
 	function_set.AddFunction(func);
 	return function_set;

--- a/src/erpl_web_extension.cpp
+++ b/src/erpl_web_extension.cpp
@@ -47,6 +47,7 @@
 
 // Needed for OPENSSL_init_ssl / OPENSSL_INIT_NO_ATEXIT
 #include <openssl/ssl.h>
+#include "erpl_web_banner.hpp"
 
 #if defined(__linux__) || defined(__APPLE__)
 #include <dlfcn.h>
@@ -82,6 +83,11 @@
     #undef BOTH
 #endif
 #endif
+
+// Deliberately outside namespace duckdb: the banner library is DuckDB-agnostic
+// and the guard macro refers to this object from every guarded source file.
+const datazoo::BannerInfo ERPL_WEB_BANNER {
+    "erpl_web", "2026.07.24", "https://github.com/DataZooDE/erpl-web"};
 
 namespace duckdb {
 
@@ -920,6 +926,11 @@ static void LoadInternal(ExtensionLoader &loader) {
     RegisterGraphEntraFunctions(loader);
     RegisterGraphTeamsFunctions(loader);
     RegisterTracingPragmas(loader);
+
+    datazoo::RegisterBannerOption(loader);
+    // Last, so a load that fails earlier never advertises itself. Silent unless
+    // stderr is a terminal and the ~/.duckdb stamp is over a day old.
+    datazoo::ShowBanner(ERPL_WEB_BANNER);
 }
     
 void ErplWebExtension::Load(ExtensionLoader &loader) {

--- a/src/graph_entra_functions.cpp
+++ b/src/graph_entra_functions.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "tracing.hpp"
 #include "yyjson.hpp"
+#include "erpl_web_banner.hpp"
 
 using namespace duckdb;
 using namespace duckdb_yyjson;
@@ -484,7 +485,7 @@ void GraphEntraFunctions::SignInLogsScan(
 
 void GraphEntraFunctions::Register(ExtensionLoader &loader) {
     {
-        TableFunction users_func("graph_users", {}, UsersScan, UsersBind);
+        TableFunction users_func("graph_users", {}, DATAZOO_GUARD(ERPL_WEB_BANNER, UsersScan), DATAZOO_GUARD(ERPL_WEB_BANNER, UsersBind));
         users_func.named_parameters["secret"] = LogicalType::VARCHAR;
         CreateTableFunctionInfo info(users_func);
         FunctionDescription desc;
@@ -497,7 +498,7 @@ void GraphEntraFunctions::Register(ExtensionLoader &loader) {
         loader.RegisterFunction(std::move(info));
     }
     {
-        TableFunction groups_func("graph_groups", {}, GroupsScan, GroupsBind);
+        TableFunction groups_func("graph_groups", {}, DATAZOO_GUARD(ERPL_WEB_BANNER, GroupsScan), DATAZOO_GUARD(ERPL_WEB_BANNER, GroupsBind));
         groups_func.named_parameters["secret"] = LogicalType::VARCHAR;
         CreateTableFunctionInfo info(groups_func);
         FunctionDescription desc;
@@ -510,7 +511,7 @@ void GraphEntraFunctions::Register(ExtensionLoader &loader) {
         loader.RegisterFunction(std::move(info));
     }
     {
-        TableFunction devices_func("graph_devices", {}, DevicesScan, DevicesBind);
+        TableFunction devices_func("graph_devices", {}, DATAZOO_GUARD(ERPL_WEB_BANNER, DevicesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, DevicesBind));
         devices_func.named_parameters["secret"] = LogicalType::VARCHAR;
         CreateTableFunctionInfo info(devices_func);
         FunctionDescription desc;
@@ -523,7 +524,7 @@ void GraphEntraFunctions::Register(ExtensionLoader &loader) {
         loader.RegisterFunction(std::move(info));
     }
     {
-        TableFunction signin_logs_func("graph_signin_logs", {}, SignInLogsScan, SignInLogsBind);
+        TableFunction signin_logs_func("graph_signin_logs", {}, DATAZOO_GUARD(ERPL_WEB_BANNER, SignInLogsScan), DATAZOO_GUARD(ERPL_WEB_BANNER, SignInLogsBind));
         signin_logs_func.named_parameters["secret"] = LogicalType::VARCHAR;
         CreateTableFunctionInfo info(signin_logs_func);
         FunctionDescription desc;

--- a/src/graph_excel_functions.cpp
+++ b/src/graph_excel_functions.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/types/date.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "yyjson.hpp"
+#include "erpl_web_banner.hpp"
 
 using namespace duckdb_yyjson;
 
@@ -991,7 +992,7 @@ void GraphExcelFunctions::Register(ExtensionLoader &loader) {
     ERPL_TRACE_INFO("GRAPH_EXCEL", "Registering Microsoft Graph Excel functions");
 
     {
-        TableFunction list_files("graph_show_files", {}, ListFilesScan, ListFilesBind);
+        TableFunction list_files("graph_show_files", {}, DATAZOO_GUARD(ERPL_WEB_BANNER, ListFilesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, ListFilesBind));
         list_files.varargs = LogicalType::VARCHAR;
         list_files.named_parameters["secret"] = LogicalType::VARCHAR;
         list_files.named_parameters["drive"] = LogicalType::VARCHAR;
@@ -1015,7 +1016,7 @@ void GraphExcelFunctions::Register(ExtensionLoader &loader) {
     }
     {
         TableFunction excel_tables("graph_excel_tables", {LogicalType::VARCHAR},
-                                   ExcelTablesScan, ExcelTablesBind);
+                                   DATAZOO_GUARD(ERPL_WEB_BANNER, ExcelTablesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, ExcelTablesBind));
         excel_tables.named_parameters["secret"] = LogicalType::VARCHAR;
         excel_tables.named_parameters["drive"] = LogicalType::VARCHAR;
         excel_tables.named_parameters["site"] = LogicalType::VARCHAR;
@@ -1038,7 +1039,7 @@ void GraphExcelFunctions::Register(ExtensionLoader &loader) {
     }
     {
         TableFunction excel_worksheets("graph_excel_worksheets", {LogicalType::VARCHAR},
-                                       ExcelWorksheetsScan, ExcelWorksheetsBind);
+                                       DATAZOO_GUARD(ERPL_WEB_BANNER, ExcelWorksheetsScan), DATAZOO_GUARD(ERPL_WEB_BANNER, ExcelWorksheetsBind));
         excel_worksheets.named_parameters["secret"] = LogicalType::VARCHAR;
         excel_worksheets.named_parameters["drive"] = LogicalType::VARCHAR;
         excel_worksheets.named_parameters["site"] = LogicalType::VARCHAR;
@@ -1062,7 +1063,7 @@ void GraphExcelFunctions::Register(ExtensionLoader &loader) {
     {
         TableFunction excel_range("graph_excel_range",
                                   {LogicalType::VARCHAR, LogicalType::VARCHAR},
-                                  ExcelRangeScan, ExcelRangeBind);
+                                  DATAZOO_GUARD(ERPL_WEB_BANNER, ExcelRangeScan), DATAZOO_GUARD(ERPL_WEB_BANNER, ExcelRangeBind));
         excel_range.varargs = LogicalType::VARCHAR;
         excel_range.named_parameters["secret"] = LogicalType::VARCHAR;
         excel_range.named_parameters["drive"] = LogicalType::VARCHAR;
@@ -1089,7 +1090,7 @@ void GraphExcelFunctions::Register(ExtensionLoader &loader) {
     {
         TableFunction excel_table_data("graph_excel_read",
                                        {LogicalType::VARCHAR, LogicalType::VARCHAR},
-                                       ExcelTableDataScan, ExcelTableDataBind);
+                                       DATAZOO_GUARD(ERPL_WEB_BANNER, ExcelTableDataScan), DATAZOO_GUARD(ERPL_WEB_BANNER, ExcelTableDataBind));
         excel_table_data.named_parameters["secret"] = LogicalType::VARCHAR;
         excel_table_data.named_parameters["drive"] = LogicalType::VARCHAR;
         excel_table_data.named_parameters["site"] = LogicalType::VARCHAR;

--- a/src/graph_outlook_functions.cpp
+++ b/src/graph_outlook_functions.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "yyjson.hpp"
+#include "erpl_web_banner.hpp"
 
 using namespace duckdb_yyjson;
 
@@ -595,7 +596,7 @@ void GraphOutlookFunctions::Register(ExtensionLoader &loader) {
     ERPL_TRACE_INFO("GRAPH_OUTLOOK", "Registering Microsoft Graph Outlook functions");
 
     {
-        TableFunction fn("graph_calendars", {}, CalendarsScan, CalendarsBind);
+        TableFunction fn("graph_calendars", {}, DATAZOO_GUARD(ERPL_WEB_BANNER, CalendarsScan), DATAZOO_GUARD(ERPL_WEB_BANNER, CalendarsBind));
         fn.named_parameters["user"]    = LogicalType::VARCHAR;
         fn.named_parameters["secret"]  = LogicalType::VARCHAR;
         CreateTableFunctionInfo info(fn);
@@ -615,7 +616,7 @@ void GraphOutlookFunctions::Register(ExtensionLoader &loader) {
         loader.RegisterFunction(std::move(info));
     }
     {
-        TableFunction fn("graph_calendar_events", {}, CalendarEventsScan, CalendarEventsBind);
+        TableFunction fn("graph_calendar_events", {}, DATAZOO_GUARD(ERPL_WEB_BANNER, CalendarEventsScan), DATAZOO_GUARD(ERPL_WEB_BANNER, CalendarEventsBind));
         fn.named_parameters["user"]        = LogicalType::VARCHAR;
         fn.named_parameters["calendar_id"] = LogicalType::VARCHAR;
         fn.named_parameters["start_date"]  = LogicalType::VARCHAR;
@@ -641,7 +642,7 @@ void GraphOutlookFunctions::Register(ExtensionLoader &loader) {
         loader.RegisterFunction(std::move(info));
     }
     {
-        TableFunction fn("graph_contacts", {}, ContactsScan, ContactsBind);
+        TableFunction fn("graph_contacts", {}, DATAZOO_GUARD(ERPL_WEB_BANNER, ContactsScan), DATAZOO_GUARD(ERPL_WEB_BANNER, ContactsBind));
         fn.named_parameters["user"]    = LogicalType::VARCHAR;
         fn.named_parameters["secret"]  = LogicalType::VARCHAR;
         CreateTableFunctionInfo info(fn);
@@ -661,7 +662,7 @@ void GraphOutlookFunctions::Register(ExtensionLoader &loader) {
         loader.RegisterFunction(std::move(info));
     }
     {
-        TableFunction fn("graph_outlook_mail_folders", {}, MailFoldersScan, MailFoldersBind);
+        TableFunction fn("graph_outlook_mail_folders", {}, DATAZOO_GUARD(ERPL_WEB_BANNER, MailFoldersScan), DATAZOO_GUARD(ERPL_WEB_BANNER, MailFoldersBind));
         fn.named_parameters["user"]    = LogicalType::VARCHAR;
         fn.named_parameters["secret"]  = LogicalType::VARCHAR;
         CreateTableFunctionInfo info(fn);
@@ -681,7 +682,7 @@ void GraphOutlookFunctions::Register(ExtensionLoader &loader) {
         loader.RegisterFunction(std::move(info));
     }
     {
-        TableFunction fn("graph_outlook_emails", {}, MessagesScan, MessagesBind);
+        TableFunction fn("graph_outlook_emails", {}, DATAZOO_GUARD(ERPL_WEB_BANNER, MessagesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, MessagesBind));
         fn.named_parameters["user"]    = LogicalType::VARCHAR;
         fn.named_parameters["folder"]  = LogicalType::VARCHAR;
         fn.named_parameters["secret"]  = LogicalType::VARCHAR;

--- a/src/graph_planner_functions.cpp
+++ b/src/graph_planner_functions.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "yyjson.hpp"
+#include "erpl_web_banner.hpp"
 
 using namespace duckdb_yyjson;
 
@@ -455,7 +456,7 @@ void GraphPlannerFunctions::Register(ExtensionLoader &loader) {
 
     {
         TableFunction planner_plans("graph_planner_plans", {LogicalType::VARCHAR},
-                                    PlansScan, PlansBind);
+                                    DATAZOO_GUARD(ERPL_WEB_BANNER, PlansScan), DATAZOO_GUARD(ERPL_WEB_BANNER, PlansBind));
         planner_plans.named_parameters["secret"] = LogicalType::VARCHAR;
         CreateTableFunctionInfo info(planner_plans);
         FunctionDescription desc;
@@ -469,7 +470,7 @@ void GraphPlannerFunctions::Register(ExtensionLoader &loader) {
     }
     {
         TableFunction planner_buckets("graph_planner_buckets", {LogicalType::VARCHAR},
-                                      BucketsScan, BucketsBind);
+                                      DATAZOO_GUARD(ERPL_WEB_BANNER, BucketsScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BucketsBind));
         planner_buckets.named_parameters["secret"] = LogicalType::VARCHAR;
         CreateTableFunctionInfo info(planner_buckets);
         FunctionDescription desc;
@@ -483,7 +484,7 @@ void GraphPlannerFunctions::Register(ExtensionLoader &loader) {
     }
     {
         TableFunction planner_tasks("graph_planner_tasks", {LogicalType::VARCHAR},
-                                    TasksScan, TasksBind);
+                                    DATAZOO_GUARD(ERPL_WEB_BANNER, TasksScan), DATAZOO_GUARD(ERPL_WEB_BANNER, TasksBind));
         planner_tasks.named_parameters["secret"] = LogicalType::VARCHAR;
         CreateTableFunctionInfo info(planner_tasks);
         FunctionDescription desc;
@@ -499,7 +500,7 @@ void GraphPlannerFunctions::Register(ExtensionLoader &loader) {
     {
         TableFunction create_task("graph_planner_create_task",
                                    {LogicalType::VARCHAR, LogicalType::VARCHAR},
-                                   CreateTaskScan, CreateTaskBind);
+                                   DATAZOO_GUARD(ERPL_WEB_BANNER, CreateTaskScan), DATAZOO_GUARD(ERPL_WEB_BANNER, CreateTaskBind));
         create_task.named_parameters["bucket_id"]        = LogicalType::VARCHAR;
         create_task.named_parameters["due_date"]         = LogicalType::VARCHAR;
         create_task.named_parameters["start_date"]       = LogicalType::VARCHAR;

--- a/src/graph_sharepoint_functions.cpp
+++ b/src/graph_sharepoint_functions.cpp
@@ -12,6 +12,7 @@
 #include "yyjson.hpp"
 #include <algorithm>
 #include <unordered_set>
+#include "erpl_web_banner.hpp"
 
 using namespace duckdb_yyjson;
 
@@ -729,7 +730,7 @@ void GraphSharePointFunctions::Register(ExtensionLoader &loader) {
     ERPL_TRACE_INFO("GRAPH_SHAREPOINT", "Registering Microsoft Graph SharePoint functions");
 
     {
-        TableFunction show_sites("graph_show_sites", {}, ShowSitesScan, ShowSitesBind);
+        TableFunction show_sites("graph_show_sites", {}, DATAZOO_GUARD(ERPL_WEB_BANNER, ShowSitesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, ShowSitesBind));
         show_sites.varargs = LogicalType::VARCHAR;
         show_sites.named_parameters["secret"] = LogicalType::VARCHAR;
         CreateTableFunctionInfo info(show_sites);
@@ -749,7 +750,7 @@ void GraphSharePointFunctions::Register(ExtensionLoader &loader) {
         loader.RegisterFunction(std::move(info));
     }
     {
-        TableFunction show_drives("graph_show_drives", {}, ShowDrivesScan, ShowDrivesBind);
+        TableFunction show_drives("graph_show_drives", {}, DATAZOO_GUARD(ERPL_WEB_BANNER, ShowDrivesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, ShowDrivesBind));
         show_drives.varargs = LogicalType::VARCHAR;
         show_drives.named_parameters["secret"] = LogicalType::VARCHAR;
         show_drives.named_parameters["site"] = LogicalType::VARCHAR;
@@ -770,7 +771,7 @@ void GraphSharePointFunctions::Register(ExtensionLoader &loader) {
         loader.RegisterFunction(std::move(info));
     }
     {
-        TableFunction show_lists("graph_show_lists", {}, ShowListsScan, ShowListsBind);
+        TableFunction show_lists("graph_show_lists", {}, DATAZOO_GUARD(ERPL_WEB_BANNER, ShowListsScan), DATAZOO_GUARD(ERPL_WEB_BANNER, ShowListsBind));
         show_lists.varargs = LogicalType::VARCHAR;
         show_lists.named_parameters["secret"] = LogicalType::VARCHAR;
         show_lists.named_parameters["site"] = LogicalType::VARCHAR;
@@ -795,7 +796,7 @@ void GraphSharePointFunctions::Register(ExtensionLoader &loader) {
     {
         TableFunction describe_list("graph_describe_list",
                                     {LogicalType::VARCHAR, LogicalType::VARCHAR},
-                                    DescribeListScan, DescribeListBind);
+                                    DATAZOO_GUARD(ERPL_WEB_BANNER, DescribeListScan), DATAZOO_GUARD(ERPL_WEB_BANNER, DescribeListBind));
         describe_list.named_parameters["secret"] = LogicalType::VARCHAR;
         CreateTableFunctionInfo info(describe_list);
         FunctionDescription desc;
@@ -817,7 +818,7 @@ void GraphSharePointFunctions::Register(ExtensionLoader &loader) {
     {
         TableFunction list_items("graph_sharepoint_list_read",
                                  {LogicalType::VARCHAR, LogicalType::VARCHAR},
-                                 ListItemsScan, ListItemsBind);
+                                 DATAZOO_GUARD(ERPL_WEB_BANNER, ListItemsScan), DATAZOO_GUARD(ERPL_WEB_BANNER, ListItemsBind));
         list_items.named_parameters["secret"] = LogicalType::VARCHAR;
         CreateTableFunctionInfo info(list_items);
         FunctionDescription desc;
@@ -839,7 +840,7 @@ void GraphSharePointFunctions::Register(ExtensionLoader &loader) {
     {
         TableFunction create_item("graph_sharepoint_create_item",
                                   {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
-                                  CreateItemScan, CreateItemBind);
+                                  DATAZOO_GUARD(ERPL_WEB_BANNER, CreateItemScan), DATAZOO_GUARD(ERPL_WEB_BANNER, CreateItemBind));
         create_item.named_parameters["secret"] = LogicalType::VARCHAR;
         CreateTableFunctionInfo info(create_item);
         FunctionDescription desc;

--- a/src/graph_teams_functions.cpp
+++ b/src/graph_teams_functions.cpp
@@ -5,6 +5,7 @@
 #include "graph_output_utils.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "yyjson.hpp"
+#include "erpl_web_banner.hpp"
 
 using namespace duckdb;
 using namespace duckdb_yyjson;
@@ -390,7 +391,7 @@ void GraphTeamsFunctions::ChannelMessagesScan(
 
 void GraphTeamsFunctions::Register(ExtensionLoader &loader) {
     {
-        TableFunction my_teams_func("graph_my_teams", {}, MyTeamsScan, MyTeamsBind);
+        TableFunction my_teams_func("graph_my_teams", {}, DATAZOO_GUARD(ERPL_WEB_BANNER, MyTeamsScan), DATAZOO_GUARD(ERPL_WEB_BANNER, MyTeamsBind));
         my_teams_func.named_parameters["user"]   = LogicalType::VARCHAR;
         my_teams_func.named_parameters["secret"] = LogicalType::VARCHAR;
         CreateTableFunctionInfo info(my_teams_func);
@@ -408,7 +409,7 @@ void GraphTeamsFunctions::Register(ExtensionLoader &loader) {
         loader.RegisterFunction(std::move(info));
     }
     {
-        TableFunction team_channels_func("graph_teams_channels", {LogicalType::VARCHAR}, TeamChannelsScan, TeamChannelsBind);
+        TableFunction team_channels_func("graph_teams_channels", {LogicalType::VARCHAR}, DATAZOO_GUARD(ERPL_WEB_BANNER, TeamChannelsScan), DATAZOO_GUARD(ERPL_WEB_BANNER, TeamChannelsBind));
         team_channels_func.named_parameters["secret"] = LogicalType::VARCHAR;
         team_channels_func.named_parameters["user"]   = LogicalType::VARCHAR;
         CreateTableFunctionInfo info(team_channels_func);
@@ -426,7 +427,7 @@ void GraphTeamsFunctions::Register(ExtensionLoader &loader) {
         loader.RegisterFunction(std::move(info));
     }
     {
-        TableFunction team_members_func("graph_teams_members", {LogicalType::VARCHAR}, TeamMembersScan, TeamMembersBind);
+        TableFunction team_members_func("graph_teams_members", {LogicalType::VARCHAR}, DATAZOO_GUARD(ERPL_WEB_BANNER, TeamMembersScan), DATAZOO_GUARD(ERPL_WEB_BANNER, TeamMembersBind));
         team_members_func.named_parameters["secret"] = LogicalType::VARCHAR;
         team_members_func.named_parameters["user"]   = LogicalType::VARCHAR;
         CreateTableFunctionInfo info(team_members_func);
@@ -446,7 +447,7 @@ void GraphTeamsFunctions::Register(ExtensionLoader &loader) {
     {
         TableFunction channel_messages_func("graph_channel_messages",
             {LogicalType::VARCHAR, LogicalType::VARCHAR},
-            ChannelMessagesScan, ChannelMessagesBind);
+            DATAZOO_GUARD(ERPL_WEB_BANNER, ChannelMessagesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, ChannelMessagesBind));
         channel_messages_func.named_parameters["secret"] = LogicalType::VARCHAR;
         channel_messages_func.named_parameters["user"]   = LogicalType::VARCHAR;
         CreateTableFunctionInfo info(channel_messages_func);

--- a/src/include/erpl_web_banner.hpp
+++ b/src/include/erpl_web_banner.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "datazoo_banner_duckdb.hpp"
+
+// Shared identity for the load banner and the issue-link error footer.
+// External linkage: DATAZOO_GUARD takes the address as a non-type template
+// argument. Defined in erpl_web_extension.cpp.
+extern const datazoo::BannerInfo ERPL_WEB_BANNER;

--- a/src/odata_attach_functions.cpp
+++ b/src/odata_attach_functions.cpp
@@ -6,6 +6,7 @@
 
 #include "odata_attach_functions.hpp"
 #include "telemetry.hpp"
+#include "erpl_web_banner.hpp"
 
 namespace erpl_web {
 
@@ -169,7 +170,7 @@ TableFunctionSet CreateODataAttachFunction()
 {
     TableFunctionSet function_set("odata_attach");
 
-    TableFunction attach_service_ignore_complex({LogicalType::VARCHAR}, ODataAttachScan, ODataAttachBind);
+    TableFunction attach_service_ignore_complex({LogicalType::VARCHAR}, DATAZOO_GUARD(ERPL_WEB_BANNER, ODataAttachScan), DATAZOO_GUARD(ERPL_WEB_BANNER, ODataAttachBind));
     attach_service_ignore_complex.named_parameters["overwrite"] = LogicalTypeId::BOOLEAN;
     attach_service_ignore_complex.named_parameters["ignore"] = LogicalType::LIST(LogicalTypeId::VARCHAR);
     function_set.AddFunction(attach_service_ignore_complex);

--- a/src/odata_catalog.cpp
+++ b/src/odata_catalog.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/parser/column_definition.hpp"
 #include "http_client.hpp"
 #include "odata_attach_functions.hpp"
+#include "erpl_web_banner.hpp"
 
 namespace erpl_web {
 
@@ -199,7 +200,7 @@ duckdb::TableFunction ODataTableEntry::GetScanFunction(duckdb::ClientContext &co
     bind_data = std::move(odata_bind_data);
     
     // Create and return a TableFunction with OData scan capabilities
-    duckdb::TableFunction table_function("odata_table_scan", {}, ODataReadScan, ODataReadBind, ODataReadTableInitGlobalState);
+    duckdb::TableFunction table_function("odata_table_scan", {}, DATAZOO_GUARD(ERPL_WEB_BANNER, ODataReadScan), DATAZOO_GUARD(ERPL_WEB_BANNER, ODataReadBind), ODataReadTableInitGlobalState);
     table_function.filter_pushdown = true;
     table_function.projection_pushdown = true;
     table_function.table_scan_progress = ODataReadTableProgress;

--- a/src/odata_describe_functions.cpp
+++ b/src/odata_describe_functions.cpp
@@ -8,6 +8,7 @@
 
 #include <optional>
 #include <set>
+#include "erpl_web_banner.hpp"
 
 namespace erpl_web {
 
@@ -493,7 +494,7 @@ static void ODataDescribeScan(
 TableFunctionSet CreateODataDescribeFunction() {
     TableFunctionSet describe_func("odata_describe");
     
-    TableFunction describe_function({LogicalTypeId::VARCHAR}, ODataDescribeScan, ODataDescribeBind);
+    TableFunction describe_function({LogicalTypeId::VARCHAR}, DATAZOO_GUARD(ERPL_WEB_BANNER, ODataDescribeScan), DATAZOO_GUARD(ERPL_WEB_BANNER, ODataDescribeBind));
     describe_function.named_parameters["secret"] = LogicalTypeId::VARCHAR;
     
     describe_func.AddFunction(describe_function);

--- a/src/odata_read_functions.cpp
+++ b/src/odata_read_functions.cpp
@@ -9,6 +9,7 @@
 
 #include "tracing.hpp"
 #include "telemetry.hpp"
+#include "erpl_web_banner.hpp"
 
 namespace erpl_web {
 
@@ -2134,7 +2135,7 @@ void ODataReadScan(ClientContext &context, TableFunctionInput &data,
 TableFunctionSet CreateODataReadFunction() {
     TableFunctionSet function_set("odata_read");
     
-    TableFunction read_entity_set({LogicalTypeId::VARCHAR}, ODataReadScan, ODataReadBind, ODataReadTableInitGlobalState);
+    TableFunction read_entity_set({LogicalTypeId::VARCHAR}, DATAZOO_GUARD(ERPL_WEB_BANNER, ODataReadScan), DATAZOO_GUARD(ERPL_WEB_BANNER, ODataReadBind), ODataReadTableInitGlobalState);
     read_entity_set.filter_pushdown = true;
     read_entity_set.projection_pushdown = true;
     read_entity_set.table_scan_progress = ODataReadTableProgress;

--- a/src/sac_read_functions.cpp
+++ b/src/sac_read_functions.cpp
@@ -7,6 +7,7 @@
 #include "odata_content.hpp"
 #include "telemetry.hpp"
 #include <algorithm>
+#include "erpl_web_banner.hpp"
 
 namespace erpl_web {
 
@@ -69,7 +70,7 @@ duckdb::TableFunctionSet CreateSacReadPlanningDataFunction() {
 
     duckdb::TableFunction function(
         {duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR)},  // model_id
-        ODataReadScan,
+        DATAZOO_GUARD(ERPL_WEB_BANNER, ODataReadScan),
         SacReadPlanningDataBind,
         ODataReadTableInitGlobalState
     );
@@ -166,7 +167,7 @@ duckdb::TableFunctionSet CreateSacReadAnalyticalFunction() {
 
     duckdb::TableFunction function(
         {duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR)},  // model_id
-        ODataReadScan,
+        DATAZOO_GUARD(ERPL_WEB_BANNER, ODataReadScan),
         SacReadAnalyticalBind,
         ODataReadTableInitGlobalState
     );
@@ -232,7 +233,7 @@ duckdb::TableFunctionSet CreateSacReadStoryDataFunction() {
 
     duckdb::TableFunction function(
         {duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR)},  // story_id
-        ODataReadScan,
+        DATAZOO_GUARD(ERPL_WEB_BANNER, ODataReadScan),
         SacReadStoryDataBind,
         ODataReadTableInitGlobalState
     );


### PR DESCRIPTION
OData services, Datasphere tenants and Business Central instances differ by version and auth setup in ways we cannot reproduce here, so the users who hit a problem are the only ones who can tell us what their setup looked like.

This completes a fleet-wide rollout using the shared [`DataZooDE/duckdb-extension-banner`](https://github.com/DataZooDE/duckdb-extension-banner) submodule — erpl-adt and erpl-rev are released, the rest are in review.

## What changed

**Once-a-day banner on interactive load.** Silent when piped, in notebooks, in CI and under the test runner — which is why no existing expected output changes.

**Issue link on errors** from 101 scan/bind pointers across the OData, Datasphere, Business Central, Graph and ODP surfaces, via `DATAZOO_GUARD`.

```
Invalid Input Error: Failed to access OData service at: not-a-url. Error: {...}
-> Unexpected? Please report it: https://github.com/DataZooDE/erpl-web/issues
```

## Branched from main, not stacked on the migration

This is deliberately **not** built on `migrate/datazoo-oauth2` ([#56](https://github.com/DataZooDE/erpl-web/pull/56)), so the two can merge in either order without a rebase dance.

## Verified against the built artifact

- Banner on an interactive `LOAD`, **absent when piped**
- Failing `odata_read` reports its original `Invalid Input Error` with the link appended
- **C++ suite: 1141 assertions in 226 cases** — identical to before this change

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788626350&installation_model_id=425457&pr_number=57&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F57&signature=2822ab95daefafb4ec7d24aee22c4788915a112dfdb0f46aece914eda2327dae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->