### PR TITLE
test: account for the two TLS settings in the erpl_ setting count

### DIFF
--- a/test/sql/web_core.test
+++ b/test/sql/web_core.test
@@ -31,11 +31,13 @@ SELECT COUNT(*) FROM duckdb_functions() WHERE function_name LIKE '%datasphere%' 
 # SECTION 2: Core Extension Settings
 # ============================================================================
 
-# Test that extension-specific settings exist
+# Test that extension-specific settings exist.
+# 10 = 7 tracing/telemetry settings + erpl_ca_cert_file and
+# erpl_unsafe_disable_server_cert_verification, added with TLS verification (#63).
 query I
 SELECT COUNT(*) FROM duckdb_settings() WHERE name LIKE 'erpl_%';
 ----
-8
+10
 
 # Verify core settings exist
 query I
@@ -74,3 +76,12 @@ query I
 SELECT COUNT(*) FROM duckdb_extensions() WHERE extension_name = 'erpl_web';
 ----
 1
+
+# The TLS settings must be registered, or a user reaching a self-signed on-premise
+# service has no way to trust its CA and no way to opt out. A bare count would not
+# have caught their absence, so name them (#63).
+query I
+SELECT COUNT(*) FROM duckdb_settings()
+WHERE name IN ('erpl_ca_cert_file', 'erpl_unsafe_disable_server_cert_verification');
+----
+2


### PR DESCRIPTION
`main` was left red by #120: enabling TLS verification registered `erpl_ca_cert_file` and `erpl_unsafe_disable_server_cert_verification`, but `web_core.test` asserts a bare count of `erpl_%` settings, which was still 8.

```
test/sql/web_core.test:35: FAILED
  SELECT COUNT(*) FROM duckdb_settings() WHERE name LIKE 'erpl_%';  -- expected 8, got 10
```

My miss — I ran the C++ suite and the OData E2E suites on that branch but not `web_core`.

Count updated to 10, with a comment recording what the two extra settings are and why. Also added an assertion naming them: **a bare count would not have caught either of them disappearing**, which matters here, because without those settings a user reaching a self-signed on-premise service has no way to trust its CA and no way to opt out — exactly the regression the E2E check on #120 caught the first time.

Verified on `main` + this change: `web_core` (11 assertions), plus `web_secrets`, `microsoft_entra`, `graph_excel`, `graph_sharepoint`, `business_central` and `dataverse` all green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791617917&installation_model_id=425457&pr_number=128&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F128&signature=47844c6ce7bab3886c90b760cc6150d793154821642a46d5ddb97e170782079b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->