### PR TITLE
fix: make $expand option splitting quote-aware (#122)

### DIFF
--- a/src/include/odata_text_scanning.hpp
+++ b/src/include/odata_text_scanning.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace erpl_web {
+
+//! Scanning helpers shared by the $expand parser and the URL sanitizer.
+//!
+//! Both need to walk OData query text without being fooled by structural characters that
+//! appear inside string literals or nested option groups. They previously had separate
+//! tokenizers: the parser's was depth- and quote-aware, the sanitizer's only depth-aware,
+//! so a literal containing ';' or ',' desynchronised the sanitizer and produced a
+//! half-encoded filter with an unescaped quote (GitHub #122). One implementation now
+//! serves both.
+namespace odata_text {
+
+constexpr char SINGLE_QUOTE = '\'';
+constexpr char PAREN_OPEN = '(';
+constexpr char PAREN_CLOSE = ')';
+
+//! Returns the index just past the string literal that opens at `open_quote`.
+//!
+//! OData escapes a single quote by DOUBLING it ('O''Brien'), so a naive toggle-on-quote
+//! scanner desynchronises on the very first escaped quote and treats the rest of the
+//! expression as being outside the literal. An unterminated literal yields the end of the
+//! text rather than an error: callers are sanitizers, not validators, and the service is
+//! the right place for that complaint.
+inline std::size_t SkipQuotedLiteral(const std::string &text, std::size_t open_quote)
+{
+    std::size_t i = open_quote + 1;
+    while (i < text.size()) {
+        if (text[i] != SINGLE_QUOTE) {
+            i++;
+            continue;
+        }
+        if (i + 1 < text.size() && text[i + 1] == SINGLE_QUOTE) {
+            i += 2;
+            continue;
+        }
+        return i + 1;
+    }
+    return i;
+}
+
+//! Returns the index just past the option group that opens at `open_paren`, ignoring
+//! parentheses that occur inside string literals.
+inline std::size_t SkipOptionGroup(const std::string &text, std::size_t open_paren)
+{
+    std::size_t depth = 0;
+    std::size_t i = open_paren;
+    while (i < text.size()) {
+        const char c = text[i];
+        if (c == SINGLE_QUOTE) {
+            i = SkipQuotedLiteral(text, i);
+            continue;
+        }
+        if (c == PAREN_OPEN) {
+            depth++;
+        } else if (c == PAREN_CLOSE) {
+            depth--;
+            if (depth == 0) {
+                return i + 1;
+            }
+        }
+        i++;
+    }
+    return i;
+}
+
+//! Splits at every occurrence of any character in `delimiters` that is neither nested
+//! inside parentheses nor inside a string literal.
+inline std::vector<std::string> SplitTopLevel(const std::string &text, const std::string &delimiters)
+{
+    std::vector<std::string> parts;
+    std::size_t depth = 0;
+    std::size_t start = 0;
+    std::size_t i = 0;
+
+    while (i < text.size()) {
+        const char c = text[i];
+        if (c == SINGLE_QUOTE) {
+            i = SkipQuotedLiteral(text, i);
+            continue;
+        }
+        if (c == PAREN_OPEN) {
+            depth++;
+        } else if (c == PAREN_CLOSE) {
+            if (depth > 0) {
+                depth--;
+            }
+        } else if (depth == 0 && delimiters.find(c) != std::string::npos) {
+            parts.emplace_back(text.substr(start, i - start));
+            parts.emplace_back(std::string(1, c));
+            start = i + 1;
+        }
+        i++;
+    }
+    parts.emplace_back(text.substr(start));
+    return parts;
+}
+
+} // namespace odata_text
+} // namespace erpl_web

--- a/src/odata_url_helpers.cpp
+++ b/src/odata_url_helpers.cpp
@@ -1,4 +1,5 @@
 #include "odata_url_helpers.hpp"
+#include "odata_text_scanning.hpp"
 #include <sstream>
 
 namespace erpl_web {
@@ -270,6 +271,13 @@ std::string ODataUrlCodec::normalizeExpand(const std::string &expand_value) {
             std::string opt;
             while (i < expand_value.size() && depth > 0) {
                 char c = expand_value[i];
+                if (c == '\'') {
+                    // A parenthesis inside a string literal must not change the depth.
+                    const auto literal_end = odata_text::SkipQuotedLiteral(expand_value, i);
+                    opt.append(expand_value, i, literal_end - i);
+                    i = literal_end;
+                    continue;
+                }
                 if (c == '(') { depth++; opt += c; i++; continue; }
                 if (c == ')') {
                     depth--;
@@ -281,18 +289,14 @@ std::string ODataUrlCodec::normalizeExpand(const std::string &expand_value) {
 
             // Now normalize options list like "expand=Services();select=Id" (semicolon or comma separated)
             // Split on ';' and ',' but not inside nested parentheses
+            // Split on ';' and ',' at depth 0 only, and never inside a string literal:
+            // "$filter=Name eq 'Product;Name'" is one option, not two. See GitHub #122.
+            std::vector<std::string> raw_parts = odata_text::SplitTopLevel(opt, ";,");
             std::vector<std::string> parts;
-            {
-                size_t j = 0, start = 0; int d = 0;
-                while (j <= opt.size()) {
-                    if (j == opt.size() || ((opt[j] == ';' || opt[j] == ',') && d == 0)) {
-                        if (j > start) parts.emplace_back(opt.substr(start, j - start));
-                        if (j < opt.size()) parts.emplace_back(std::string(1, opt[j]));
-                        j++; start = j; continue;
-                    }
-                    if (opt[j] == '(') d++;
-                    else if (opt[j] == ')') d--;
-                    j++;
+            parts.reserve(raw_parts.size());
+            for (auto &raw_part : raw_parts) {
+                if (!raw_part.empty()) {
+                    parts.emplace_back(std::move(raw_part));
                 }
             }
 
@@ -357,7 +361,13 @@ std::string ODataUrlCodec::normalizeAndSanitizeExpand(const std::string &expand_
             while (i < normalized.size() && normalized[i] != ')') {
                 // Extract key
                 size_t key_start = i;
-                while (i < normalized.size() && normalized[i] != '=' && normalized[i] != ';' && normalized[i] != ')') i++;
+                while (i < normalized.size() && normalized[i] != '=' && normalized[i] != ';' && normalized[i] != ')') {
+                    if (normalized[i] == '\'') {
+                        i = odata_text::SkipQuotedLiteral(normalized, i);
+                        continue;
+                    }
+                    i++;
+                }
                 std::string key = normalized.substr(key_start, i - key_start);
                 // Trim spaces
                 while (!key.empty() && key.front() == ' ') key.erase(key.begin());
@@ -368,6 +378,13 @@ std::string ODataUrlCodec::normalizeAndSanitizeExpand(const std::string &expand_
                     size_t val_start = i;
                     int depth = 0;
                     while (i < normalized.size()) {
+                        if (normalized[i] == '\'') {
+                            // ';', ')' and '(' inside a string literal are data, not
+                            // structure - stepping over the literal keeps the option
+                            // boundaries correct. See GitHub #122.
+                            i = odata_text::SkipQuotedLiteral(normalized, i);
+                            continue;
+                        }
                         if (normalized[i] == '(') depth++;
                         if (normalized[i] == ')') { if (depth == 0) break; depth--; }
                         if (depth == 0 && normalized[i] == ';') break;

--- a/test/cpp/test_odata_url_helpers.cpp
+++ b/test/cpp/test_odata_url_helpers.cpp
@@ -102,3 +102,38 @@ TEST_CASE("ODataUrlResolver only treats .svc as a service root at a segment boun
     HttpUrl later_segment("https://host/a.svcx/Sales.svc/Orders");
     REQUIRE(r.resolveMetadataUrl(later_segment, "") == "https://host/a.svcx/Sales.svc/$metadata");
 }
+
+TEST_CASE("normalizeAndSanitizeExpand does not split options inside a string literal", "[odata_url]") {
+    // GitHub #122: the option splitter treated ';' as a separator even inside a quoted
+    // literal, so "$filter=Name eq 'Product;Name'" was cut in half - the first part was
+    // encoded as a filter value and the trailing "Name'" was re-emitted as a separate
+    // valueless option key, with its apostrophe left raw. A round-trip decode still
+    // matched the input, which is why it looked benign, but what reached the wire was a
+    // half-encoded expression containing an unescaped quote.
+    auto sanitized = ODataUrlCodec::normalizeAndSanitizeExpand("Products($filter=Name eq 'Product;Name')");
+
+    // The whole literal must be inside one encoded $filter value: the semicolon belongs
+    // to the string, so it must be percent-encoded rather than left as a separator.
+    REQUIRE(sanitized.find("%3B") != std::string::npos);
+    REQUIRE(sanitized.find(";Name'") == std::string::npos);
+}
+
+TEST_CASE("normalizeAndSanitizeExpand handles a comma inside a string literal", "[odata_url]") {
+    auto sanitized = ODataUrlCodec::normalizeAndSanitizeExpand("Products($filter=Name eq 'A,B')");
+    REQUIRE(sanitized.find("%2C") != std::string::npos);
+}
+
+TEST_CASE("normalizeAndSanitizeExpand survives OData's doubled-quote escape", "[odata_url]") {
+    // A naive toggle-on-quote scanner desynchronises on the escaped quote and treats the
+    // rest of the expression as being outside the literal.
+    auto sanitized = ODataUrlCodec::normalizeAndSanitizeExpand("Products($filter=Name eq 'O''Brien;X')");
+    REQUIRE(sanitized.find("%3B") != std::string::npos);
+    REQUIRE(sanitized.find(";X'") == std::string::npos);
+}
+
+TEST_CASE("normalizeAndSanitizeExpand keeps a parenthesis inside a literal from closing the group",
+          "[odata_url]") {
+    auto sanitized = ODataUrlCodec::normalizeAndSanitizeExpand("Products($filter=Name eq 'A)B';$select=Name)");
+    // $select is part of the same option group, so it must still be $-prefixed and present.
+    REQUIRE(sanitized.find("$select=Name") != std::string::npos);
+}


### PR DESCRIPTION
The `$expand` sanitizer split options on `;` and `,` while tracking only parenthesis depth, so a separator **inside a quoted string literal** cut the literal in half:

```
in:   Products($filter=Name eq 'Product;Name')
out:  Products($filter=Name%20eq%20%27Product;Name')
                                              ^^^^^^ re-emitted as a separate
                                                     option key, quote left raw
```

A round-trip decode of that output still equals the input, which is exactly why it survived unnoticed — but what reaches the wire is a **half-encoded filter expression containing an unescaped quote**, which strict services (SAP Gateway) reject.

I originally triaged this as a stale test expectation while reviving the never-run tests in #125. An agent pushed back and was right; this is a real defect.

## Three loops, one blind spot

The option-group scanner, the option splitter, and the key/value reader in the sanitize pass all tracked depth but not quotes. All three now step over string literals.

## Consolidation rather than a second implementation

The `$expand` parser fixed in #116 already had a correct scanner — including OData's **doubled-quote escape** (`'O''Brien'`), where a naive toggle-on-quote desynchronises on the first escaped quote. The sanitizer's was depth-only. Rather than write a second one, the helpers move into `src/include/odata_text_scanning.hpp` and both callers share them. That also closes the duplication #116's PR flagged as unresolved.

## Tests

Four cases, all confirmed red first:

| input | was | now |
|---|---|---|
| `'Product;Name'` | `;` treated as separator | `%3B` inside the encoded value |
| `'A,B'` | `,` treated as separator | `%2C` inside the encoded value |
| `'O''Brien;X'` | scanner desynchronised on the escaped quote | literal kept whole |
| `'A)B';$select=Name` | `)` closed the group early, losing `$select` | `$select=Name` survives |

Full C++ suite: **340 cases, 1775 assertions**. Live E2E: `odata_conformance_e2e` (22), `odata_expand` (46), `odata_v2`, `odata_v4` all green.

Closes #122.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791618850&installation_model_id=425457&pr_number=129&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F129&signature=7921ced93c58b15966813a3ed025cdf4c6dd698d0e2ad8c98ea63e60a51e9aaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->