### PR TITLE
fix: detect the OData version from the payload first, surface service errors (#77, #79)

### DIFF
--- a/src/include/odata_content.hpp
+++ b/src/include/odata_content.hpp
@@ -6,6 +6,8 @@
 #include "yyjson.hpp"
 
 #include <memory>
+#include <optional>
+#include <string>
 
 using namespace duckdb_yyjson;
 
@@ -51,6 +53,20 @@ public:
 };
 
 // -------------------------------------------------------------------------------------------------
+
+//! The error a service reported in its own response body. Both OData v2 and v4 wrap it in a
+//! top-level "error" object; only the shape of "message" differs (a string in v4, a
+//! {"lang","value"} object in v2), which is why both are decoded into the same struct.
+struct ODataErrorInfo {
+    std::string code;
+    std::string message;
+
+    //! Renders the error the way it is surfaced to the user, e.g.
+    //! "OData service reported an error (code 'SY/530'): Property 'Foo' does not exist".
+    std::string ToString() const;
+};
+
+// -------------------------------------------------------------------------------------------------
 class ODataJsonContentMixin {
 public:
     static bool IsJsonContentType(const std::string& content_type);
@@ -61,11 +77,37 @@ public:
     void SetODataVersion(ODataVersion version) { odata_version = version; }
     ODataVersion GetODataVersion() const { return odata_version; }
     
-    // Auto-detect OData version from JSON content
+    //! Detects the version from the payload alone, falling back to V4 when nothing is conclusive.
+    //! Kept for callers that have no access to the response headers.
     static ODataVersion DetectODataVersion(const std::string& content);
+
+    //! Header-based detection: the service tells us the version in "OData-Version" (v4) or
+    //! "DataServiceVersion" (v2/v3). Version suffixes such as SAP's "4.0;NetFx" are tolerated.
+    //! Returns UNKNOWN when no such header is present or the value is not understood.
+    static ODataVersion DetectODataVersionFromHeaders(const HeaderMap& headers);
+
+    //! Payload sniffing, honest about failure: returns UNKNOWN when the body carries no
+    //! discriminator (empty body, non-JSON body, or an error payload), instead of guessing V4.
+    static ODataVersion DetectODataVersionFromPayload(const std::string& content);
+
+    //! The detection order the readers should use: what the service declared in its headers
+    //! first, payload sniffing second, V4 as the last resort.
+    static ODataVersion DetectODataVersion(const std::string& content, const HeaderMap& headers);
+
+    //! Decodes a top-level OData error payload (v2 or v4 shape). Returns nullopt when the body
+    //! is not an error document.
+    static std::optional<ODataErrorInfo> TryGetODataError(const std::string& content);
 
 protected:
     std::shared_ptr<yyjson_doc> doc;
+
+    //! Same as the public overload, on an already-parsed document root.
+    static std::optional<ODataErrorInfo> TryGetODataError(yyjson_val *root);
+
+    //! Throws with the service's own code and message when `root` is an error document; a no-op
+    //! otherwise. Used wherever we would otherwise report a generic parse failure and discard
+    //! what the server actually said.
+    static void ThrowIfODataError(yyjson_val *root);
 
     // Scan-wide failure log (may be null when the content is used standalone)
     // and the column currently being deserialized, used to attribute failures.

--- a/src/odata_client.cpp
+++ b/src/odata_client.cpp
@@ -145,9 +145,17 @@ std::shared_ptr<ODataEntitySetContent> ODataEntitySetResponse::CreateODataConten
     ERPL_TRACE_DEBUG("ODATA_CONTENT", "Content size: " + std::to_string(content.length()) + " bytes");
     
     if (ODataJsonContentMixin::IsJsonContentType(ContentType())) {
-        auto detected_version = ODataJsonContentMixin::DetectODataVersion(content);
-        ERPL_TRACE_DEBUG("ODATA_CONTENT", std::string("Detected OData version from response: ") + (detected_version == ODataVersion::V2 ? "V2" : "V4"));
-        ERPL_TRACE_DEBUG("ODATA_CONTENT", std::string("Metadata suggested version: ") + (odata_version == ODataVersion::V2 ? "V2" : "V4"));
+        // Detection order (GitHub #77): what the service declared in its response headers, then
+        // payload sniffing, then the version the metadata document implied - which is what the
+        // `odata_version` parameter carries. Guessing V4 is the last resort, not the first.
+        auto detected_version = ODataJsonContentMixin::DetectODataVersionFromHeaders(http_response->headers);
+        if (detected_version == ODataVersion::UNKNOWN) {
+            detected_version = ODataJsonContentMixin::DetectODataVersionFromPayload(content);
+        }
+        if (detected_version == ODataVersion::UNKNOWN) {
+            detected_version = (odata_version != ODataVersion::UNKNOWN) ? odata_version : ODataVersion::V4;
+        }
+        ERPL_TRACE_DEBUG("ODATA_CONTENT", std::string("Resolved OData version for response: ") + (detected_version == ODataVersion::V2 ? "V2" : "V4"));
         auto content_obj = std::make_shared<ODataEntitySetJsonContent>(content);
         content_obj->SetODataVersion(detected_version);
         return content_obj;
@@ -206,7 +214,7 @@ std::shared_ptr<ODataEntitySetResponse> ODataEntitySetClient::Get(bool get_next)
     if (odata_version == ODataVersion::UNKNOWN) {
         auto content_str = http_response->Content();
         if (ODataJsonContentMixin::IsJsonContentType(http_response->ContentType())) {
-            auto detected_version = ODataJsonContentMixin::DetectODataVersion(content_str);
+            auto detected_version = ODataJsonContentMixin::DetectODataVersion(content_str, http_response->headers);
             odata_version = detected_version;
             std::string version_str = (odata_version == ODataVersion::V2 ? "V2" : "V4");
             ERPL_TRACE_INFO("ODATA_CLIENT", "Detected OData version from response: " + version_str);

--- a/src/odata_client.cpp
+++ b/src/odata_client.cpp
@@ -145,12 +145,17 @@ std::shared_ptr<ODataEntitySetContent> ODataEntitySetResponse::CreateODataConten
     ERPL_TRACE_DEBUG("ODATA_CONTENT", "Content size: " + std::to_string(content.length()) + " bytes");
     
     if (ODataJsonContentMixin::IsJsonContentType(ContentType())) {
-        // Detection order (GitHub #77): what the service declared in its response headers, then
-        // payload sniffing, then the version the metadata document implied - which is what the
-        // `odata_version` parameter carries. Guessing V4 is the last resort, not the first.
-        auto detected_version = ODataJsonContentMixin::DetectODataVersionFromHeaders(http_response->headers);
+        // Detection order (GitHub #77): the payload first, because what this decides is how to
+        // PARSE the body and the body is ground truth for that. The declared protocol version
+        // does not determine the JSON shape - OData v3 announces "DataServiceVersion: 3.0" for
+        // both the verbose format, which wraps rows in "d", and the minimalmetadata format,
+        // which uses a "value" array like v4. Then the headers, which are what actually helps
+        // when the body says nothing (empty, non-JSON, or an error document). Then the version
+        // the metadata document implied, carried by `odata_version`. Guessing V4 is the last
+        // resort, not the first.
+        auto detected_version = ODataJsonContentMixin::DetectODataVersionFromPayload(content);
         if (detected_version == ODataVersion::UNKNOWN) {
-            detected_version = ODataJsonContentMixin::DetectODataVersionFromPayload(content);
+            detected_version = ODataJsonContentMixin::DetectODataVersionFromHeaders(http_response->headers);
         }
         if (detected_version == ODataVersion::UNKNOWN) {
             detected_version = (odata_version != ODataVersion::UNKNOWN) ? odata_version : ODataVersion::V4;

--- a/src/odata_content.cpp
+++ b/src/odata_content.cpp
@@ -150,17 +150,27 @@ ODataVersion ODataJsonContentMixin::DetectODataVersionFromHeaders(const HeaderMa
 
 ODataVersion ODataJsonContentMixin::DetectODataVersion(const std::string& content, const HeaderMap& headers)
 {
-    const auto from_headers = DetectODataVersionFromHeaders(headers);
-    if (from_headers != ODataVersion::UNKNOWN) {
-        return from_headers;
-    }
-
+    // The payload wins whenever it carries a discriminator, because what this decides is
+    // how to PARSE the body, and the body is ground truth for that. The protocol version
+    // in the header does not determine the JSON shape: OData v3 announces
+    // "DataServiceVersion: 3.0" for both the verbose format, which wraps rows in "d", and
+    // the minimalmetadata/fullmetadata/nometadata formats, which use a "value" array like
+    // v4. Trusting the header there sends a v3 minimalmetadata response down the v2 path,
+    // which then fails with "No value array found" on a perfectly good document -
+    // services.odata.org/northwind/northwind.svc does exactly this.
     const auto from_payload = DetectODataVersionFromPayload(content);
     if (from_payload != ODataVersion::UNKNOWN) {
         return from_payload;
     }
 
-    ERPL_TRACE_DEBUG("DETECT_VERSION", "Neither headers nor payload are conclusive, defaulting to V4");
+    // Only once the body says nothing - an empty body, a non-JSON body, or an error
+    // document - do the headers decide. That is the case #77 was really about.
+    const auto from_headers = DetectODataVersionFromHeaders(headers);
+    if (from_headers != ODataVersion::UNKNOWN) {
+        return from_headers;
+    }
+
+    ERPL_TRACE_DEBUG("DETECT_VERSION", "Neither payload nor headers are conclusive, defaulting to V4");
     return ODataVersion::V4;
 }
 

--- a/src/odata_content.cpp
+++ b/src/odata_content.cpp
@@ -49,8 +49,59 @@ std::string NormalizeBase64(const std::string &encoded)
     return normalized;
 }
 
+//! Reads the major version out of an OData version header value. Services are liberal here:
+//! SAP Gateway answers "4.0;NetFx", some proxies pad with whitespace, and v2 services spell the
+//! header "DataServiceVersion" with values "1.0" / "2.0" / "3.0". Only the leading integer is
+//! significant, everything from the first ';' onwards is a parameter list and is ignored.
+bool TryParseHeaderMajorVersion(const std::string &header_value, int &major_version)
+{
+    const auto parameter_start = header_value.find(';');
+    std::string value = header_value.substr(0, parameter_start);
+
+    const auto first = value.find_first_not_of(" \t");
+    if (first == std::string::npos) {
+        return false;
+    }
+    const auto last = value.find_last_not_of(" \t");
+    value = value.substr(first, last - first + 1);
+
+    if (value.empty() || std::isdigit(static_cast<unsigned char>(value.front())) == 0) {
+        return false;
+    }
+
+    major_version = value.front() - '0';
+    return true;
+}
+
+//! Extracts a string property, tolerating a missing or non-string node.
+std::string OptionalStringProperty(yyjson_val *object, const char *property_name)
+{
+    if (object == nullptr) {
+        return std::string();
+    }
+    auto property = yyjson_obj_get(object, property_name);
+    if (property == nullptr || yyjson_is_str(property) == false) {
+        return std::string();
+    }
+    return std::string(yyjson_get_str(property), yyjson_get_len(property));
+}
+
 } // namespace
 
+
+// ----------------------------------------------------------------------
+
+std::string ODataErrorInfo::ToString() const
+{
+    std::string rendered = "OData service reported an error";
+    if (!code.empty()) {
+        rendered += " (code '" + code + "')";
+    }
+    if (!message.empty()) {
+        rendered += ": " + message;
+    }
+    return rendered;
+}
 
 // ----------------------------------------------------------------------
 
@@ -64,27 +115,86 @@ bool ODataJsonContentMixin::IsJsonContentType(const std::string& content_type)
     return content_type.find("application/json") != std::string::npos;
 }
 
+ODataVersion ODataJsonContentMixin::DetectODataVersionFromHeaders(const HeaderMap& headers)
+{
+    // OData v4 declares "OData-Version: 4.0"; v2 and v3 declare "DataServiceVersion: 2.0".
+    // A v4 service never sends DataServiceVersion, so OData-Version is checked first and wins.
+    static const char *const VERSION_HEADER_NAMES[] = {"OData-Version", "DataServiceVersion"};
+
+    for (const auto *header_name : VERSION_HEADER_NAMES) {
+        const auto header = headers.find(header_name);
+        if (header == headers.end()) {
+            continue;
+        }
+
+        int major_version = 0;
+        if (!TryParseHeaderMajorVersion(header->second, major_version)) {
+            ERPL_TRACE_DEBUG("DETECT_VERSION", std::string("Unparsable ") + header_name + " header: " + header->second);
+            continue;
+        }
+
+        // v1 through v3 all use the "d"-wrapped JSON verbose format this reader treats as V2.
+        if (major_version >= 4) {
+            ERPL_TRACE_DEBUG("DETECT_VERSION", std::string("Header ") + header_name + ": " + header->second + " -> V4");
+            return ODataVersion::V4;
+        }
+        if (major_version >= 1) {
+            ERPL_TRACE_DEBUG("DETECT_VERSION", std::string("Header ") + header_name + ": " + header->second + " -> V2");
+            return ODataVersion::V2;
+        }
+    }
+
+    ERPL_TRACE_DEBUG("DETECT_VERSION", "No OData version header present");
+    return ODataVersion::UNKNOWN;
+}
+
+ODataVersion ODataJsonContentMixin::DetectODataVersion(const std::string& content, const HeaderMap& headers)
+{
+    const auto from_headers = DetectODataVersionFromHeaders(headers);
+    if (from_headers != ODataVersion::UNKNOWN) {
+        return from_headers;
+    }
+
+    const auto from_payload = DetectODataVersionFromPayload(content);
+    if (from_payload != ODataVersion::UNKNOWN) {
+        return from_payload;
+    }
+
+    ERPL_TRACE_DEBUG("DETECT_VERSION", "Neither headers nor payload are conclusive, defaulting to V4");
+    return ODataVersion::V4;
+}
+
 ODataVersion ODataJsonContentMixin::DetectODataVersion(const std::string& content)
+{
+    const auto detected = DetectODataVersionFromPayload(content);
+    if (detected != ODataVersion::UNKNOWN) {
+        return detected;
+    }
+
+    ERPL_TRACE_DEBUG("DETECT_VERSION", "No clear indicators found, defaulting to V4");
+    return ODataVersion::V4;
+}
+
+ODataVersion ODataJsonContentMixin::DetectODataVersionFromPayload(const std::string& content)
 {
     ERPL_TRACE_DEBUG("DETECT_VERSION", "Starting OData version detection");
     
     if (content.empty()) {
-        ERPL_TRACE_DEBUG("DETECT_VERSION", "Empty content, defaulting to V4");
-        return ODataVersion::V4;
+        ERPL_TRACE_DEBUG("DETECT_VERSION", "Empty content, version is undetermined");
+        return ODataVersion::UNKNOWN;
     }
     
     // Parse the JSON content to detect OData version
     auto doc = std::shared_ptr<yyjson_doc>(yyjson_read(content.c_str(), content.size(), 0), yyjson_doc_free);
     if (!doc) {
-        ERPL_TRACE_DEBUG("DETECT_VERSION", "Failed to parse JSON, defaulting to V4");
-        // If we can't parse JSON, default to v4
-        return ODataVersion::V4;
+        ERPL_TRACE_DEBUG("DETECT_VERSION", "Failed to parse JSON, version is undetermined");
+        return ODataVersion::UNKNOWN;
     }
     
     auto root = yyjson_doc_get_root(doc.get());
     if (!root || !yyjson_is_obj(root)) {
-        ERPL_TRACE_DEBUG("DETECT_VERSION", "Root is not an object, defaulting to V4");
-        return ODataVersion::V4;
+        ERPL_TRACE_DEBUG("DETECT_VERSION", "Root is not an object, version is undetermined");
+        return ODataVersion::UNKNOWN;
     }
     
     // Simple and reliable version detection based on top-level elements
@@ -131,9 +241,68 @@ ODataVersion ODataJsonContentMixin::DetectODataVersion(const std::string& conten
         return ODataVersion::V2;
     }
     
-    ERPL_TRACE_DEBUG("DETECT_VERSION", "No clear indicators found, defaulting to V4");
-    // Default to v4 if we can't determine
-    return ODataVersion::V4;
+    ERPL_TRACE_DEBUG("DETECT_VERSION", "No clear indicators found in the payload");
+    return ODataVersion::UNKNOWN;
+}
+
+std::optional<ODataErrorInfo> ODataJsonContentMixin::TryGetODataError(yyjson_val *root)
+{
+    if (root == nullptr || !yyjson_is_obj(root)) {
+        return std::nullopt;
+    }
+
+    // v4 and v2 both use "error"; the JSON verbose format of some v2/v3 services spells it
+    // "odata.error" instead.
+    auto error_object = yyjson_obj_get(root, "error");
+    if (error_object == nullptr) {
+        error_object = yyjson_obj_get(root, "odata.error");
+    }
+    if (error_object == nullptr || !yyjson_is_obj(error_object)) {
+        return std::nullopt;
+    }
+
+    ODataErrorInfo error;
+    error.code = OptionalStringProperty(error_object, "code");
+
+    auto message = yyjson_obj_get(error_object, "message");
+    if (message != nullptr && yyjson_is_str(message)) {
+        // v4: {"error":{"code":"...","message":"..."}}
+        error.message = std::string(yyjson_get_str(message), yyjson_get_len(message));
+    } else if (message != nullptr && yyjson_is_obj(message)) {
+        // v2: {"error":{"code":"...","message":{"lang":"en","value":"..."}}}
+        error.message = OptionalStringProperty(message, "value");
+    }
+
+    if (error.code.empty() && error.message.empty()) {
+        return std::nullopt;
+    }
+
+    return error;
+}
+
+std::optional<ODataErrorInfo> ODataJsonContentMixin::TryGetODataError(const std::string& content)
+{
+    if (content.empty()) {
+        return std::nullopt;
+    }
+
+    auto parsed = std::shared_ptr<yyjson_doc>(yyjson_read(content.c_str(), content.size(), 0), yyjson_doc_free);
+    if (!parsed) {
+        return std::nullopt;
+    }
+
+    return TryGetODataError(yyjson_doc_get_root(parsed.get()));
+}
+
+void ODataJsonContentMixin::ThrowIfODataError(yyjson_val *root)
+{
+    const auto error = TryGetODataError(root);
+    if (!error) {
+        return;
+    }
+
+    ERPL_TRACE_ERROR("ODATA_CONTENT", error->ToString());
+    throw std::runtime_error(error->ToString());
 }
 
 void ODataJsonContentMixin::ThrowTypeError(yyjson_val* json_value, const std::string& expected)
@@ -1293,10 +1462,13 @@ yyjson_val* ODataJsonContentMixin::GetValueArray(yyjson_val* root) {
         ERPL_TRACE_DEBUG("GET_VALUE_ARRAY", "Processing OData v2 structure");
         
         // OData v2: {"d": [...]} or {"d": {"results": [...]}}
+        // A missing or unusable wrapper is reported as "no rows" rather than as a failure: a
+        // delta or skip-token page is allowed to carry a next link and no value array at all
+        // (GitHub #79). Callers decide whether that is an empty page or a real defect.
         auto d_wrapper = yyjson_obj_get(root, "d");
         if (!d_wrapper) {
             ERPL_TRACE_DEBUG("GET_VALUE_ARRAY", "No 'd' wrapper found in OData v2 response");
-            throw std::runtime_error("No 'd' wrapper found in OData v2 response.");
+            return nullptr;
         }
         
         // Check if d is directly an array (common case)
@@ -1315,7 +1487,7 @@ yyjson_val* ODataJsonContentMixin::GetValueArray(yyjson_val* root) {
         }
         
         ERPL_TRACE_DEBUG("GET_VALUE_ARRAY", "'d' element is neither an array nor contains 'results' array");
-        throw std::runtime_error("'d' element in OData v2 response is not an array or doesn't contain a 'results' array.");
+        return nullptr;
     } else {
         ERPL_TRACE_DEBUG("GET_VALUE_ARRAY", "Processing OData v4 structure");
         // OData v4: {"value": [...]}
@@ -1418,6 +1590,19 @@ std::vector<std::vector<duckdb::Value>> ODataEntitySetJsonContent::ToRows(std::v
     auto root = yyjson_doc_get_root(doc.get());
     auto json_values = GetValueArray(root);
     if (!json_values) {
+        // The service may have answered with an error document instead of a page. Report what it
+        // actually said rather than a generic parse failure (GitHub #77).
+        ThrowIfODataError(root);
+
+        // A page without a value array but with a next link is a legitimate empty page - Graph
+        // delta and skip-token pages do exactly this. Treat it as zero rows and keep paging
+        // (GitHub #79).
+        const auto next_url = GetNextUrl(root);
+        if (next_url.has_value()) {
+            ERPL_TRACE_DEBUG("ODATA_TO_ROWS", "Page has no value array but carries a next link; yielding zero rows");
+            return {};
+        }
+
         throw std::runtime_error("No value array found in OData response, cannot get rows.");
     }
 
@@ -1532,6 +1717,10 @@ std::vector<ODataEntitySetReference> ODataServiceJsonContent::EntitySets()
 {
     auto root = yyjson_doc_get_root(doc.get());
     auto ret = std::vector<ODataEntitySetReference>();
+
+    // A service that answered with an error document must not look like a service with no
+    // entity sets (GitHub #77).
+    ThrowIfODataError(root);
 
     if (odata_version == ODataVersion::V2) {
         // OData V2 service document: { "d": { "EntitySets": ["Products", ...] } }

--- a/test/cpp/test_odata_content.cpp
+++ b/test/cpp/test_odata_content.cpp
@@ -719,3 +719,137 @@ TEST_CASE("Test OData v2 /Date(ms)/ rendered as VARCHAR keeps milliseconds", "[o
     REQUIRE(rows.size() == 1);
     REQUIRE(rows[0][1].ToString() == "2016-01-01 00:00:00.123");
 }
+
+
+// ---------------------------------------------------------------------------------------------
+// Regression coverage for GitHub #77 (version detection from response headers, and surfacing the
+// error the service itself reported) and GitHub #79 (an empty page that carries a next link).
+// ---------------------------------------------------------------------------------------------
+
+TEST_CASE("Test OData version is taken from the response headers", "[odata_content][version]")
+{
+    // OData v4 declares OData-Version; SAP Gateway appends a parameter list to it.
+    erpl_web::HeaderMap v4_headers;
+    v4_headers["OData-Version"] = "4.0";
+    REQUIRE(ODataJsonContentMixin::DetectODataVersionFromHeaders(v4_headers) == ODataVersion::V4);
+
+    erpl_web::HeaderMap sap_headers;
+    sap_headers["OData-Version"] = "4.0;NetFx";
+    REQUIRE(ODataJsonContentMixin::DetectODataVersionFromHeaders(sap_headers) == ODataVersion::V4);
+
+    // v2 (and v3) services declare DataServiceVersion instead.
+    erpl_web::HeaderMap v2_headers;
+    v2_headers["DataServiceVersion"] = "2.0";
+    REQUIRE(ODataJsonContentMixin::DetectODataVersionFromHeaders(v2_headers) == ODataVersion::V2);
+
+    // Header names are case-insensitive on the wire.
+    erpl_web::HeaderMap lowercase_headers;
+    lowercase_headers["dataserviceversion"] = " 2.0 ";
+    REQUIRE(ODataJsonContentMixin::DetectODataVersionFromHeaders(lowercase_headers) == ODataVersion::V2);
+
+    // Nothing to go on must be reported as such, not guessed.
+    erpl_web::HeaderMap no_version_headers;
+    no_version_headers["Content-Type"] = "application/json";
+    REQUIRE(ODataJsonContentMixin::DetectODataVersionFromHeaders(no_version_headers) == ODataVersion::UNKNOWN);
+}
+
+TEST_CASE("Test headers win over payload sniffing for version detection", "[odata_content][version]")
+{
+    // A body with no discriminator at all: payload sniffing cannot decide, so the version the
+    // service declared has to be used instead of falling through to V4.
+    const std::string inconclusive_body = R"({"error":{"code":"SY/530","message":{"lang":"en","value":"boom"}}})";
+    REQUIRE(ODataJsonContentMixin::DetectODataVersionFromPayload(inconclusive_body) == ODataVersion::UNKNOWN);
+
+    erpl_web::HeaderMap v2_headers;
+    v2_headers["DataServiceVersion"] = "2.0";
+    REQUIRE(ODataJsonContentMixin::DetectODataVersion(inconclusive_body, v2_headers) == ODataVersion::V2);
+
+    // An empty body with a v2 header is still v2.
+    REQUIRE(ODataJsonContentMixin::DetectODataVersion("", v2_headers) == ODataVersion::V2);
+
+    // Without any header, the payload still decides.
+    erpl_web::HeaderMap no_headers;
+    const std::string v2_body = R"({"d":{"results":[{"CustomerID":"ALFKI"}]}})";
+    REQUIRE(ODataJsonContentMixin::DetectODataVersion(v2_body, no_headers) == ODataVersion::V2);
+}
+
+TEST_CASE("Test OData v4 error payload is surfaced with code and message", "[odata_content][error]")
+{
+    // v4 shape: {"error":{"code":"...","message":"..."}}
+    const std::string error_body =
+        R"({"error":{"code":"Request_ResourceNotFound","message":"Resource 'Foo' does not exist."}})";
+
+    ODataEntitySetJsonContent content(error_body);
+    content.SetODataVersion(ODataVersion::V4);
+
+    std::vector<std::string> column_names = {"CustomerID"};
+    std::vector<duckdb::LogicalType> column_types = {duckdb::LogicalTypeId::VARCHAR};
+
+    try {
+        content.ToRows(column_names, column_types);
+        FAIL("expected the service error to be raised");
+    } catch (const std::exception &e) {
+        const std::string message = e.what();
+        INFO(message);
+        REQUIRE(message.find("Request_ResourceNotFound") != std::string::npos);
+        REQUIRE(message.find("Resource 'Foo' does not exist.") != std::string::npos);
+    }
+}
+
+TEST_CASE("Test OData v2 error payload is surfaced with code and message", "[odata_content_v2][error]")
+{
+    // v2 shape: the message is an object, {"lang":"en","value":"..."}
+    const std::string error_body =
+        R"({"error":{"code":"SY/530","message":{"lang":"en","value":"Invalid filter on property Foo"},)"
+        R"("innererror":{"application":{"service_id":"ZSVC"}}}})";
+
+    ODataEntitySetJsonContent content(error_body);
+    content.SetODataVersion(ODataVersion::V2);
+
+    std::vector<std::string> column_names = {"CustomerID"};
+    std::vector<duckdb::LogicalType> column_types = {duckdb::LogicalTypeId::VARCHAR};
+
+    try {
+        content.ToRows(column_names, column_types);
+        FAIL("expected the service error to be raised");
+    } catch (const std::exception &e) {
+        const std::string message = e.what();
+        INFO(message);
+        REQUIRE(message.find("SY/530") != std::string::npos);
+        REQUIRE(message.find("Invalid filter on property Foo") != std::string::npos);
+    }
+}
+
+TEST_CASE("Test a v4 page without a value array but with a next link yields zero rows",
+          "[odata_content][paging]")
+{
+    // Graph delta / skip-token pages do this. It is an empty page, not a failure.
+    const std::string page =
+        R"({"@odata.context":"https://example.com/$metadata#Customers",)"
+        R"("@odata.nextLink":"https://example.com/Customers?$skiptoken=abc"})";
+
+    ODataEntitySetJsonContent content(page);
+    content.SetODataVersion(ODataVersion::V4);
+
+    std::vector<std::string> column_names = {"CustomerID"};
+    std::vector<duckdb::LogicalType> column_types = {duckdb::LogicalTypeId::VARCHAR};
+
+    REQUIRE(content.ToRows(column_names, column_types).empty());
+    REQUIRE(content.NextUrl().has_value());
+}
+
+TEST_CASE("Test a v2 page without a results array but with a next link yields zero rows",
+          "[odata_content_v2][paging]")
+{
+    const std::string page =
+        R"({"d":{"__next":"https://example.com/MySet?$skiptoken=page2"}})";
+
+    ODataEntitySetJsonContent content(page);
+    content.SetODataVersion(ODataVersion::V2);
+
+    std::vector<std::string> column_names = {"CustomerID"};
+    std::vector<duckdb::LogicalType> column_types = {duckdb::LogicalTypeId::VARCHAR};
+
+    REQUIRE(content.ToRows(column_names, column_types).empty());
+    REQUIRE(content.NextUrl().has_value());
+}

--- a/test/cpp/test_odata_content.cpp
+++ b/test/cpp/test_odata_content.cpp
@@ -853,3 +853,34 @@ TEST_CASE("Test a v2 page without a results array but with a next link yields ze
     REQUIRE(content.ToRows(column_names, column_types).empty());
     REQUIRE(content.NextUrl().has_value());
 }
+
+TEST_CASE("A v3 minimalmetadata payload is parsed by shape, not by its version header",
+          "[odata_content]") {
+    // services.odata.org/northwind/northwind.svc announces "DataServiceVersion: 3.0" and
+    // returns a "value" array, because the JSON SHAPE is set by the format
+    // (minimalmetadata/fullmetadata/nometadata all use "value"; only verbose wraps rows in
+    // "d"), not by the protocol version. Letting the header decide sent this document down
+    // the v2 path, which then failed with "No value array found" on a perfectly good
+    // response. The payload is ground truth for how to parse; headers only break ties.
+    const std::string v3_minimal_metadata = R"({
+        "odata.metadata": "https://services.odata.org/Northwind/Northwind.svc/$metadata#Customers",
+        "value": [ { "CustomerID": "ALFKI" } ]
+    })";
+
+    HeaderMap headers;
+    headers["DataServiceVersion"] = "3.0;";
+
+    REQUIRE(ODataJsonContentMixin::DetectODataVersion(v3_minimal_metadata, headers) == ODataVersion::V4);
+}
+
+TEST_CASE("Headers still decide when the payload carries no discriminator", "[odata_content]") {
+    // This is what #77 was actually about: an empty or error body tells us nothing, so the
+    // declared version is the only signal left.
+    HeaderMap v2_headers;
+    v2_headers["DataServiceVersion"] = "2.0";
+    REQUIRE(ODataJsonContentMixin::DetectODataVersion("{}", v2_headers) == ODataVersion::V2);
+
+    HeaderMap v4_headers;
+    v4_headers["OData-Version"] = "4.0;NetFx";
+    REQUIRE(ODataJsonContentMixin::DetectODataVersion("{}", v4_headers) == ODataVersion::V4);
+}

--- a/test/cpp/test_odata_server_e2e.cpp
+++ b/test/cpp/test_odata_server_e2e.cpp
@@ -254,6 +254,110 @@ TEST_CASE("odata_read keeps paging through an empty page that has a next link",
     REQUIRE(AnyRequestQueryContains(server.RequestsFor("/empty/Airlines"), "$skiptoken=3"));
 }
 
+// Catches GitHub #79 (v4 branch): a page that omits the "value" array altogether while carrying
+// a next link. Graph delta and skip-token pages legitimately do this. Before the fix the missing
+// array made ToRows() throw "No value array found in OData response", which aborted the whole
+// scan and dropped every row on the pages that follow.
+TEST_CASE("odata_read keeps paging when a v4 page omits the value array entirely",
+          "[odata_e2e][paging]") {
+    ODataTestServer server;
+    const std::string entity_url = server.Url("/novalue/Airlines");
+    const std::string context = server.Url("/novalue/$metadata") + "#Airlines";
+
+    server.ServeMetadataFixture("/novalue/$metadata", "edm_trippin.xml");
+    // Page 2 has a next link but no "value" member at all.
+    server.OnMatch(
+        [](const RecordedRequest &request) {
+            return request.path == "/novalue/Airlines" && request.QueryParam("$skiptoken") == "2";
+        },
+        CannedResponse::Json("{\"@odata.context\":\"" + context + "\",\"@odata.nextLink\":\"" +
+                             entity_url + "?$format=json&$skiptoken=3\"}"));
+    server.OnMatch(
+        [](const RecordedRequest &request) {
+            return request.path == "/novalue/Airlines" && request.QueryParam("$skiptoken") == "3";
+        },
+        CannedResponse::Json(MakeV4Page(context, {AIRLINE_MU, AIRLINE_AF})));
+    server.OnPath("/novalue/Airlines",
+                  CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA, AIRLINE_FM},
+                                                  entity_url + "?$format=json&$skiptoken=2")));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto result = con.Query("SELECT count(*) FROM odata_read('" + entity_url + "')");
+    INFO((result->HasError() ? result->GetError() : std::string()));
+    REQUIRE_FALSE(result->HasError());
+    REQUIRE(result->GetValue(0, 0).GetValue<int64_t>() == 4);
+
+    // The page AFTER the value-less one really was fetched.
+    REQUIRE(AnyRequestQueryContains(server.RequestsFor("/novalue/Airlines"), "$skiptoken=3"));
+}
+
+// Catches GitHub #79 (v2 branch): the same defect on the OData v2 side, where the abort came from
+// a throw inside GetValueArray() ("'d' element ... is not an array or doesn't contain a 'results'
+// array") rather than from the nullptr path. A v4-only fix leaves half the bug in place.
+TEST_CASE("odata_read keeps paging when a v2 page omits the results array",
+          "[odata_e2e][paging][v2]") {
+    ODataTestServer server;
+    const std::string entity_url = server.Url("/v2empty/Regions");
+
+    server.ServeMetadataFixture("/v2empty/$metadata", "edm_northwind_v2.xml");
+    // Page 2 is a "d" wrapper with a __next link and no results array.
+    server.OnMatch(
+        [](const RecordedRequest &request) {
+            return request.path == "/v2empty/Regions" && request.QueryParam("$skiptoken") == "2";
+        },
+        CannedResponse::Json("{\"d\":{\"__next\":\"" + entity_url +
+                             "?$format=json&$skiptoken=3\"}}"));
+    server.OnMatch(
+        [](const RecordedRequest &request) {
+            return request.path == "/v2empty/Regions" && request.QueryParam("$skiptoken") == "3";
+        },
+        CannedResponse::Json(MakeV2Page({R"({"RegionID":3,"RegionDescription":"Northern"})"})));
+    server.OnPath("/v2empty/Regions",
+                  CannedResponse::Json(MakeV2Page({R"({"RegionID":1,"RegionDescription":"Eastern"})",
+                                                   R"({"RegionID":2,"RegionDescription":"Western"})"},
+                                                  entity_url + "?$format=json&$skiptoken=2")));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto result = con.Query("SELECT count(*) FROM odata_read('" + entity_url + "')");
+    INFO((result->HasError() ? result->GetError() : std::string()));
+    REQUIRE_FALSE(result->HasError());
+    REQUIRE(result->GetValue(0, 0).GetValue<int64_t>() == 3);
+
+    REQUIRE(AnyRequestQueryContains(server.RequestsFor("/v2empty/Regions"), "$skiptoken=3"));
+}
+
+// Catches GitHub #77: a SAP Gateway style error payload answered with HTTP 200. The scan must
+// fail with the code and message the SERVICE reported; before the fix the missing value array
+// produced the generic "No value array found in OData response" and the server's own diagnosis
+// was discarded.
+TEST_CASE("odata_read surfaces the service's own error code and message",
+          "[odata_e2e][error]") {
+    ODataTestServer server;
+    const std::string entity_url = server.Url("/svcerr/Airlines");
+
+    server.ServeMetadataFixture("/svcerr/$metadata", "edm_trippin.xml");
+    server.OnPath("/svcerr/Airlines",
+                  CannedResponse::Json(R"({"error":{"code":"SY/530","message":{"lang":"en",)"
+                                       R"("value":"Invalid filter on property Foo"}}})"));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto result = con.Query("SELECT * FROM odata_read('" + entity_url + "')");
+    REQUIRE(result->HasError());
+    const auto message = result->GetError();
+    INFO(message);
+    REQUIRE(message.find("SY/530") != std::string::npos);
+    REQUIRE(message.find("Invalid filter on property Foo") != std::string::npos);
+}
+
 // ----------------------------------------------------------------------
 // What we put on the wire
 


### PR DESCRIPTION
## #77 — headers were ignored, and service errors were discarded

Detection sniffed the payload only. `OData-Version`, `DataServiceVersion` and SAP's `4.0;NetFx` were all ignored despite the headers being available, and an empty body, a non-JSON body or an error payload fell through to V4 — after which `ToRows` threw the generic **"No value array found"**, throwing away the server's own code and message. That is the most common user-facing SAP Gateway failure, reported as an internal parse error.

Error documents are now decoded in **both** shapes — v4's string `message`, v2's `{lang, value}` object — and rethrown carrying the service's code and message.

## A regression this PR caused, caught by E2E, and how it changed the design

The first cut made headers win. That broke a service that had been working:

```
SELECT COUNT(*) FROM odata_read('https://services.odata.org/northwind/northwind.svc/Customers');
-- Invalid Error: No value array found in OData response, cannot get rows.
```

That endpoint announces `DataServiceVersion: 3.0` and returns a **`value` array**. The protocol version does not determine the JSON shape: OData v3's `minimalmetadata`/`fullmetadata`/`nometadata` formats use `value` like v4, and **only `verbose` wraps rows in `d`**. So a v3 minimalmetadata document was being sent down the v2 path.

Corrected precedence — **payload, then headers, then the metadata-derived version, then V4**. What this decides is how to *parse* the body, and the body is ground truth for that; headers are what helps when the body says nothing, which is the case #77 was actually about. Two chains had to change: `DetectODataVersion` and a second one in `ODataEntitySetResponse::CreateODataContent`.

Only the live suite caught this — the unit tests were green throughout.

## The discarded parameter

`CreateODataContent` computed a version from the metadata document, logged it, then discarded it. It is now **used** as the third tiebreak rather than removed: it is the only reliable signal for a body with no discriminator, but it must not outrank a payload that plainly shows its shape.

## #79 — an empty page with a next link aborted the scan

Graph delta and skip-token pages legitimately deliver zero rows while carrying a next link. Both version branches now treat that as zero rows and keep paging. A malformed response with **no** next link still fails loudly, so the existing v2 error-handling tests still hold.

Note the pre-existing harness case "keeps paging through an empty page that has a next link" did *not* cover this — it emits `"value":[]`, an empty but **present** array, which never reaches the null path. The new tests use bodies with no array at all.

## Verification

- Full C++ suite: **351 cases, 1807 assertions.**
- Live E2E: `odata_v2`, `odata_v4`, `odata_conformance_e2e` (22), `odata_expand` (46), `odata_v2_storage`, `odata_v4_storage` — all green, including the v3 endpoint that regressed.
- New tests: 6 offline (header detection, both error shapes, both empty-page branches) + 3 over real HTTP against the local server + 2 pinning the v3-minimalmetadata precedence.

Closes #77, closes #79.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791620796&installation_model_id=425457&pr_number=130&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F130&signature=eab9f0e4a0d744ba5c258b7feca3f123339c42737bcef65071ea59cea4f2a847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->