### PR TITLE
fix: transmit the prepared query verbatim, and stop self-referential paging (#126, #78)

### DIFF
--- a/src/include/odata_client.hpp
+++ b/src/include/odata_client.hpp
@@ -183,6 +183,14 @@ public:
     std::string Url() const { return url.ToString(); }
     std::shared_ptr<HttpClient> GetHttpClient() const { return http_client->GetHttpClient(); }
     std::shared_ptr<HttpAuthParams> AuthParams() const { return auth_params; }
+
+    // Server-driven paging follows whatever @odata.nextLink / __next the service
+    // hands back, so the number of requests is bounded by the service and not by
+    // us. A service that repeats a link (SAP ODP is known to echo the same
+    // $skiptoken on a "!deltatoken" response) would otherwise spin forever.
+    // This is the hard stop on how many pages one client will ever fetch.
+    static constexpr idx_t MAX_PAGE_REQUESTS = 10000;
+
 protected:
     std::shared_ptr<CachingHttpClient> http_client;
     HttpUrl url;
@@ -190,6 +198,7 @@ protected:
     std::shared_ptr<TResponse> current_response;
     ODataVersion odata_version;
     std::string metadata_context_url; // For Datasphere dual-URL pattern
+    idx_t page_requests = 0;          // Pages fetched via a next link on this client
 
     std::unique_ptr<HttpResponse> DoHttpGet(const HttpUrl& url) {
         // Create a copy of the URL to modify with input parameters

--- a/src/odata_client.cpp
+++ b/src/odata_client.cpp
@@ -183,8 +183,27 @@ std::shared_ptr<ODataEntitySetResponse> ODataEntitySetClient::Get(bool get_next)
             return nullptr;
         }
 
-        url = HttpUrl::MergeWithBaseUrlIfRelative(url, next_url.value());
-        ERPL_TRACE_DEBUG("ODATA_CLIENT", "Using next URL: " + url.ToString());
+        // A next link that resolves back onto the URL we just fetched would make
+        // this loop issue the identical request forever, uninterruptibly. Stop
+        // with an error instead: neither terminating nor reporting is worse than
+        // failing. See GitHub #78.
+        const auto previous_url = url.ToString();
+        auto resolved_next_url = HttpUrl::MergeWithBaseUrlIfRelative(url, next_url.value());
+        if (resolved_next_url.ToString() == previous_url) {
+            throw std::runtime_error(
+                "OData service returned a next link identical to the request that produced it, which would page "
+                "forever. Repeated URL: " + previous_url);
+        }
+
+        if (page_requests >= MAX_PAGE_REQUESTS) {
+            throw std::runtime_error(
+                "OData server-driven paging exceeded the limit of " + std::to_string(MAX_PAGE_REQUESTS) +
+                " pages; the service keeps advertising a next link. Last URL: " + resolved_next_url.ToString());
+        }
+        page_requests++;
+
+        url = resolved_next_url;
+        ERPL_TRACE_DEBUG("ODATA_CLIENT", "Using next URL (page " + std::to_string(page_requests) + "): " + url.ToString());
     }
 
     // Add input parameters to the URL if they exist

--- a/test/cpp/include/odata_test_server.hpp
+++ b/test/cpp/include/odata_test_server.hpp
@@ -40,11 +40,11 @@ struct RecordedRequest {
     // sigil differently.
     //
     // QueryParam() returns the bytes exactly as they arrived. DecodedQueryParam()
-    // undoes the application/x-www-form-urlencoded encoding httplib's client puts
-    // on every query value on its way out -- percent escapes AND '+' for a space
-    // -- and so returns the value the extension asked for. Prefer the decoded form
-    // for assertions about a clause; use the raw form only when the encoding
-    // itself is what is under test.
+    // undoes percent escapes and also reads '+' as a space, so it recovers the
+    // value the extension asked for whether the request went out verbatim
+    // (url_encode = false) or through httplib's form-urlencoded round trip
+    // (url_encode = true). Prefer the decoded form for assertions about a clause;
+    // use the raw form only when the encoding itself is what is under test.
     bool HasQueryParam(const std::string &name) const;
     std::string QueryParam(const std::string &name) const;         // raw wire bytes
     std::string DecodedQueryParam(const std::string &name) const;  // form-decoded

--- a/test/cpp/odata_test_server.cpp
+++ b/test/cpp/odata_test_server.cpp
@@ -52,21 +52,23 @@ int HexValue(char c)
     return -1;
 }
 
-// Decodes a query-string value the way it was encoded, which for everything this
-// extension sends is application/x-www-form-urlencoded -- percent escapes plus
-// '+' for a space.
+// Decodes a query-string value tolerantly: percent escapes, plus '+' read as a
+// space.
 //
-// That is not a choice the extension makes, it is httplib's. The extension hands
-// the client a fully prepared query (spaces already written as %20 by
-// ODataUrlCodec::encodeFilterExpression), but ClientImpl::write_request
-// unconditionally round-trips it: parse_query_text() decodes every value with
-// decode_query_component(..., plus_as_space = true) and params_to_query_str()
-// re-encodes it with encode_query_component(..., space_as_plus = true). So a
-// %20 the extension wrote leaves the socket as '+', while a literal '+' in a
-// value leaves it as %2B. Decoding '+' back to a space is therefore lossless and
-// is the only way to recover the value the caller actually asked for.
+// Which of the two spellings arrives depends on the request. Requests sent with
+// url_encode = false -- every OData path -- now reach the socket byte for byte
+// as the extension composed them, spaces already written as %20 by
+// ODataUrlCodec::encodeFilterExpression (GitHub #126). Requests sent with the
+// default url_encode = true still go through httplib's
+// application/x-www-form-urlencoded round trip in ClientImpl::write_request,
+// where parse_query_text() decodes with plus_as_space = true and
+// params_to_query_str() re-encodes with space_as_plus = true, so a space shows
+// up as '+'. Accepting both keeps this read-back usable for either kind of
+// request; the cost is that a value containing a genuine literal '+' reads back
+// as a space.
 //
 // Callers that want the untouched wire bytes use QueryParam(), which is raw.
+// Assertions about the encoding itself must use the raw form.
 std::string FormDecode(const std::string &value)
 {
     std::string result;

--- a/test/cpp/test_odata_transport_and_paging.cpp
+++ b/test/cpp/test_odata_transport_and_paging.cpp
@@ -1,0 +1,190 @@
+// Transport fidelity and pagination safety, driven end to end against the local
+// HTTP test server so that the assertions are about the bytes and the request
+// count the extension actually produced.
+//
+//  * GitHub #126 -- httplib's client form-urlencodes the whole query on its way
+//    to the socket, turning the "%20" the extension composed into "+". Only a
+//    server-side recording of the RAW request target can catch that, because
+//    every layer we own still looks correct.
+//  * GitHub #78  -- server-driven paging followed whatever next link came back
+//    without ever comparing it to the URL that produced it, so a service echoing
+//    the same link paged forever.
+
+#include "catch.hpp"
+#include "duckdb.hpp"
+
+#include "odata_test_server.hpp"
+
+#include <string>
+#include <vector>
+
+using erpl_web::test_support::CannedResponse;
+using erpl_web::test_support::MakeV4Page;
+using erpl_web::test_support::ODataTestServer;
+using erpl_web::test_support::RecordedRequest;
+
+namespace {
+
+// The jemalloc/background-thread option is mandatory: a bare DuckDB(nullptr)
+// crashes in DEBUG builds shortly after the first query (see CLAUDE.md).
+// DBConfig is neither copyable nor movable, hence the small RAII wrapper.
+class TestDatabase {
+public:
+    TestDatabase()
+    {
+        config.SetOption("allocator_background_threads", duckdb::Value::BOOLEAN(true));
+        database = duckdb::make_uniq<duckdb::DuckDB>(nullptr, &config);
+        connection = duckdb::make_uniq<duckdb::Connection>(*database);
+    }
+
+    duckdb::Connection &Con() const { return *connection; }
+
+private:
+    duckdb::DBConfig config;
+    duckdb::unique_ptr<duckdb::DuckDB> database;
+    duckdb::unique_ptr<duckdb::Connection> connection;
+};
+
+const char *const AIRLINE_AA = R"({"AirlineCode":"AA","Name":"American Airlines"})";
+const char *const AIRLINE_FM = R"({"AirlineCode":"FM","Name":"Shanghai Airline"})";
+
+// A next link that keeps pointing at the same URL would page forever before the
+// fix. Cap the canned sequence so a regression fails the suite in bounded time
+// instead of hanging CI: after this many pages the service starts erroring, which
+// terminates the scan with a *different* (and clearly wrong) message.
+constexpr std::size_t LOOP_PAGE_BUDGET = 50;
+
+}  // namespace
+
+// ----------------------------------------------------------------------
+// GitHub #126 -- the bytes we composed must be the bytes on the wire
+
+// Catches: httplib re-encoding the query as application/x-www-form-urlencoded.
+// The extension percent-encodes the filter itself (%20 for a space, %27 for a
+// quote); anything that decodes and re-encodes it turns those into '+' and a
+// bare quote. services.odata.org and Microsoft Graph tolerate the form spelling,
+// so no existing test notices -- a strict service (SAP Gateway) need not.
+//
+// Deliberately reads the RAW QueryParam(): the encoding itself is what is under
+// test, so the harness's form-decoding read-back would hide the defect.
+TEST_CASE("odata_read puts percent-encoded filter bytes on the wire",
+          "[odata_e2e][transport][encoding]") {
+    ODataTestServer server;
+    server.ServeMetadataFixture("/enc/$metadata", "edm_trippin.xml");
+    server.OnPath("/enc/Airlines",
+                  CannedResponse::Json(MakeV4Page(server.Url("/enc/$metadata") + "#Airlines",
+                                                  {AIRLINE_AA})));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto result = con.Query("SELECT AirlineCode FROM odata_read('" + server.Url("/enc/Airlines") +
+                            "') WHERE AirlineCode = 'AA'");
+    INFO((result->HasError() ? result->GetError() : std::string()));
+    REQUIRE_FALSE(result->HasError());
+
+    std::string raw_filter;
+    std::string raw_query;
+    for (const auto &request : server.RequestsFor("/enc/Airlines")) {
+        if (request.HasQueryParam("$filter")) {
+            raw_filter = request.QueryParam("$filter");
+            raw_query = request.query;
+        }
+    }
+
+    INFO("raw query: " << raw_query);
+    REQUIRE_FALSE(raw_filter.empty());
+    // ODataUrlCodec::encodeFilterExpression writes every non-unreserved byte as a
+    // percent escape, so this is what the server must see -- not "+eq+" and not a
+    // bare quote.
+    REQUIRE(raw_filter.find("%20eq%20") != std::string::npos);
+    REQUIRE(raw_filter.find("%27AA%27") != std::string::npos);
+    REQUIRE(raw_filter.find('+') == std::string::npos);
+    REQUIRE(raw_filter.find('\'') == std::string::npos);
+    REQUIRE(raw_query.find('+') == std::string::npos);
+}
+
+// Catches the same defect one layer lower and without the OData stack in the
+// way: http_get(url_encode := false) is the contract "I prepared these bytes,
+// send them". Before the fix the flag guarded only the path half, so the nested
+// '=' of an $expand option group came out as %3D and every %20 came out as '+'.
+TEST_CASE("http_get with url_encode := false transmits the query verbatim",
+          "[odata_e2e][transport][encoding]") {
+    ODataTestServer server;
+    server.OnPath("/raw/Echo", CannedResponse::Json("{}"));
+
+    const std::string query =
+        "?$filter=Country%20eq%20%27UK%27"
+        "&$expand=Category($filter=CategoryName%20eq%20%27Beverages%27)";
+    const std::string url = server.Url("/raw/Echo") + query;
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto result = con.Query("SELECT status FROM http_get('" + url + "', url_encode := false)");
+    INFO((result->HasError() ? result->GetError() : std::string()));
+    REQUIRE_FALSE(result->HasError());
+
+    const auto requests = server.RequestsFor("/raw/Echo");
+    REQUIRE(requests.size() == 1);
+
+    INFO("raw target: " << requests.front().target);
+    // Byte-for-byte: the query we handed in is the query that arrived, options in
+    // the order we wrote them.
+    REQUIRE(requests.front().query == query.substr(1));
+    // Spelled out so a partial regression is legible in the failure output.
+    REQUIRE(requests.front().query.find("Country%20eq%20%27UK%27") != std::string::npos);
+    REQUIRE(requests.front().query.find("Category($filter=CategoryName%20eq%20%27Beverages%27)") !=
+            std::string::npos);
+    REQUIRE(requests.front().query.find('+') == std::string::npos);
+    REQUIRE(requests.front().query.find("%3D") == std::string::npos);
+}
+
+// ----------------------------------------------------------------------
+// GitHub #78 -- a repeated next link must terminate with an error
+
+// Catches: a next link that resolves back onto the URL that produced it being
+// followed anyway. SAP ODP repeating a $skiptoken on a "!deltatoken" response is
+// the real-world trigger. Before the fix this issued HTTP requests forever and
+// could not be interrupted with Ctrl-C, which is worse than a crash: it neither
+// terminates nor reports.
+//
+// The canned sequence stops handing out the self-referential page after
+// LOOP_PAGE_BUDGET entries so that a regression fails here in bounded time
+// rather than hanging the suite.
+TEST_CASE("odata_read stops with an error when a next link repeats itself",
+          "[odata_e2e][paging][error]") {
+    ODataTestServer server;
+    const std::string entity_url = server.Url("/loop/Airlines");
+    const std::string context = server.Url("/loop/$metadata") + "#Airlines";
+    // Fixed link: every page advertises the very same next URL.
+    const std::string repeated_next = entity_url + "?$format=json&$skiptoken=stuck";
+
+    server.ServeMetadataFixture("/loop/$metadata", "edm_trippin.xml");
+
+    std::vector<CannedResponse> pages(
+        LOOP_PAGE_BUDGET,
+        CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA, AIRLINE_FM}, repeated_next)));
+    // Repeated for every request past the budget -- the escape hatch that keeps a
+    // regression bounded.
+    pages.push_back(CannedResponse::Error(508, R"({"error":{"code":"loop_detected"}})"));
+    server.OnPathSequence("/loop/Airlines", std::move(pages));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto result = con.Query("SELECT count(*) FROM odata_read('" + entity_url + "')");
+    REQUIRE(result->HasError());
+
+    const auto data_requests = server.RequestsFor("/loop/Airlines");
+    INFO("error: " << result->GetError());
+    INFO("data requests: " << data_requests.size());
+    // The loop was detected, not merely survived because the service gave up.
+    REQUIRE(result->GetError().find("next link identical to the request that produced it") !=
+            std::string::npos);
+    // First page, then the repeated link once, then the stop. Never the budget.
+    REQUIRE(data_requests.size() < LOOP_PAGE_BUDGET);
+}


### PR DESCRIPTION
> Depends on DataZooDE/datazoo-oauth2#2 (merged); the submodule pin is bumped here.

## #126 — the transport silently rewrote every query

The extension percent-encodes `$filter` correctly, and then httplib's **client** round-tripped the whole query through `application/x-www-form-urlencoded` on the way to the socket: `%20`→`+`, a nested `=`→`%3D`, and — because `httplib::Params` is a `std::multimap` — **the parameters were re-sorted alphabetically** too, which the issue had not spotted.

`url_encode = false` did not prevent it: `path_encode_` guards only `encode_path(path_part)`, never the query.

Public services tolerate `+` as a space; per RFC 3986 it is a literal plus, and a strict service (SAP Gateway) may not.

**The two obvious fixes turned out to be impossible**, not merely worse, against pinned httplib 0.27.0:
- No choice of bytes survives the round trip — the output is `encode_query_component(decode_query_component(x))`, and `encode_query_component` never emits `%20` for *any* input.
- `params_to_query_str` hard-codes `space_as_plus = true`; there is no seam.
- Emptying the query does not help either: `write_request` then **drops the query entirely**.

The fix uses `set_header_writer`, the one extension point inside `write_request`: it runs against the same in-memory buffer right after the request line is written and before anything is flushed, so the line is pinned to the exact composed bytes. It fires only when the buffered line matches the one we composed, so an internal digest-auth re-send is untouched, and it **fails safe** — no match means today's behaviour.

## #78 — a self-referential next link paged forever

The next link was never compared against the URL that produced it, so a server echoing an identical `@odata.nextLink`/`__next` — SAP ODP repeating a `$skiptoken`, or a legal empty page carrying a next link — spun forever, uninterruptible by Ctrl-C. Worse than a crash: it neither terminates nor reports.

Now the resolved next URL is compared against the previous request and throws a clear error naming the repeated URL, with a `MAX_PAGE_REQUESTS` ceiling as a second backstop. No new timeout — a 30s per-request budget already exists; the problem was the unbounded *number* of requests.

**Still outstanding, and deliberately not done here** (that file was being changed concurrently): `FetchAdditionalPagesIfNeeded` in `odata_read_functions.cpp` still needs a per-page `context.interrupted` check and a per-`GetData` page cap, so Ctrl-C works and long scans yield. Recorded on #78 with current line numbers; the client-side guard here is a backstop, not a substitute.

## Tests

Three cases in `test/cpp/test_odata_transport_and_paging.cpp`, all red first:

| test | pre-fix |
|---|---|
| filter bytes on the wire | server recorded `$filter=AirlineCode+eq+'AA'` |
| `http_get` with `url_encode := false` | recorded query form-re-encoded **and alphabetically reordered** |
| self-referential next link | followed the same link 50 times |

The loop test bounds itself by serving the repeating page 50 times then a 508, rather than using a thread and timeout whose runaway would outlive the test server.

## Verification

Full C++ suite **354 cases / 1827 assertions**. Live E2E: `odata_conformance_e2e` (22), `odata_v2`, `odata_v4`, `odata_expand` (46), `web_http` (31), `web_core` — all green, and a live filtered query still returns the right row.

Closes #126. Partially addresses #78.
