### PR TITLE
fix: move scan state off bind data, reconcile schema order (#75, #86, #88, #90)

### DIFF
--- a/src/include/odata_predicate_pushdown_helper.hpp
+++ b/src/include/odata_predicate_pushdown_helper.hpp
@@ -25,6 +25,15 @@ public:
     using ColumnNameResolver = std::function<std::string(duckdb::column_t)>;
     
     explicit ODataPredicatePushdownHelper(const std::vector<std::string> &all_column_names);
+    ODataPredicatePushdownHelper(const std::vector<std::string> &all_column_names,
+                                 const std::vector<duckdb::LogicalType> &all_column_types);
+
+    // Refresh the full-schema column names and types this helper reasons about.
+    // The types are needed to decide whether $select is safe (see
+    // IsNestedColumnType); they are optional and may be empty, in which case
+    // $select is built without the nested-column guard.
+    void SetColumnSchema(const std::vector<std::string> &names,
+                         const std::vector<duckdb::LogicalType> &types);
     
     // Set OData version for proper syntax generation
     void SetODataVersion(ODataVersion version);
@@ -36,10 +45,16 @@ public:
     // Consume DuckDB operations and convert to OData clauses
     void ConsumeColumnSelection(const std::vector<duckdb::column_t> &column_ids);
     void ConsumeFilters(duckdb::optional_ptr<duckdb::TableFilterSet> filters);
+    // NOTE (see GitHub #90): a SQL `LIMIT` is NOT pushed down to `$top`.
+    // DuckDB never hands a table function its result modifiers, so nothing in
+    // this extension observes `LIMIT`/`OFFSET`. `$top`/`$skip` are produced
+    // only from the explicit `top=`/`skip=` named parameters of odata_read()
+    // (and the equivalent Datasphere/SAC parameters). A query such as
+    // `SELECT * FROM odata_read(...) LIMIT 10` therefore still transfers every
+    // page the service is willing to give.
     void ConsumeLimit(duckdb::idx_t limit);
     void ConsumeOffset(duckdb::idx_t offset);
     void ConsumeExpand(const std::string& expand_clause);
-    void ConsumeResultModifiers(const std::vector<duckdb::unique_ptr<duckdb::BoundResultModifier>> &modifiers);
     
     // Get generated OData clauses
     std::string SelectClause() const;
@@ -61,8 +76,10 @@ private:
     // OData version for proper syntax generation
     ODataVersion odata_version = ODataVersion::V4; // Default to V4
     
-    // Column information
+    // Column information (full schema order, as produced by
+    // ODataReadBindData::GetResultNames(true) / GetResultTypes(true))
     std::vector<std::string> all_column_names;
+    std::vector<duckdb::LogicalType> all_column_types;
     ColumnNameResolver column_name_resolver;
     
     // Generated OData clauses
@@ -95,9 +112,12 @@ private:
     std::string TranslateConjunction(const duckdb::ConjunctionAndFilter &filter, const std::string &column_name) const;
     std::string TranslateConjunction(const duckdb::ConjunctionOrFilter &filter, const std::string &column_name) const;
     
-    // Result modifier processing
-    void ProcessResultModifier(const duckdb::BoundResultModifier &modifier);
-    
+    // True when the column at the given full-schema index maps to a nested
+    // DuckDB type (LIST/STRUCT/MAP/ARRAY/UNION). Such columns come from OData
+    // collection or complex properties, which many services reject inside
+    // $select, so projection pushdown is skipped when one is requested.
+    bool IsNestedColumnType(duckdb::column_t schema_index) const;
+
     // Refactored helper methods for ApplyFiltersToUrl
     void LogCurrentClauses() const;
     std::map<std::string, std::string> ParseExistingQueryParameters(const std::string& existing_query) const;

--- a/src/include/odata_read_functions.hpp
+++ b/src/include/odata_read_functions.hpp
@@ -76,6 +76,15 @@ public:
     // DuckDB lifecycle methods
     void ActivateColumns(const std::vector<duckdb::column_t> &column_ids);
     void AddFilters(const duckdb::optional_ptr<duckdb::TableFilterSet> &filters);
+    // NOTE (GitHub #90): SQL `LIMIT`/`OFFSET` are NOT translated into `$top`/`$skip`.
+    // DuckDB never hands a table function its bound result modifiers, so this
+    // entry point has no caller in a real plan; the only remaining caller is
+    // OdpODataReadBindData::AddResultModifiers, which is itself uncalled. The
+    // machinery that used to walk the modifiers and synthesise $top/$skip has
+    // been deleted because it made the code read as though LIMIT were pushed
+    // down when it never was. `$top`/`$skip` come exclusively from the explicit
+    // `top=`/`skip=` named parameters. Kept only so the ODP compilation unit
+    // still links; delete together with the two ODP stubs.
     void AddResultModifiers(const std::vector<duckdb::unique_ptr<duckdb::BoundResultModifier>> &modifiers);
     void UpdateUrlFromPredicatePushdown();
     void PrefetchFirstPage();
@@ -113,6 +122,20 @@ public:
     std::shared_ptr<ConversionFailureLog> GetConversionFailureLog() const;
     // Emit the accumulated per-column failure summary once, at end of scan.
     void ReportConversionFailures();
+    // Produce an independent scan instance for one execution of a bound plan.
+    // See ODataReadGlobalState below and GitHub #75: all mutable scan state
+    // (row buffer, paging cursor, progress, emitted-row counter, request
+    // client) lives on the returned copy, so the bind data itself stays
+    // immutable after bind and a plan can be executed more than once.
+    duckdb::unique_ptr<ODataReadBindData> CloneForScan() const;
+
+    // Reconcile the schema column order. EDMX/metadata order is authoritative
+    // because that is the order the DuckDB catalog (ODataTableEntry) declares
+    // its columns in; JSON key order may only contribute names metadata does
+    // not know about, which are appended at the end. See GitHub #88.
+    static std::vector<std::string> ReconcileSchemaOrder(
+        const std::vector<std::string> &metadata_names,
+        const std::vector<std::string> &json_names);
 
 private:
     // Core components
@@ -126,11 +149,21 @@ private:
     // buffer, both of which are replaced during pagination.
     std::shared_ptr<ConversionFailureLog> conversion_failure_log;
 
-    // State management
+    // Schema, settled during bind and read-only afterwards.
+    // all_result_names / all_result_types are the EDMX (metadata) schema, in
+    // metadata order. extracted_column_names holds the JSON key order observed
+    // in the first data page (V2 / Datasphere only); it is used for type
+    // inference and as a fallback when metadata is unavailable, never to
+    // define column order (GitHub #88).
     std::vector<std::string> all_result_names;
-    std::vector<duckdb::column_t> active_column_ids;
     std::vector<duckdb::LogicalType> all_result_types;
     std::vector<std::string> extracted_column_names;
+    std::vector<std::string> base_result_names;
+    std::vector<duckdb::LogicalType> base_result_types;
+    bool base_schema_resolved_ = false;
+
+    // Projection, settled in ActivateColumns during global-state init.
+    std::vector<duckdb::column_t> active_column_ids;
     std::vector<duckdb::column_t> activated_to_original_mapping;
     
     // Configuration
@@ -138,7 +171,12 @@ private:
     std::string expand_clause;
     bool has_expanded_data = false;
     
-    // State tracking
+    // Mutable scan state. On the instance held as bind data these only ever
+    // carry what bind itself produced (a pre-fetched first page, if any); the
+    // scan mutates the per-execution clone returned by CloneForScan, never the
+    // bind data (GitHub #75). Together with row_buffer, progress_tracker,
+    // data_extractor's row cache and odata_client's paging cursor, this is the
+    // complete set of fields the clone must own.
     bool first_page_cached_ = false;
     // Tracks how many rows have been emitted so far to align expanded cache row-wise
     size_t emitted_row_index_ = 0;
@@ -147,6 +185,19 @@ private:
 
     // Helper methods
     void InitializeComponents(bool service_root_mode = false);
+
+    // (Re-)install the column-name resolver on the predicate pushdown helper,
+    // capturing this instance. Must be called on every object that owns a
+    // helper, including scan clones.
+    void BindPredicateColumnResolver();
+
+    // Metadata (EDMX) schema, fetched once and cached.
+    const std::vector<std::string> &MetadataColumnNames();
+    const std::vector<duckdb::LogicalType> &MetadataColumnTypes();
+
+    // Base (non-expanded) schema in authoritative metadata order, with the
+    // per-name types resolved from metadata. Computed once, then cached.
+    void EnsureBaseSchemaResolved();
 
     // Buffer the rows of an already-fetched first page into row_buffer and
     // mark first_page_cached_. Shared by PrefetchFirstPage (response from
@@ -374,6 +425,9 @@ public:
     std::vector<duckdb::Value> GetNextRow();
     bool HasMoreRows() const;
     size_t Size() const;
+    // Snapshot of the still-buffered rows, used to seed a per-scan clone with
+    // rows that were buffered during bind (see ODataReadBindData::CloneForScan).
+    std::vector<std::vector<duckdb::Value>> CopyRows() const;
     void Clear();
     
     // Page management
@@ -383,6 +437,40 @@ public:
 private:
     std::deque<std::vector<duckdb::Value>> row_buffer_;
     bool has_next_page_ = false;
+};
+
+// ============================================================================
+// Scan State - one instance per execution of a bound plan
+// ============================================================================
+
+/**
+ * @brief Owns all mutable scan state for a single execution of an OData scan.
+ *
+ * Historically the row buffer, paging cursor, progress tracker and
+ * emitted-row counter lived directly on ODataReadBindData behind a bare
+ * GlobalTableFunctionState. Bind data outlives a single execution, so a
+ * re-executed bound plan (PREPARE then EXECUTE twice) found the buffer already
+ * drained and returned zero rows, and a self-join of one odata_read() call had
+ * two scans sharing one cursor (GitHub #75).
+ *
+ * ODataReadTableInitGlobalState now clones the bind data into this object and
+ * runs projection/filter pushdown and the first-page prefetch against the
+ * clone, leaving the bind data untouched by the scan.
+ */
+class ODataReadGlobalState : public duckdb::GlobalTableFunctionState {
+public:
+    explicit ODataReadGlobalState(duckdb::unique_ptr<ODataReadBindData> scan_state);
+
+    // The OData scan is inherently sequential: pagination is server-driven via
+    // @odata.nextLink / __next, so page N+1 is unknowable until page N has been
+    // read. There is no partitioning scheme to hand to a second thread.
+    duckdb::idx_t MaxThreads() const override { return 1; }
+
+    ODataReadBindData &Scan() { return *scan_state; }
+    const ODataReadBindData &Scan() const { return *scan_state; }
+
+private:
+    duckdb::unique_ptr<ODataReadBindData> scan_state;
 };
 
 // ============================================================================

--- a/src/odata_predicate_pushdown_helper.cpp
+++ b/src/odata_predicate_pushdown_helper.cpp
@@ -118,13 +118,47 @@ static void SanitizeExpandParam(std::map<std::string, std::string>& params);
 static void EnsureJsonFormat(std::map<std::string, std::string>& params);
 
 ODataPredicatePushdownHelper::ODataPredicatePushdownHelper(const std::vector<std::string> &all_column_names)
+    : ODataPredicatePushdownHelper(all_column_names, std::vector<duckdb::LogicalType>())
+{ }
+
+ODataPredicatePushdownHelper::ODataPredicatePushdownHelper(const std::vector<std::string> &all_column_names,
+                                                           const std::vector<duckdb::LogicalType> &all_column_types)
     : all_column_names(all_column_names)
+    , all_column_types(all_column_types)
 {
     ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN", "Created predicate pushdown helper with " + std::to_string(all_column_names.size()) + " columns");
     
     // Log all available column names for debugging
     for (size_t i = 0; i < all_column_names.size(); ++i) {
         ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN", "Column " + std::to_string(i) + ": " + all_column_names[i]);
+    }
+}
+
+void ODataPredicatePushdownHelper::SetColumnSchema(const std::vector<std::string> &names,
+                                                   const std::vector<duckdb::LogicalType> &types)
+{
+    all_column_names = names;
+    all_column_types = types;
+    ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN",
+                     "Column schema refreshed: " + std::to_string(all_column_names.size()) + " names, " +
+                         std::to_string(all_column_types.size()) + " types");
+}
+
+bool ODataPredicatePushdownHelper::IsNestedColumnType(duckdb::column_t schema_index) const
+{
+    if (schema_index >= all_column_types.size()) {
+        return false;
+    }
+
+    switch (all_column_types[schema_index].id()) {
+    case duckdb::LogicalTypeId::LIST:
+    case duckdb::LogicalTypeId::STRUCT:
+    case duckdb::LogicalTypeId::MAP:
+    case duckdb::LogicalTypeId::ARRAY:
+    case duckdb::LogicalTypeId::UNION:
+        return true;
+    default:
+        return false;
     }
 }
 
@@ -191,20 +225,6 @@ void ODataPredicatePushdownHelper::ConsumeExpand(const std::string& expand_claus
     } else {
         ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN", "No expand clause to consume");
         this->expand_clause = "";
-    }
-}
-
-void ODataPredicatePushdownHelper::ConsumeResultModifiers(const std::vector<duckdb::unique_ptr<duckdb::BoundResultModifier>> &modifiers)
-{
-    if (modifiers.empty()) {
-        ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN", "No result modifiers to consume");
-        return;
-    }
-    
-    ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN", "Consuming " + std::to_string(modifiers.size()) + " result modifiers");
-    
-    for (const auto &modifier : modifiers) {
-        ProcessResultModifier(*modifier);
     }
 }
 
@@ -547,48 +567,36 @@ std::string ODataPredicatePushdownHelper::BuildSelectClause(const std::vector<du
         return "";
     }
 
-    // Check if any of the selected columns are complex fields that might cause OData errors
-    // Complex fields like Emails, AddressInfo, HomeAddress, Features are arrays or complex objects
-    // that the OData service might not handle properly in $select
-    std::vector<std::string> complex_fields = {"Emails", "AddressInfo", "HomeAddress", "Features"};
-    
-    // Track output position separately (skip rowid entries)
-    size_t output_pos = 0;
+    // Skip $select entirely when any requested column is a nested (collection or
+    // complex) property. Many services reject such properties inside $select, and
+    // OData v2 in particular has no portable syntax for projecting into them.
+    //
+    // This used to be a hard-coded list of TripPin demo property names
+    // ("Emails", "AddressInfo", "HomeAddress", "Features") matched by PREFIX,
+    // which silently disabled projection pushdown for any real service with a
+    // scalar column merely starting with one of those words (GitHub #86).
+    // The DuckDB LogicalType is the accurate signal the name match approximated.
     for (size_t i = 0; i < column_ids.size(); ++i) {
         if (duckdb::IsRowIdColumnId(column_ids[i])) {
             continue;
         }
 
-        // Use column name resolver if available, otherwise fall back to direct indexing.
-        // Resolver expects the OUTPUT position (not schema index) so that it can map
-        // through activated_to_original_mapping to the correct column name.
-        std::string field_name;
-        if (column_name_resolver) {
-            field_name = column_name_resolver(output_pos);
-            if (field_name.empty()) {
-                ERPL_TRACE_ERROR("PREDICATE_PUSHDOWN", "Column name resolver returned empty string for output pos " + std::to_string(output_pos));
-                output_pos++;
-                continue;
-            }
-        } else {
-            field_name = all_column_names[column_ids[i]];
+        if (IsNestedColumnType(column_ids[i])) {
+            const std::string field_name = (column_ids[i] < all_column_names.size())
+                                               ? all_column_names[column_ids[i]]
+                                               : std::string("<unknown>");
+            ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN",
+                             "Nested column type detected: " + field_name + " (" +
+                                 all_column_types[column_ids[i]].ToString() +
+                                 "), skipping $select to avoid OData errors");
+            return "";
         }
-
-        // Check if this is a complex field
-        for (const auto& complex_field : complex_fields) {
-            if (field_name == complex_field || field_name.find(complex_field) == 0) {
-                // Complex field detected, skip $select to avoid OData errors
-                ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN", "Complex field detected: " + field_name + ", skipping $select to avoid OData errors");
-                return "";
-            }
-        }
-        output_pos++;
     }
 
     std::stringstream select_clause;
     std::set<std::string> unique_fields; // Use set to avoid duplicates
 
-    output_pos = 0;
+    size_t output_pos = 0;
     for (size_t i = 0; i < column_ids.size(); ++i) {
         if (duckdb::IsRowIdColumnId(column_ids[i])) {
             continue;
@@ -745,42 +753,6 @@ std::string ODataPredicatePushdownHelper::BuildSkipClause(duckdb::idx_t offset) 
     ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN", "Built skip clause: " + result);
     return result;
 }
-
-void ODataPredicatePushdownHelper::ProcessResultModifier(const duckdb::BoundResultModifier &modifier)
-{
-    ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN", "Processing result modifier of type: " + std::to_string(static_cast<int>(modifier.type)));
-    
-    switch (modifier.type) {
-        case duckdb::ResultModifierType::LIMIT_MODIFIER: {
-            const auto &limit_modifier = modifier.Cast<duckdb::BoundLimitModifier>();
-            ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN", "Processing LIMIT modifier");
-            
-            // Handle LIMIT
-            if (limit_modifier.limit_val.Type() == duckdb::LimitNodeType::CONSTANT_VALUE) {
-                auto limit_value = limit_modifier.limit_val.GetConstantValue();
-                ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN", "LIMIT constant value: " + std::to_string(limit_value));
-                ConsumeLimit(limit_value);
-            }
-            
-            // Handle OFFSET
-            if (limit_modifier.offset_val.Type() == duckdb::LimitNodeType::CONSTANT_VALUE) {
-                auto offset_value = limit_modifier.offset_val.GetConstantValue();
-                ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN", "OFFSET constant value: " + std::to_string(offset_value));
-                ConsumeOffset(offset_value);
-            }
-            break;
-        }
-        case duckdb::ResultModifierType::ORDER_MODIFIER: {
-            ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN", "ORDER BY modifier not yet supported");
-            break;
-        }
-        default:
-            ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN", "Unsupported result modifier type: " + std::to_string(static_cast<int>(modifier.type)));
-            break;
-    }
-}
-
-
 
 std::string ODataPredicatePushdownHelper::InlineCountClause() const {
     if (!inline_count_enabled) {

--- a/src/odata_read_functions.cpp
+++ b/src/odata_read_functions.cpp
@@ -7,6 +7,8 @@
 #include "odata_url_helpers.hpp"
 #include "yyjson.hpp"
 
+#include <unordered_set>
+
 #include "tracing.hpp"
 #include "telemetry.hpp"
 #include "erpl_web_banner.hpp"
@@ -229,6 +231,11 @@ std::vector<duckdb::Value> ODataRowBuffer::GetNextRow() {
 bool ODataRowBuffer::HasMoreRows() const { return !row_buffer_.empty(); }
 
 size_t ODataRowBuffer::Size() const { return row_buffer_.size(); }
+
+std::vector<std::vector<duckdb::Value>> ODataRowBuffer::CopyRows() const {
+    return std::vector<std::vector<duckdb::Value>>(row_buffer_.begin(),
+                                                   row_buffer_.end());
+}
 
 void ODataRowBuffer::Clear() { row_buffer_.clear(); }
 
@@ -911,248 +918,194 @@ void ODataReadBindData::ParseODataV2Response(
                   "Could not extract column names from OData v2 response");
 }
 
-std::vector<std::string> ODataReadBindData::GetResultNames(bool all_columns) {
-  ERPL_TRACE_INFO("ODATA_READ_BIND",
-                  std::string("GetResultNames called - service_root_mode: ") +
-                      (service_root_mode_ ? "true" : "false"));
+const std::vector<std::string> &ODataReadBindData::MetadataColumnNames() {
+  if (!all_result_names.empty() || service_root_mode_ || !odata_client) {
+    return all_result_names;
+  }
+  try {
+    ERPL_TRACE_INFO("ODATA_READ_BIND",
+                    "Calling odata_client->GetResultNames() for metadata");
+    all_result_names = odata_client->GetResultNames();
+  } catch (const std::exception &e) {
+    ERPL_TRACE_WARN("ODATA_READ_BIND",
+                    std::string("Metadata column names unavailable: ") + e.what());
+  }
+  return all_result_names;
+}
 
-    std::vector<std::string> base_names;
+const std::vector<duckdb::LogicalType> &ODataReadBindData::MetadataColumnTypes() {
+  if (!all_result_types.empty() || service_root_mode_ || !odata_client) {
+    return all_result_types;
+  }
+  try {
+    ERPL_TRACE_INFO("ODATA_READ_BIND",
+                    "Calling odata_client->GetResultTypes() for metadata");
+    all_result_types = odata_client->GetResultTypes();
+  } catch (const std::exception &e) {
+    ERPL_TRACE_WARN("ODATA_READ_BIND",
+                    std::string("Metadata column types unavailable: ") + e.what());
+  }
+  return all_result_types;
+}
 
-    // If we have extracted column names from the first data row, use those
-    if (!extracted_column_names.empty()) {
-        base_names = extracted_column_names;
-    ERPL_TRACE_INFO("ODATA_READ_BIND", "Using extracted column names, count: " +
-                                           std::to_string(base_names.size()));
-  } else if (service_root_mode_) {
-    // In service root mode, we should never reach here, but provide a fallback
-    ERPL_TRACE_WARN("ODATA_READ_BIND", "GetResultNames called in service root "
-                                       "mode without extracted column names!");
-    base_names = {"name", "kind", "url"};
-    } else {
-        // Fall back to getting names from the OData client (metadata)
-        if (all_result_names.empty()) {
-      ERPL_TRACE_INFO("ODATA_READ_BIND",
-                      "Calling odata_client->GetResultNames() for metadata");
-            all_result_names = odata_client->GetResultNames();
-        }
-        base_names = all_result_names;
+std::vector<std::string> ODataReadBindData::ReconcileSchemaOrder(
+    const std::vector<std::string> &metadata_names,
+    const std::vector<std::string> &json_names) {
+  // Metadata (EDMX) order wins: the DuckDB catalog entry for an ATTACHed
+  // service declares its columns from EDMX, and DuckDB indexes the scan's
+  // column_ids against that declaration. Deriving the scan schema from JSON
+  // key order instead put values under the wrong headers (GitHub #88).
+  if (metadata_names.empty()) {
+    return json_names;
+  }
+  if (json_names.empty()) {
+    return metadata_names;
+  }
+
+  std::vector<std::string> reconciled = metadata_names;
+  std::unordered_set<std::string> known(metadata_names.begin(),
+                                        metadata_names.end());
+  for (const auto &json_name : json_names) {
+    if (known.insert(json_name).second) {
+      // Present in the payload but not declared in EDMX. Keep it, but only
+      // after every declared column so the metadata prefix stays aligned with
+      // the catalog.
+      reconciled.push_back(json_name);
     }
-    
-    // Add expanded data columns if we have any, avoiding duplicates
-    if (HasExpandedData()) {
-    ERPL_TRACE_DEBUG(
-        "ODATA_READ_BIND",
-        "Adding expanded data columns. Schema size: " +
-            std::to_string(data_extractor->GetExpandedDataSchema().size()) +
-                        ", Base names size: " + std::to_string(base_names.size()));
-        
+  }
+  return reconciled;
+}
+
+void ODataReadBindData::EnsureBaseSchemaResolved() {
+  if (base_schema_resolved_) {
+    return;
+  }
+
+  if (service_root_mode_) {
+    base_result_names = extracted_column_names.empty()
+                            ? std::vector<std::string>{"name", "kind", "url"}
+                            : extracted_column_names;
+    base_result_types.assign(
+        base_result_names.size(),
+        duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR));
+    base_schema_resolved_ = true;
+    return;
+  }
+
+  const auto metadata_names = MetadataColumnNames();
+  const auto metadata_types = MetadataColumnTypes();
+
+  base_result_names = ReconcileSchemaOrder(metadata_names, extracted_column_names);
+
+  base_result_types.clear();
+  base_result_types.reserve(base_result_names.size());
+  for (const auto &column_name : base_result_names) {
+    auto it = std::find(metadata_names.begin(), metadata_names.end(), column_name);
+    if (it != metadata_names.end()) {
+      const auto metadata_index =
+          static_cast<size_t>(std::distance(metadata_names.begin(), it));
+      if (metadata_index < metadata_types.size()) {
+        base_result_types.push_back(metadata_types[metadata_index]);
+        continue;
+      }
+    }
+    ERPL_TRACE_WARN("ODATA_READ_BIND",
+                    "Column '" + column_name +
+                        "' has no declared metadata type, using VARCHAR");
+    base_result_types.push_back(
+        duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR));
+  }
+
+  ERPL_TRACE_INFO("ODATA_READ_BIND",
+                  duckdb::StringUtil::Format(
+                      "Resolved base schema: %d columns (%d from metadata)",
+                      (int)base_result_names.size(), (int)metadata_names.size()));
+
+  base_schema_resolved_ = true;
+}
+
+std::vector<std::string> ODataReadBindData::GetResultNames(bool all_columns) {
+  EnsureBaseSchemaResolved();
+
+  std::vector<std::string> base_names = base_result_names;
+
+  // Add expanded data columns if we have any, avoiding duplicates
+  if (HasExpandedData()) {
     for (const auto &expand_name : data_extractor->GetExpandedDataSchema()) {
-      // Check if this column name already exists in base_names to avoid
-      // duplicates
-            bool exists = false;
-      for (const auto &base_name : base_names) {
-                if (base_name == expand_name) {
-                    exists = true;
-                    break;
-                }
-            }
-            if (!exists) {
+      if (std::find(base_names.begin(), base_names.end(), expand_name) ==
+          base_names.end()) {
         ERPL_TRACE_DEBUG("ODATA_READ_BIND",
                          "Adding expanded column: " + expand_name);
-                base_names.push_back(expand_name);
-            } else {
-        ERPL_TRACE_DEBUG("ODATA_READ_BIND",
-                         "Skipping duplicate expanded column: " + expand_name);
-            }
-        }
-        
-    ERPL_TRACE_DEBUG("ODATA_READ_BIND", "Final base names size: " +
-                                            std::to_string(base_names.size()));
+        base_names.push_back(expand_name);
+      }
     }
-    
-    // Ensure we always return the same size as GetResultTypes would return
-    // This is critical for DuckDB binding consistency
-    if (all_columns || active_column_ids.empty()) {
-        return base_names;
+  }
+
+  if (all_columns || active_column_ids.empty()) {
+    return base_names;
+  }
+
+  std::vector<std::string> active_result_names;
+  for (auto &column_id : active_column_ids) {
+    if (duckdb::IsRowIdColumnId(column_id)) {
+      continue;
     }
-
-    std::vector<std::string> active_result_names;
-    for (auto &column_id : active_column_ids) {
-        if (duckdb::IsRowIdColumnId(column_id)) {
-            continue;
-        }
-
-        if (column_id < base_names.size()) {
-            active_result_names.push_back(base_names[column_id]);
-        }
+    if (column_id < base_names.size()) {
+      active_result_names.push_back(base_names[column_id]);
     }
+  }
 
-    return active_result_names;
+  return active_result_names;
 }
 
 std::vector<duckdb::LogicalType>
 ODataReadBindData::GetResultTypes(bool all_columns) {
-  ERPL_TRACE_INFO("ODATA_READ_BIND",
-                  std::string("GetResultTypes called - service_root_mode: ") +
-                      (service_root_mode_ ? "true" : "false"));
+  EnsureBaseSchemaResolved();
 
-  // Only get types from the OData client (metadata) if we haven't mapped them
-  // yet
-    if (all_result_types.empty()) {
-    if (service_root_mode_) {
-      // In service root mode, use fixed VARCHAR types for the unified schema
-      ERPL_TRACE_INFO("ODATA_READ_BIND",
-                      "Using fixed VARCHAR types for service root mode");
-      all_result_types = {duckdb::LogicalTypeId::VARCHAR,
-                          duckdb::LogicalTypeId::VARCHAR,
-                          duckdb::LogicalTypeId::VARCHAR};
-    } else {
-      ERPL_TRACE_INFO("ODATA_READ_BIND",
-                      "Calling odata_client->GetResultTypes() for metadata");
-        all_result_types = odata_client->GetResultTypes();
-    }
-        
-        // If we have extracted column names, align types to those names
-    if (!extracted_column_names.empty() && !service_root_mode_) {
-            if (extracted_column_names.size() == all_result_types.size()) {
-                // Create a mapping from extracted column names to metadata types
-                std::vector<duckdb::LogicalType> mapped_types;
-                mapped_types.reserve(extracted_column_names.size());
-                
-                // Get the metadata column names to map them to extracted names
-                auto metadata_names = odata_client->GetResultNames();
-                
-        for (const auto &extracted_name : extracted_column_names) {
-                    // Find the index of this column in the metadata
-          auto it = std::find(metadata_names.begin(), metadata_names.end(),
-                              extracted_name);
-                    if (it != metadata_names.end()) {
-                        size_t metadata_index = std::distance(metadata_names.begin(), it);
-                        if (metadata_index < all_result_types.size()) {
-                            mapped_types.push_back(all_result_types[metadata_index]);
-              ERPL_TRACE_DEBUG("ODATA_READ_BIND",
-                               "Mapped column '" + extracted_name +
-                                   "' to type: " +
-                                   all_result_types[metadata_index].ToString());
-                        } else {
-                            // Fallback to VARCHAR if metadata index is out of bounds
-                            mapped_types.push_back(duckdb::LogicalTypeId::VARCHAR);
-              ERPL_TRACE_WARN(
-                  "ODATA_READ_BIND",
-                  "Column '" + extracted_name +
-                      "' not found in metadata, using VARCHAR fallback");
-                        }
-                    } else {
-                        // Fallback to VARCHAR if column not found in metadata
-                        mapped_types.push_back(duckdb::LogicalTypeId::VARCHAR);
-            ERPL_TRACE_WARN(
-                "ODATA_READ_BIND",
-                "Column '" + extracted_name +
-                    "' not found in metadata, using VARCHAR fallback");
-                    }
-                }
-                
-                // Replace all_result_types with the mapped types
-                all_result_types = mapped_types;
-            } else {
-        // Sizes mismatch (common in OData v2 when inferring from data) ->
-        // default all to VARCHAR
-        ERPL_TRACE_INFO(
-            "ODATA_READ_BIND",
-            duckdb::StringUtil::Format(
-                "Metadata column count (%d) does not match extracted column "
-                "count (%d); defaulting all types to VARCHAR",
-                    all_result_types.size(), extracted_column_names.size()));
-        all_result_types.assign(extracted_column_names.size(),
-                                duckdb::LogicalTypeId::VARCHAR);
-            }
-        }
-    }
-    
-    // Create a combined types vector that includes expanded data types
-    std::vector<duckdb::LogicalType> combined_types = all_result_types;
+  std::vector<duckdb::LogicalType> combined_types = base_result_types;
+  const auto &base_names_local = base_result_names;
 
-    // Compute the base column names to support duplicate detection
-    std::vector<std::string> base_names_local;
-    if (!extracted_column_names.empty()) {
-        base_names_local = extracted_column_names;
-    } else {
-        if (all_result_names.empty()) {
-            all_result_names = odata_client->GetResultNames();
-        }
-        base_names_local = all_result_names;
-    }
-    
-  // Add/merge expanded data types if we have any, ensuring alignment with
-  // schema
-    if (HasExpandedData()) {
-    ERPL_TRACE_DEBUG(
-        "ODATA_READ_BIND",
-        "Merging expanded data types. Schema size: " +
-            std::to_string(data_extractor->GetExpandedDataSchema().size()) +
-            ", Types size: " +
-            std::to_string(data_extractor->GetExpandedDataTypes().size()));
-        
-        // Ensure we have the same number of types as schema columns where appended
-        const auto &exp_schema = data_extractor->GetExpandedDataSchema();
+  // Add/merge expanded data types if we have any, keeping them aligned with the
+  // names GetResultNames() produces.
+  if (HasExpandedData()) {
+    const auto &exp_schema = data_extractor->GetExpandedDataSchema();
     const auto &exp_types = data_extractor->GetExpandedDataTypes();
-        for (size_t i = 0; i < exp_schema.size(); ++i) {
-            const auto &exp_name = exp_schema[i];
+    for (size_t i = 0; i < exp_schema.size(); ++i) {
+      const auto &exp_name = exp_schema[i];
       duckdb::LogicalType exp_type =
-          (i < exp_types.size()) ? exp_types[i] : duckdb::LogicalTypeId::VARCHAR;
-            
-      // Check if this type has been updated from the fallback LIST(VARCHAR) to
-      // a proper struct type
-            if (exp_type.id() == duckdb::LogicalTypeId::LIST && 
-          duckdb::ListType::GetChildType(exp_type).id() !=
-              duckdb::LogicalTypeId::VARCHAR) {
-        ERPL_TRACE_DEBUG("ODATA_READ_BIND",
-                         "Using updated inferred type for expanded column '" +
-                             exp_name + "': " + exp_type.ToString());
-      }
+          (i < exp_types.size())
+              ? exp_types[i]
+              : duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
 
       auto it =
           std::find(base_names_local.begin(), base_names_local.end(), exp_name);
-            if (it != base_names_local.end()) {
-                size_t idx = std::distance(base_names_local.begin(), it);
-                if (idx < combined_types.size()) {
-                    // Replace base type with expanded type
-                    combined_types[idx] = exp_type;
-          ERPL_TRACE_DEBUG("ODATA_READ_BIND",
-                           "Replaced base type for expanded column '" +
-                               exp_name + "' at index " + std::to_string(idx) +
-                               " with " + exp_type.ToString());
-                }
-            } else {
-                // Append new expanded column type
-                combined_types.push_back(exp_type);
-        ERPL_TRACE_DEBUG("ODATA_READ_BIND",
-                         "Appended expanded type for new column '" + exp_name +
-                             "': " + exp_type.ToString());
-            }
+      if (it != base_names_local.end()) {
+        const auto idx =
+            static_cast<size_t>(std::distance(base_names_local.begin(), it));
+        if (idx < combined_types.size()) {
+          combined_types[idx] = exp_type;
         }
+      } else {
+        combined_types.push_back(exp_type);
+      }
     }
-    
-  ERPL_TRACE_DEBUG("ODATA_READ_BIND",
-                   "Final combined types size: " +
-                       std::to_string(combined_types.size()));
+  }
 
-    if (all_columns || active_column_ids.empty()) {
-        return combined_types;
+  if (all_columns || active_column_ids.empty()) {
+    return combined_types;
+  }
+
+  std::vector<duckdb::LogicalType> active_result_types;
+  for (auto &column_id : active_column_ids) {
+    if (duckdb::IsRowIdColumnId(column_id)) {
+      continue;
     }
-
-    std::vector<duckdb::LogicalType> active_result_types;
-    for (auto &column_id : active_column_ids) {
-        if (duckdb::IsRowIdColumnId(column_id)) {
-            continue;
-        }
-
-        if (column_id < combined_types.size()) {
-            active_result_types.push_back(combined_types[column_id]);
-        }
+    if (column_id < combined_types.size()) {
+      active_result_types.push_back(combined_types[column_id]);
     }
+  }
 
-    return active_result_types;
+  return active_result_types;
 }
 
 // ============================================================================
@@ -1440,6 +1393,11 @@ void ODataReadBindData::ActivateColumns(
                    std::string("ActivateColumns: service_root_mode_ = ") +
                        (service_root_mode_ ? "true" : "false"));
   if (!service_root_mode_) {
+    // Refresh the helper's view of the schema before it builds $select: the
+    // expand clause processed after helper creation can add columns, and the
+    // types decide whether $select is safe at all (GitHub #86).
+    PredicatePushdownHelper()->SetColumnSchema(GetResultNames(true),
+                                               GetResultTypes(true));
     PredicatePushdownHelper()->ConsumeColumnSelection(visible_ids);
     ERPL_TRACE_DEBUG("ODATA_READ_BIND",
                      duckdb::StringUtil::Format(
@@ -1484,20 +1442,22 @@ void ODataReadBindData::AddFilters(
 void ODataReadBindData::AddResultModifiers(
     const std::vector<duckdb::unique_ptr<duckdb::BoundResultModifier>>
         &modifiers) {
-  if (service_root_mode_) {
-    ERPL_TRACE_DEBUG("ODATA_READ_BIND",
-                     "Service-root mode: ignoring result modifiers");
-    return;
-  }
-    if (!modifiers.empty()) {
-    ERPL_TRACE_DEBUG("ODATA_READ_BIND",
-                     duckdb::StringUtil::Format("Adding %d result modifiers",
-                                                modifiers.size()));
-        PredicatePushdownHelper()->ConsumeResultModifiers(modifiers);
-        ERPL_TRACE_DEBUG("ODATA_READ_BIND", "Result modifiers processed");
-    } else {
-        ERPL_TRACE_DEBUG("ODATA_READ_BIND", "No result modifiers to add");
-    }
+  // Deliberately does nothing (GitHub #90). DuckDB does not hand table
+  // functions their bound result modifiers, so a SQL `LIMIT`/`OFFSET` never
+  // reaches this extension and is NEVER translated into `$top`/`$skip`:
+  // `SELECT * FROM odata_read(...) LIMIT 10` still pulls every page the
+  // service offers. `$top`/`$skip` are produced only from the explicit
+  // `top=`/`skip=` named parameters (see ODataReadBindHelpers::
+  // ProcessNamedParameters) and their Datasphere/SAC equivalents.
+  //
+  // The code that used to walk the modifiers and synthesise those clauses has
+  // been deleted because it made the read path look as though LIMIT pushdown
+  // existed. This stub survives only so the (equally uncalled)
+  // OdpODataReadBindData::AddResultModifiers keeps linking; delete both
+  // together.
+  (void)modifiers;
+  ERPL_TRACE_DEBUG("ODATA_READ_BIND",
+                   "AddResultModifiers is a no-op: LIMIT is not pushed to $top");
 }
 
 void ODataReadBindData::UpdateUrlFromPredicatePushdown() {
@@ -1561,25 +1521,18 @@ ODataReadBindData::PredicatePushdownHelper() {
     ERPL_TRACE_DEBUG("ODATA_READ_BIND",
                      "Creating new predicate pushdown helper");
         
-    // Use extracted column names if available, otherwise fall back to OData client
-        std::vector<std::string> column_names;
-        if (!extracted_column_names.empty()) {
-            column_names = extracted_column_names;
-      ERPL_TRACE_DEBUG(
-          "ODATA_READ_BIND",
-          duckdb::StringUtil::Format(
-              "Using extracted column names for predicate pushdown: %d columns",
-              column_names.size()));
-        } else {
-            column_names = odata_client->GetResultNames();
-      ERPL_TRACE_DEBUG(
-          "ODATA_READ_BIND",
-          duckdb::StringUtil::Format("Using OData client column names for "
-                                     "predicate pushdown: %d columns",
-                                     column_names.size()));
-    }
+    // Feed the helper the full resolved schema (metadata order, plus expanded
+    // columns) together with its types. The types let it decide whether
+    // $select is safe rather than guessing from column names (GitHub #86),
+    // and the order matches what DuckDB's column_ids index into.
+    auto column_names = GetResultNames(true);
+    auto column_types = GetResultTypes(true);
+    ERPL_TRACE_DEBUG("ODATA_READ_BIND",
+                     duckdb::StringUtil::Format(
+                         "Creating predicate pushdown helper with %d columns",
+                         (int)column_names.size()));
     predicate_pushdown_helper =
-        std::make_shared<ODataPredicatePushdownHelper>(column_names);
+        std::make_shared<ODataPredicatePushdownHelper>(column_names, column_types);
         
         // Set the OData version for proper filter syntax generation
         auto odata_version = odata_client->GetODataVersion();
@@ -1590,39 +1543,33 @@ ODataReadBindData::PredicatePushdownHelper() {
             std::string(odata_version == ODataVersion::V2 ? "V2" : "V4") +
             " on predicate pushdown helper");
 
-    // Column name resolver: DuckDB passes the OUTPUT position (index within the
-    // projected column list from InitGlobal). We must translate that through
-    // activated_to_original_mapping to get the schema index before looking up
-    // the column name, because the activated column order may differ from the
-    // schema order (e.g. column_ids=[8,0] puts Country at output pos 0).
-    predicate_pushdown_helper->SetColumnNameResolver([this](duckdb::column_t
-                                                                output_index)
-                                                         -> std::string {
-      // Translate output position → full-schema index
-      size_t schema_index = output_index;
-      if (output_index < this->activated_to_original_mapping.size()) {
-          schema_index = this->activated_to_original_mapping[output_index];
-      }
+    BindPredicateColumnResolver();
+    }
 
-      if (!this->extracted_column_names.empty()) {
-        if (schema_index < this->extracted_column_names.size()) {
-          return this->extracted_column_names[schema_index];
-        } else {
-          ERPL_TRACE_ERROR(
-              "ODATA_READ_BIND",
-              duckdb::StringUtil::Format("Schema column index %d (from output "
-                                         "index %d) is out of bounds for "
-                                         "extracted column names",
-                                         (int)schema_index, (int)output_index));
-          return std::string();
+    return predicate_pushdown_helper;
+}
+
+void ODataReadBindData::BindPredicateColumnResolver() {
+  if (!predicate_pushdown_helper) {
+    return;
+  }
+
+  // DuckDB passes the OUTPUT position (index within the projected column list
+  // from InitGlobal). Translate that through activated_to_original_mapping to
+  // the full-schema index before looking up the column name, because the
+  // activated column order may differ from the schema order (e.g.
+  // column_ids=[8,0] puts Country at output pos 0).
+  predicate_pushdown_helper->SetColumnNameResolver(
+      [this](duckdb::column_t output_index) -> std::string {
+        size_t schema_index = output_index;
+        if (output_index < this->activated_to_original_mapping.size()) {
+          schema_index = this->activated_to_original_mapping[output_index];
         }
-      }
-      if (this->all_result_names.empty()) {
-        this->all_result_names = this->odata_client->GetResultNames();
-      }
-      if (schema_index < this->all_result_names.size()) {
-        return this->all_result_names[schema_index];
-      } else {
+
+        this->EnsureBaseSchemaResolved();
+        if (schema_index < this->base_result_names.size()) {
+          return this->base_result_names[schema_index];
+        }
         ERPL_TRACE_ERROR(
             "ODATA_READ_BIND",
             duckdb::StringUtil::Format(
@@ -1630,11 +1577,69 @@ ODataReadBindData::PredicatePushdownHelper() {
                 "bounds for result names",
                 (int)schema_index, (int)output_index));
         return std::string();
-      }
-        });
-    }
+      });
+}
 
-    return predicate_pushdown_helper;
+duckdb::unique_ptr<ODataReadBindData> ODataReadBindData::CloneForScan() const {
+  // The clone owns every piece of mutable scan state; the source keeps only
+  // the schema and configuration settled during bind (GitHub #75).
+  auto clone = duckdb::make_uniq<ODataReadBindData>(odata_client, true);
+
+  clone->service_root_mode_ = service_root_mode_;
+  clone->InitializeComponents(service_root_mode_);
+
+  // Schema and configuration: pure values, safe to copy.
+  clone->all_result_names = all_result_names;
+  clone->all_result_types = all_result_types;
+  clone->extracted_column_names = extracted_column_names;
+  clone->base_result_names = base_result_names;
+  clone->base_result_types = base_result_types;
+  clone->base_schema_resolved_ = base_schema_resolved_;
+  clone->input_parameters = input_parameters;
+  clone->expand_clause = expand_clause;
+  clone->has_expanded_data = has_expanded_data;
+  clone->active_column_ids = active_column_ids;
+  clone->activated_to_original_mapping = activated_to_original_mapping;
+
+  // The clone gets its own extractor so its per-row expand cache starts empty,
+  // but it must carry the expand schema and the types inferred during bind.
+  if (data_extractor && clone->data_extractor) {
+    clone->data_extractor->SetExpandedDataSchema(
+        data_extractor->GetExpandedDataSchema());
+    clone->data_extractor->SetNestedExpandPaths(
+        data_extractor->GetNestedExpandPaths());
+    const auto &expanded_types = data_extractor->GetExpandedDataTypes();
+    for (size_t i = 0; i < expanded_types.size(); ++i) {
+      clone->data_extractor->UpdateExpandedColumnType(i, expanded_types[i]);
+    }
+  }
+
+  // Carry the clauses generated at bind time (top/skip/expand/count from named
+  // parameters) but re-point the column resolver at the clone.
+  if (predicate_pushdown_helper) {
+    clone->predicate_pushdown_helper =
+        std::make_shared<ODataPredicatePushdownHelper>(*predicate_pushdown_helper);
+    clone->BindPredicateColumnResolver();
+  }
+
+  // Carry rows buffered during bind. The ODP path hands a pre-fetched first
+  // page in via FromEntitySetClient and the service-root path pre-buffers its
+  // synthetic rows; dropping those here would make every execution re-issue a
+  // bare GET (which SAP ODP answers with the entire dataset).
+  if (row_buffer && clone->row_buffer) {
+    clone->row_buffer->AddRows(row_buffer->CopyRows());
+    clone->row_buffer->SetHasNextPage(row_buffer->HasNextPage());
+  }
+  clone->first_page_cached_ = first_page_cached_;
+
+  ERPL_TRACE_DEBUG(
+      "ODATA_READ_BIND",
+      duckdb::StringUtil::Format(
+          "Cloned bind data for scan: %d buffered rows, first_page_cached=%s",
+          (int)(row_buffer ? row_buffer->Size() : 0),
+          first_page_cached_ ? "true" : "false"));
+
+  return clone;
 }
 
 double ODataReadBindData::GetProgressFraction() const {
@@ -1729,6 +1734,7 @@ void ODataReadBindData::BufferFirstPageFromResponse(
 void ODataReadBindData::SetExtractedColumnNames(
     const std::vector<std::string> &column_names) {
     extracted_column_names = column_names;
+    base_schema_resolved_ = false;
   ERPL_TRACE_DEBUG("ODATA_READ_BIND", "Stored " +
                                           std::to_string(column_names.size()) +
                                           " extracted column names");
@@ -1741,47 +1747,29 @@ std::string ODataReadBindData::GetOriginalColumnName(
     // by user) Just return empty string for columns we don't have mapping for
         return "";
     }
-    
+
     auto original_index = activated_to_original_mapping[activated_column_index];
-    
-  // Always use all_result_names (EDMX-derived, no navigation properties).
-  // extracted_column_names comes from JSON key order and may include nav
-  // properties at lower indices, causing off-by-one mismatches against the
-  // DuckDB catalog column indices which are built from EDMX only.
-    if (!all_result_names.empty()) {
-        if (original_index >= all_result_names.size()) {
-      ERPL_TRACE_ERROR(
-          "ODATA_READ_BIND",
-          duckdb::StringUtil::Format(
-              "Original column index %d is out of bounds for result names (%d total)",
-              original_index, (int)all_result_names.size()));
-            return "";
-        }
-        auto column_name = all_result_names[original_index];
-    ERPL_TRACE_DEBUG("ODATA_READ_BIND",
-                     duckdb::StringUtil::Format(
-                         "Activated index %d maps to original index %d which "
-                         "is column '%s' (from EDMX result names)",
-                         (int)activated_column_index, (int)original_index,
-                         column_name.c_str()));
-        return column_name;
-    }
-    if (original_index >= extracted_column_names.size()) {
-      ERPL_TRACE_ERROR(
-          "ODATA_READ_BIND",
-          duckdb::StringUtil::Format("Original column index %d is out of "
-                                     "bounds for extracted column names (%d total)",
-                                     original_index, (int)extracted_column_names.size()));
-        return "";
-    }
-    auto column_name = extracted_column_names[original_index];
-    ERPL_TRACE_DEBUG("ODATA_READ_BIND",
-                     duckdb::StringUtil::Format(
-                         "Activated index %d maps to original index %d which "
-                         "is column '%s' (from JSON-extracted names, EDMX unavailable)",
-                         (int)activated_column_index, (int)original_index,
-                         column_name.c_str()));
-    return column_name;
+
+  // base_result_names is the reconciled schema: EDMX order first, JSON-only
+  // columns appended. That is exactly the order DuckDB's column indices refer
+  // to, so no other list may be consulted here (GitHub #88).
+  if (original_index >= base_result_names.size()) {
+    ERPL_TRACE_ERROR(
+        "ODATA_READ_BIND",
+        duckdb::StringUtil::Format(
+            "Original column index %d is out of bounds for result names (%d total)",
+            original_index, (int)base_result_names.size()));
+    return "";
+  }
+
+  const auto column_name = base_result_names[original_index];
+  ERPL_TRACE_DEBUG("ODATA_READ_BIND",
+                   duckdb::StringUtil::Format(
+                       "Activated index %d maps to original index %d which "
+                       "is column '%s'",
+                       (int)activated_column_index, (int)original_index,
+                       column_name.c_str()));
+  return column_name;
 }
 
 void ODataReadBindData::SetInputParameters(
@@ -1830,33 +1818,21 @@ bool ODataReadBindData::HasExpandedData() const {
 
 void ODataReadBindData::UpdateExpandedColumnType(
     const std::string &expand_path, const duckdb::LogicalType &new_type) {
-    // Find the expanded column in our schema and update its type
-  if (HasExpandedData() && data_extractor) {
-    const auto &exp_schema = data_extractor->GetExpandedDataSchema();
-        for (size_t i = 0; i < exp_schema.size(); ++i) {
-            if (exp_schema[i] == expand_path) {
-                // Update the type in the data extractor
-                data_extractor->UpdateExpandedColumnType(i, new_type);
-                
-                // Also update our local all_result_types if this column exists there
-                if (!extracted_column_names.empty()) {
-          auto it = std::find(extracted_column_names.begin(),
-                              extracted_column_names.end(), expand_path);
-                    if (it != extracted_column_names.end()) {
-                        size_t col_idx = std::distance(extracted_column_names.begin(), it);
-                        if (col_idx < all_result_types.size()) {
-                            all_result_types[col_idx] = new_type;
-              ERPL_TRACE_DEBUG("ODATA_READ_BIND",
-                               "Updated all_result_types[" +
-                                   std::to_string(col_idx) + "] for '" +
-                                   expand_path + "' to " + new_type.ToString());
-                        }
-                    }
-                }
-                break;
-            }
-        }
+  if (!HasExpandedData() || !data_extractor) {
+    return;
+  }
+
+  const auto &exp_schema = data_extractor->GetExpandedDataSchema();
+  for (size_t i = 0; i < exp_schema.size(); ++i) {
+    if (exp_schema[i] != expand_path) {
+      continue;
     }
+    // GetResultTypes() merges the extractor's expanded types over the base
+    // schema by column name on every call, so the extractor is the single
+    // place this type needs to live.
+    data_extractor->UpdateExpandedColumnType(i, new_type);
+    return;
+  }
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -2165,50 +2141,84 @@ ODataReadBind(ClientContext &context, TableFunctionBindInput &input,
   }
 }
 
+ODataReadGlobalState::ODataReadGlobalState(
+    duckdb::unique_ptr<ODataReadBindData> scan_state)
+    : scan_state(std::move(scan_state)) {
+}
+
+namespace {
+
+// Returns the object that owns the scan state for this execution.
+//
+// odata_read(), the ATTACHed odata_table_scan and the SAC readers use
+// ODataReadGlobalState, so each execution of a bound plan gets its own state.
+// The Datasphere readers reuse ODataReadScan with their own init-global
+// functions, which still return a bare GlobalTableFunctionState; those keep the
+// historical behaviour of scanning straight out of the bind data.
+ODataReadBindData &ResolveScanState(const duckdb::FunctionData *bind_data,
+                                    const GlobalTableFunctionState *global_state) {
+  auto *odata_global = dynamic_cast<const ODataReadGlobalState *>(global_state);
+  if (odata_global != nullptr) {
+    return const_cast<ODataReadGlobalState *>(odata_global)->Scan();
+  }
+  return bind_data->CastNoConst<ODataReadBindData>();
+}
+
+} // namespace
+
 unique_ptr<GlobalTableFunctionState>
 ODataReadTableInitGlobalState(ClientContext &context,
                               TableFunctionInitInput &input) {
-    auto &bind_data = input.bind_data->CastNoConst<ODataReadBindData>();
-    auto column_ids = input.column_ids;
+  auto &bind_data = input.bind_data->CastNoConst<ODataReadBindData>();
 
-    bind_data.ActivateColumns(column_ids);
-    bind_data.AddFilters(input.filters);
-    
-    bind_data.UpdateUrlFromPredicatePushdown();
+  // Projection, filter pushdown and the first-page prefetch all mutate scan
+  // state, so they run against a private clone. The bind data stays exactly as
+  // bind left it, which is what makes a second EXECUTE of the same prepared
+  // statement (and a self-join of one odata_read call) work (GitHub #75).
+  auto scan_state = bind_data.CloneForScan();
+
+  scan_state->ActivateColumns(input.column_ids);
+  scan_state->AddFilters(input.filters);
+  scan_state->UpdateUrlFromPredicatePushdown();
   // Prefetch first page after URL is finalized so progress can show early and
   // tiny scans return immediately
-    bind_data.PrefetchFirstPage();
+  scan_state->PrefetchFirstPage();
 
-    return duckdb::make_uniq<GlobalTableFunctionState>();
+  return duckdb::make_uniq<ODataReadGlobalState>(std::move(scan_state));
 }
 
 double ODataReadTableProgress(ClientContext &, const FunctionData *func_data,
-                              const GlobalTableFunctionState *) {
-    auto &bind_data = func_data->CastNoConst<ODataReadBindData>();
-    return bind_data.GetProgressFraction();
+                              const GlobalTableFunctionState *global_state) {
+  return ResolveScanState(func_data, global_state).GetProgressFraction();
 }
 
 void ODataReadScan(ClientContext &context, TableFunctionInput &data,
                    DataChunk &output) {
-    auto &bind_data = data.bind_data->CastNoConst<ODataReadBindData>();
-    
-    ERPL_TRACE_DEBUG("ODATA_SCAN", "Starting OData scan operation");
-    
-  if (!bind_data.HasMoreResults()) {
-        ERPL_TRACE_DEBUG("ODATA_SCAN", "No more results available");
-        // End of scan: surface the per-column conversion failures once.
-        bind_data.ReportConversionFailures();
-        return;
-    }
-    
-    ERPL_TRACE_DEBUG("ODATA_SCAN", "Fetching next result set");
-    auto rows_fetched = bind_data.FetchNextResult(output);
+  // Scan state lives on the per-execution clone owned by the global state, so a
+  // bound plan can be executed more than once (GitHub #75). ResolveScanState
+  // falls back to the bind data for callers that still supply a bare
+  // GlobalTableFunctionState.
+  auto &scan_state =
+      ResolveScanState(data.bind_data.get(), data.global_state.get());
+
+  ERPL_TRACE_DEBUG("ODATA_SCAN", "Starting OData scan operation");
+
+  if (!scan_state.HasMoreResults()) {
+    ERPL_TRACE_DEBUG("ODATA_SCAN", "No more results available");
+    // End of scan: surface the per-column conversion failures once, against the
+    // instance that actually accumulated them (GitHub #74).
+    scan_state.ReportConversionFailures();
+    return;
+  }
+
+  ERPL_TRACE_DEBUG("ODATA_SCAN", "Fetching next result set");
+  auto rows_fetched = scan_state.FetchNextResult(output);
   ERPL_TRACE_INFO("ODATA_SCAN",
                   duckdb::StringUtil::Format("Fetched %d rows", rows_fetched));
 
-    if (!bind_data.HasMoreResults()) {
-        bind_data.ReportConversionFailures();
-    }
+  if (!scan_state.HasMoreResults()) {
+    scan_state.ReportConversionFailures();
+  }
 }
 
 TableFunctionSet CreateODataReadFunction() {

--- a/test/cpp/test_odata_read_scan_state.cpp
+++ b/test/cpp/test_odata_read_scan_state.cpp
@@ -1,0 +1,172 @@
+#include "catch.hpp"
+
+#include "odata_predicate_pushdown_helper.hpp"
+#include "odata_read_functions.hpp"
+
+#include <string>
+#include <vector>
+
+using namespace erpl_web;
+
+namespace {
+
+duckdb::LogicalType Varchar() {
+    return duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// GitHub #86 - $select pushdown must key off the column's LogicalType, not off
+// a hard-coded list of TripPin demo property names matched by prefix.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Scalar column named Features still gets $select pushdown", "[odata][pushdown]")
+{
+    // A real service with scalar columns whose names happen to collide with the
+    // old hard-coded TripPin list. Before the fix, "Features" (exact match) and
+    // "HomeAddressLine1" (prefix match on "HomeAddress") each disabled $select
+    // entirely, so the scan transferred every column.
+    std::vector<std::string> names = {"ID", "Features", "HomeAddressLine1", "Notes"};
+    std::vector<duckdb::LogicalType> types = {Varchar(), Varchar(), Varchar(), Varchar()};
+
+    ODataPredicatePushdownHelper helper(names, types);
+    helper.ConsumeColumnSelection({0, 1, 2});
+
+    REQUIRE(helper.SelectClause() == "$select=ID,Features,HomeAddressLine1");
+}
+
+TEST_CASE("List-typed column disables $select pushdown", "[odata][pushdown]")
+{
+    std::vector<std::string> names = {"UserName", "Emails", "FirstName"};
+    std::vector<duckdb::LogicalType> types = {
+        Varchar(), duckdb::LogicalType::LIST(Varchar()), Varchar()};
+
+    ODataPredicatePushdownHelper helper(names, types);
+    helper.ConsumeColumnSelection({0, 1});
+
+    REQUIRE(helper.SelectClause().empty());
+}
+
+TEST_CASE("Struct-typed column disables $select pushdown", "[odata][pushdown]")
+{
+    duckdb::child_list_t<duckdb::LogicalType> children;
+    children.emplace_back("City", Varchar());
+
+    std::vector<std::string> names = {"UserName", "HomeAddress", "FirstName"};
+    std::vector<duckdb::LogicalType> types = {
+        Varchar(), duckdb::LogicalType::STRUCT(children), Varchar()};
+
+    ODataPredicatePushdownHelper helper(names, types);
+    helper.ConsumeColumnSelection({0, 1});
+
+    REQUIRE(helper.SelectClause().empty());
+}
+
+TEST_CASE("Nested column not projected does not disable $select", "[odata][pushdown]")
+{
+    std::vector<std::string> names = {"UserName", "Emails", "FirstName"};
+    std::vector<duckdb::LogicalType> types = {
+        Varchar(), duckdb::LogicalType::LIST(Varchar()), Varchar()};
+
+    ODataPredicatePushdownHelper helper(names, types);
+    helper.ConsumeColumnSelection({0, 2});
+
+    REQUIRE(helper.SelectClause() == "$select=UserName,FirstName");
+}
+
+TEST_CASE("Without column types $select is still built", "[odata][pushdown]")
+{
+    // Callers that never supply types (unit tests, legacy call sites) keep the
+    // pre-existing behaviour: no type information means no nested-column guard.
+    std::vector<std::string> names = {"ID", "Features", "Notes"};
+
+    ODataPredicatePushdownHelper helper(names);
+    helper.ConsumeColumnSelection({0, 1});
+
+    REQUIRE(helper.SelectClause() == "$select=ID,Features");
+}
+
+// ---------------------------------------------------------------------------
+// GitHub #88 - the schema order handed to the scan must follow EDMX/metadata,
+// because that is the order the DuckDB catalog declares its columns in. JSON
+// key order may only contribute names metadata does not know about.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Metadata order wins over JSON key order", "[odata][schema]")
+{
+    const std::vector<std::string> metadata_names = {"CategoryID", "CategoryName",
+                                                     "Description", "Picture"};
+    // A V2 payload that serialises its properties in a different order.
+    const std::vector<std::string> json_names = {"CategoryName", "Picture",
+                                                 "CategoryID", "Description"};
+
+    const auto reconciled =
+        ODataReadBindData::ReconcileSchemaOrder(metadata_names, json_names);
+
+    REQUIRE(reconciled == metadata_names);
+}
+
+TEST_CASE("Columns absent from the payload keep their metadata slot", "[odata][schema]")
+{
+    const std::vector<std::string> metadata_names = {"A", "B", "C"};
+    const std::vector<std::string> json_names = {"C", "A"};
+
+    const auto reconciled =
+        ODataReadBindData::ReconcileSchemaOrder(metadata_names, json_names);
+
+    REQUIRE(reconciled == metadata_names);
+}
+
+TEST_CASE("Payload-only columns are appended after the metadata columns", "[odata][schema]")
+{
+    const std::vector<std::string> metadata_names = {"A", "B"};
+    const std::vector<std::string> json_names = {"Extra1", "B", "Extra2", "A"};
+
+    const auto reconciled =
+        ODataReadBindData::ReconcileSchemaOrder(metadata_names, json_names);
+
+    const std::vector<std::string> expected = {"A", "B", "Extra1", "Extra2"};
+    REQUIRE(reconciled == expected);
+}
+
+TEST_CASE("Without metadata the JSON order is used unchanged", "[odata][schema]")
+{
+    const std::vector<std::string> json_names = {"X", "Y", "Z"};
+
+    const auto reconciled =
+        ODataReadBindData::ReconcileSchemaOrder({}, json_names);
+
+    REQUIRE(reconciled == json_names);
+}
+
+// ---------------------------------------------------------------------------
+// GitHub #75 - the row buffer is per-scan state. A clone of a scan must be able
+// to take a copy of the rows buffered during bind without draining the source.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("CopyRows snapshots the buffer without consuming it", "[odata][scan_state]")
+{
+    ODataRowBuffer buffer;
+    buffer.AddRows({{duckdb::Value("a")}, {duckdb::Value("b")}});
+    buffer.SetHasNextPage(true);
+
+    const auto snapshot = buffer.CopyRows();
+
+    REQUIRE(snapshot.size() == 2);
+    REQUIRE(buffer.Size() == 2);
+    REQUIRE(buffer.HasMoreRows());
+
+    ODataRowBuffer clone;
+    clone.AddRows(snapshot);
+    clone.SetHasNextPage(buffer.HasNextPage());
+
+    REQUIRE(clone.Size() == 2);
+    REQUIRE(clone.HasNextPage());
+
+    // Draining the clone must leave the source untouched.
+    clone.GetNextRow();
+    clone.GetNextRow();
+    REQUIRE_FALSE(clone.HasMoreRows());
+    REQUIRE(buffer.Size() == 2);
+}

--- a/test/sql/odata_scan_reexecution.test
+++ b/test/sql/odata_scan_reexecution.test
@@ -1,0 +1,129 @@
+# name: test/sql/odata_scan_reexecution.test
+# description: A bound OData plan must be re-executable (GitHub #75). All scan
+#              state used to live in the bind data, so the second EXECUTE of a
+#              prepared statement found the row buffer already drained and
+#              returned zero rows, and a self-join of one odata_read() call had
+#              both scans sharing a single pagination cursor.
+# group: [erpl_web_odata]
+
+require erpl_web
+
+statement ok
+SET autoinstall_known_extensions=1;
+
+statement ok
+SET autoload_known_extensions=1;
+
+statement ok
+SET erpl_trace_enabled=false;
+
+# ============================================================================
+# PREPARE / EXECUTE twice must return the same number of rows
+# ============================================================================
+#
+# $top=12 exceeds the TripPin server page size (8), so the scan also has to
+# follow a @odata.nextLink - i.e. the pagination cursor is exercised on every
+# execution, not just the buffered first page.
+
+statement ok
+PREPARE people_count AS SELECT COUNT(*) FROM odata_read('https://services.odata.org/TripPinRESTierService/People?$top=12');
+
+query I
+EXECUTE people_count;
+----
+12
+
+# The second execution reuses the same bound plan. Before the fix this returned
+# 0 because the bind data's row buffer had been consumed by the first run.
+query I
+EXECUTE people_count;
+----
+12
+
+query I
+EXECUTE people_count;
+----
+12
+
+# The same must hold for a projecting plan, which exercises the per-scan
+# projection state as well.
+statement ok
+PREPARE people_names AS SELECT COUNT(DISTINCT UserName) FROM odata_read('https://services.odata.org/TripPinRESTierService/People?$top=12');
+
+query I
+EXECUTE people_names;
+----
+12
+
+query I
+EXECUTE people_names;
+----
+12
+
+# ============================================================================
+# Self-join: two scans of the same table function inside one query
+# ============================================================================
+
+# Two independent scans of the same odata_read() call must each see all rows.
+# Before the fix the two scans shared the bind data's buffer and cursor, so the
+# join produced far fewer than 12 * 12 rows.
+query I
+SELECT COUNT(*) FROM
+  odata_read('https://services.odata.org/TripPinRESTierService/People?$top=12') a,
+  odata_read('https://services.odata.org/TripPinRESTierService/People?$top=12') b;
+----
+144
+
+query I
+SELECT COUNT(*) FROM
+  odata_read('https://services.odata.org/TripPinRESTierService/People?$top=12') a
+  JOIN odata_read('https://services.odata.org/TripPinRESTierService/People?$top=12') b
+    ON a.UserName = b.UserName;
+----
+12
+
+# A UNION ALL of the same call is another two-scan shape.
+query I
+SELECT COUNT(*) FROM (
+  SELECT UserName FROM odata_read('https://services.odata.org/TripPinRESTierService/People?$top=12')
+  UNION ALL
+  SELECT UserName FROM odata_read('https://services.odata.org/TripPinRESTierService/People?$top=12')
+);
+----
+24
+
+# ============================================================================
+# The same properties for an ATTACHed service (odata_table_scan)
+# ============================================================================
+
+statement ok
+ATTACH 'https://services.odata.org/TripPinRESTierService/' AS trippin (TYPE odata)
+
+# Self-join on the catalog-backed scan. Counted over a projected column rather
+# than with COUNT(*), because COUNT(*) on an ATTACHed OData table is broken
+# independently of this change (GitHub #132, pre-existing on main): the empty
+# projection it produces makes the scan write a string into an INT64 slot.
+query I
+SELECT COUNT(a.AirlineCode) > 0
+  AND COUNT(a.AirlineCode) = (SELECT COUNT(x.AirlineCode) FROM trippin.Airlines x)
+FROM trippin.Airlines a
+JOIN trippin.Airlines b ON a.AirlineCode = b.AirlineCode;
+----
+true
+
+statement ok
+PREPARE airlines_nonempty AS SELECT COUNT(AirlineCode) > 0 FROM trippin.Airlines;
+
+query I
+EXECUTE airlines_nonempty;
+----
+true
+
+# Second execution of the same bound catalog scan.
+query I
+EXECUTE airlines_nonempty;
+----
+true
+
+statement ok
+DETACH trippin;


### PR DESCRIPTION
## #75 — a re-executed bound plan returned zero rows

All mutable scan state — row buffer, paging cursor, emitted-row counter, progress, request client — lived on `ODataReadBindData`. So the second `EXECUTE` of a prepared plan returned nothing, and two scans of the same call shared one cursor.

Verified live, before and after:

```sql
PREPARE p AS SELECT COUNT(*) FROM odata_read('.../TripPinRESTierService/People', top:=12);
EXECUTE p;  EXECUTE p;  EXECUTE p;
-- before: 12, 0, 0
-- after:  12, 12, 12
```

Each execution now gets an independent instance via `CloneForScan()`, owned by a real `GlobalTableFunctionState`.

**Why clone rather than hoist fields into a new struct:** the state is not just fields. The client doubles as the paging cursor, the extractor holds a per-row expand cache, and the pushdown helper captures a resolver bound to the owning instance. Cloning moves the whole entangled set in one step without reaching into `odata_client.hpp`.

`MaxThreads()` is pinned to 1 **with the reason in code** — server-driven pagination makes page N+1 unknowable until page N is read, so there is nothing to partition. The base class already defaulted to 1; this makes it a statement rather than an accident.

It also gives the conversion failure log from #74 the right lifetime: `CloneForScan` builds a fresh one per execution, so failures are reported per scan rather than accumulating across a re-executed plan.

## #88 — values could land under the wrong headers

Catalog columns come from EDMX order; the scan's schema preferred `extracted_column_names`, populated from **JSON key order**. For V2 and Datasphere services (the only ones that populate it) values could land under the wrong headers, and a length mismatch degraded the entire schema to VARCHAR.

The review's analysis was verified independently and holds — including corroborating evidence already in the tree: a pre-existing comment on `GetOriginalColumnName` describes this exact hazard, so someone hit it before and patched one call site instead of the source.

Metadata order is now authoritative; JSON-only names are appended after it, keeping the metadata prefix index-aligned with the catalog. This deletes the all-VARCHAR fallback.

**One deliberate user-visible change:** `odata_read('...?$select=A,B')` against a V2 service used to report a 2-column schema derived from the payload keys; it now reports the full EDMX schema with NULLs for unselected columns. Catalog alignment is the correctness requirement, and one row of one page is an unreliable schema source.

## #86 and #90

`$select` pushdown was gated by a **prefix match against hard-coded TripPin demo property names**, so any service with a column named `Features` or `HomeAddressLine1` silently lost projection pushdown and transferred every column. Replaced with a `LogicalType` check — skip `$select` for nested types, which is what the hack approximated.

The unreachable result-modifier chain is deleted, with the real behaviour (LIMIT is *not* pushed to `$top`; `$top`/`$skip` come only from the named parameters) documented where a reader would look.

## A pre-existing bug this surfaced — filed, not fixed

`SELECT COUNT(*)` on an ATTACHed OData table fails with `Could not convert string 'AA' to INT64`. Confirmed **pre-existing on `main`**, unrelated to this change: it is the empty-projection path, and the plain table function is unaffected. Filed as #132; the new tests count a projected column instead and say why.

## Still outstanding

- **Datasphere still has #75** — `datasphere_read.cpp` has its own init-global functions returning a bare state, and `ResolveScanState` falls back to the legacy path for them. One-line fix, deliberately out of scope here.
- Two ODP `AddResultModifiers` stubs remain for #90 to be fully closed (~8 lines in files being changed concurrently).

## Verification

Full C++ suite **364 cases / 1843 assertions**. Live E2E: `odata_scan_reexecution` (19, new), `odata_conformance_e2e` (22), `odata_v2`, `odata_v4`, `odata_expand` (46), `odata_v2_storage`, `odata_v4_storage`, `web_core` — all green.

Closes #75, closes #86, closes #88, closes #90. Refs #132.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791623591&installation_model_id=425457&pr_number=133&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F133&signature=36a2894964a78ef038a158d100f25cb2b54e0cedcb1f64584220b64108813e85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->