### PR TITLE
fix: harden ODP subscription state, tracing and server-supplied links (#92, #94-#96, #99-#101, #105)

### DIFF
--- a/src/include/odp_request_orchestrator.hpp
+++ b/src/include/odp_request_orchestrator.hpp
@@ -11,6 +11,30 @@
 namespace erpl_web {
 
 /**
+ * @brief An ODP request that came back with an HTTP error status
+ *
+ * Carries the status code and the SAP error code from the response body, so a
+ * caller can decide what to do without pattern-matching the message text. The
+ * body itself is truncated; a full SAP error body is large and carries request
+ * context that should not end up in a log or an audit row (#100, #105).
+ */
+class OdpHttpException : public std::runtime_error {
+public:
+    OdpHttpException(int http_status_code, std::string sap_error_code, const std::string& message)
+        : std::runtime_error(message)
+        , http_status_code_(http_status_code)
+        , sap_error_code_(std::move(sap_error_code))
+    {}
+
+    int HttpStatusCode() const { return http_status_code_; }
+    const std::string& SapErrorCode() const { return sap_error_code_; }
+
+private:
+    int http_status_code_;
+    std::string sap_error_code_;
+};
+
+/**
  * @brief Orchestrates ODP-specific HTTP requests and response processing
  * 
  * This class coordinates between the ODP HTTP factory, OData client, and response
@@ -101,6 +125,26 @@ public:
      * @return Complete delta URL
      */
     static std::string BuildDeltaUrl(const std::string& base_url, const std::string& delta_token);
+
+    /**
+     * @brief True when two URLs share scheme, host and effective port
+     *
+     * Server-supplied next/delta links are followed with the caller's bearer
+     * token; a link pointing elsewhere must not carry it (#101). This mirrors
+     * the cross-origin rule HttpClient already applies to redirects.
+     */
+    static bool IsSameOrigin(const std::string& reference_url, const std::string& candidate_url);
+
+    /**
+     * @brief Percent-encode a delta token for use in a URL query string
+     */
+    static std::string EncodeDeltaToken(const std::string& delta_token);
+
+    /**
+     * @brief Extract the SAP/OData error code from an error response body
+     * @return The code (e.g. "SY/530"), or an empty string when absent
+     */
+    static std::string ExtractErrorCode(const std::string& response_content);
     /**
      * @brief Normalize delta URL (remove quoted token patterns, ensure $format=json)
      */
@@ -124,6 +168,10 @@ private:
     std::shared_ptr<HttpClient> http_client_;
     std::shared_ptr<HttpAuthParams> auth_params_;
     uint32_t default_page_size_;
+    // Origin of the service this orchestrator was pointed at; every
+    // server-supplied follow-up URL is checked against it before credentials
+    // are attached.
+    std::string service_origin_url_;
 
     // Helper methods
     OdpRequestResult ExecuteRequest(const HttpRequest& request, const std::string& operation_type);

--- a/src/include/odp_subscription_repository.hpp
+++ b/src/include/odp_subscription_repository.hpp
@@ -20,14 +20,14 @@ struct OdpSubscription {
     std::chrono::system_clock::time_point last_updated;
     std::string subscription_status; // active, terminated, expired, error
     bool preference_applied;
-    
+
     OdpSubscription() = default;
-    OdpSubscription(const std::string& service_url, const std::string& entity_set_name, 
+    OdpSubscription(const std::string& service_url, const std::string& entity_set_name,
                    const std::string& secret_name = "");
 };
 
 struct OdpAuditEntry {
-    int64_t audit_id; // Auto-increment, set by database
+    int64_t audit_id; // Allocated from a database SEQUENCE
     std::string subscription_id;
     std::string operation_type; // initial_load, delta_fetch, terminate
     std::chrono::system_clock::time_point request_timestamp;
@@ -40,71 +40,109 @@ struct OdpAuditEntry {
     std::string delta_token_after;
     std::string error_message;
     std::optional<int64_t> duration_ms;
-    
+
     OdpAuditEntry() : audit_id(0), rows_fetched(0), package_size_bytes(0) {}
     OdpAuditEntry(const std::string& subscription_id, const std::string& operation_type);
 };
 
-// Repository class for managing ODP subscriptions and audit data
+// Repository class for managing ODP subscriptions and audit data.
+//
+// All statements are prepared with bound parameters -- service URLs, entity set
+// names and delta tokens are attacker-influenced values that must never be
+// interpolated into SQL text (GitHub #99).
+//
+// All objects are qualified with a state catalog that is resolved once, at
+// construction, to a persistent DuckDB catalog. Without that, delta state lands
+// in whatever catalog happens to be default at query time -- an in-memory
+// database that discards the tokens at exit, or a foreign attached database that
+// the service URLs and secret names get exported into (GitHub #92).
 class OdpSubscriptionRepository {
 public:
+    // Layout version of the erpl_web ODP tables. Bumped whenever the columns
+    // change so an older layout is detected rather than silently misread.
+    static constexpr int32_t SCHEMA_VERSION = 1;
+
+    // Upper bound on an error body persisted into the audit table. A full SAP
+    // error body can carry request context and is not worth keeping verbatim.
+    static constexpr size_t MAX_AUDIT_ERROR_LENGTH = 1000;
+
     explicit OdpSubscriptionRepository(duckdb::ClientContext& context);
     ~OdpSubscriptionRepository() = default;
-    
+
     // Non-copyable, non-movable
     OdpSubscriptionRepository(const OdpSubscriptionRepository&) = delete;
     OdpSubscriptionRepository& operator=(const OdpSubscriptionRepository&) = delete;
     OdpSubscriptionRepository(OdpSubscriptionRepository&&) = delete;
     OdpSubscriptionRepository& operator=(OdpSubscriptionRepository&&) = delete;
-    
+
     // Schema management
     void EnsureSchemaExists();
     void EnsureTablesExist();
-    
+
+    // Name of the catalog the ODP state tables live in. Resolved lazily on the
+    // first schema access and stable for the lifetime of the repository.
+    const std::string& GetStateCatalog();
+
     // Subscription management
-    std::string CreateSubscription(const std::string& service_url, 
+    std::string CreateSubscription(const std::string& service_url,
                                  const std::string& entity_set_name,
                                  const std::string& secret_name = "");
     std::optional<OdpSubscription> GetSubscription(const std::string& subscription_id);
-    std::optional<OdpSubscription> FindActiveSubscription(const std::string& service_url, 
+    // Returns the active subscription for the pair, or nullopt when there is
+    // none. A query failure throws rather than being reported as "not found" --
+    // reporting it as not-found triggers a silent full re-extraction (#96).
+    std::optional<OdpSubscription> FindActiveSubscription(const std::string& service_url,
                                                         const std::string& entity_set_name);
     std::vector<OdpSubscription> ListAllSubscriptions();
-    std::vector<OdpSubscription> ListActiveSubscriptions();
-    
-    bool UpdateSubscription(const OdpSubscription& subscription);
-    bool UpdateDeltaToken(const std::string& subscription_id, const std::string& delta_token);
+
+    // Compare-and-swap advance of the delta token. The update only applies when
+    // the stored token still equals expected_delta_token; a concurrent reader
+    // that advanced the stream first makes this throw instead of silently
+    // splitting the delta stream (#95).
+    void AdvanceDeltaToken(const std::string& subscription_id,
+                           const std::string& expected_delta_token,
+                           const std::string& new_delta_token);
     bool UpdateSubscriptionStatus(const std::string& subscription_id, const std::string& status);
     bool RemoveSubscription(const std::string& subscription_id);
-    
+
     // Audit management
     int64_t CreateAuditEntry(const OdpAuditEntry& entry);
     bool UpdateAuditEntry(const OdpAuditEntry& entry);
-    std::vector<OdpAuditEntry> GetAuditHistory(const std::string& subscription_id, 
-                                              int days_back = 30);
-    
+
     // Utility methods
-    static std::string GenerateSubscriptionId(const std::string& service_url, 
+    static std::string GenerateSubscriptionId(const std::string& service_url,
                                              const std::string& entity_set_name);
     static std::string CleanUrlForId(const std::string& url);
+    // True when the path of the URL looks like an ODP entity set (EntityOf*,
+    // FactsOf*, AttrOf*). The query string is stripped before matching -- it
+    // regularly carries $format/$select and made valid URLs fail the check.
     static bool IsValidOdpUrl(const std::string& url);
-    
+    // Truncates an error body to MAX_AUDIT_ERROR_LENGTH, appending an elision
+    // marker when it had to cut.
+    static std::string TruncateForAudit(const std::string& message);
+
 private:
     duckdb::ClientContext& context;
+    std::string state_catalog;
+    std::string qualified_schema; // "catalog"."erpl_web"
     bool schema_initialized;
     bool tables_initialized;
-    
+
     // Helper methods
+    void ResolveStateCatalog();
+    std::string QualifiedTable(const std::string& table_name) const;
     void InitializeSchema();
     void InitializeTables();
-    duckdb::unique_ptr<duckdb::MaterializedQueryResult> ExecuteQuery(const std::string& query);
-    std::string TimestampToString(const std::chrono::system_clock::time_point& tp);
-    std::chrono::system_clock::time_point StringToTimestamp(const std::string& str);
-    
-    // SQL query builders
-    std::string BuildInsertSubscriptionQuery(const OdpSubscription& subscription);
-    std::string BuildUpdateSubscriptionQuery(const OdpSubscription& subscription);
-    std::string BuildInsertAuditQuery(const OdpAuditEntry& entry);
-    std::string BuildUpdateAuditQuery(const OdpAuditEntry& entry);
+    void VerifySchemaVersion();
+
+    // Executes a statement with bound parameters. Throws on any failure; the
+    // SQL text is a fixed template so it carries no caller data.
+    duckdb::unique_ptr<duckdb::MaterializedQueryResult> Execute(const std::string& sql,
+                                                                duckdb::vector<duckdb::Value> params);
+    static int64_t RowsChanged(duckdb::MaterializedQueryResult& result);
+    static duckdb::Value TimePointToValue(const std::chrono::system_clock::time_point& tp);
+    static std::chrono::system_clock::time_point ValueToTimePoint(const duckdb::Value& value);
+    static OdpSubscription RowToSubscription(duckdb::MaterializedQueryResult& result, duckdb::idx_t row);
 };
 
 } // namespace erpl_web

--- a/src/include/odp_subscription_state_manager.hpp
+++ b/src/include/odp_subscription_state_manager.hpp
@@ -67,8 +67,9 @@ public:
     void TransitionToTerminated();
     void TransitionToError(const std::string& error_msg);
 
-    // Persistence operations
-    void PersistSubscription();
+    // Persistence operations. The delta token advance is a compare-and-swap
+    // against the token this session last saw; a concurrent reader that moved
+    // the stream on first makes it throw rather than silently split the stream.
     void UpdateDeltaToken(const std::string& token);
     void UpdateSubscriptionStatus(const std::string& status);
 
@@ -84,6 +85,9 @@ public:
 
     // Utility methods
     static std::string PhaseToString(SubscriptionPhase phase);
+    // Throws unless the token consists only of characters SAP uses in delta
+    // tokens and is of a plausible length.
+    static void ValidateDeltaTokenShape(const std::string& token);
     void LogCurrentState() const;
 
 private:

--- a/src/include/odp_trace_redaction.hpp
+++ b/src/include/odp_trace_redaction.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <map>
+#include <string>
+#include <unordered_set>
+
+namespace erpl_web {
+
+// Trace redaction for ODP requests.
+//
+// A DEBUG trace used to write Authorization headers verbatim, which puts SAP
+// basic-auth passwords and Entra bearer tokens into the trace file (GitHub
+// #100). datazoo-oauth2's http_client.cpp has the same logic, but it is a
+// file-local static there and not exported, so this is a deliberate local copy
+// with the same policy: keep the scheme visible, drop the credential.
+namespace odp_trace {
+
+inline std::string ToLowerAscii(const std::string& value) {
+    std::string lowered = value;
+    std::transform(lowered.begin(), lowered.end(), lowered.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return lowered;
+}
+
+inline bool IsSensitiveHeader(const std::string& name) {
+    static const std::unordered_set<std::string> SENSITIVE_HEADERS = {
+        "authorization", "proxy-authorization", "cookie", "set-cookie",
+        "x-auth-token", "x-api-key", "x-access-token", "x-csrf-token"
+    };
+    return SENSITIVE_HEADERS.count(ToLowerAscii(name)) > 0;
+}
+
+// Returns a value that is safe to write to a trace log. For the two
+// Authorization headers the scheme prefix is kept so the auth type stays
+// diagnosable ("Bearer ***"), everything else collapses to "***".
+inline std::string RedactHeaderValue(const std::string& name, const std::string& value) {
+    if (!IsSensitiveHeader(name)) {
+        return value;
+    }
+
+    const std::string lowered = ToLowerAscii(name);
+    if (lowered == "authorization" || lowered == "proxy-authorization") {
+        const auto space = value.find(' ');
+        if (space != std::string::npos) {
+            return value.substr(0, space + 1) + "***";
+        }
+    }
+    return "***";
+}
+
+// Renders a header map for a trace line with every credential redacted.
+template <typename HeaderMap>
+inline std::string FormatHeaders(const HeaderMap& headers, const std::string& indent = "    ") {
+    std::string rendered;
+    for (const auto& header : headers) {
+        rendered += "\n" + indent + header.first + ": " + RedactHeaderValue(header.first, header.second);
+    }
+    return rendered;
+}
+
+// Caps a server-supplied body before it reaches a log or an audit row: SAP
+// error bodies can be large and carry request context worth not persisting.
+inline std::string TruncateBody(const std::string& body, size_t max_length = 512) {
+    if (body.length() <= max_length) {
+        return body;
+    }
+    return body.substr(0, max_length) + "... [truncated, " + std::to_string(body.length()) + " bytes total]";
+}
+
+} // namespace odp_trace
+} // namespace erpl_web

--- a/src/odp_http_request_factory.cpp
+++ b/src/odp_http_request_factory.cpp
@@ -1,4 +1,5 @@
 #include "odp_http_request_factory.hpp"
+#include "odp_trace_redaction.hpp"
 #include "tracing.hpp"
 #include <sstream>
 
@@ -81,15 +82,14 @@ HttpRequest OdpHttpRequestFactory::CreateRequest(HttpMethod method, const std::s
         ERPL_TRACE_DEBUG("ODP_HTTP_FACTORY", "Applied authentication headers");
     }
     
-    // Log final request configuration
+    // Log final request configuration. Header values are redacted: an
+    // Authorization header written verbatim puts the SAP password or the Entra
+    // bearer token into the trace file (#100).
     std::stringstream trace_msg;
     trace_msg << "Created ODP HTTP request:" << std::endl;
     trace_msg << "  Method: " << method.ToString() << std::endl;
     trace_msg << "  URL: " << url << std::endl;
-    trace_msg << "  Headers:";
-    for (const auto& header : request.headers) {
-        trace_msg << std::endl << "    " << header.first << ": " << header.second;
-    }
+    trace_msg << "  Headers:" << odp_trace::FormatHeaders(request.headers);
     ERPL_TRACE_DEBUG("ODP_HTTP_FACTORY", trace_msg.str());
     
     return request;

--- a/src/odp_odata_read_bind_data.cpp
+++ b/src/odp_odata_read_bind_data.cpp
@@ -1,6 +1,8 @@
 #include "odp_odata_read_bind_data.hpp"
 #include "secret_functions.hpp"
 #include "tracing.hpp"
+#include <algorithm>
+#include <cctype>
 #include <regex>
 
 namespace erpl_web {
@@ -270,8 +272,12 @@ void OdpODataReadBindData::ValidateEntitySetUrl() const {
         throw duckdb::InvalidInputException("Entity set URL cannot be empty");
     }
     
+    // The ODP entity-set naming convention is a hint, not a contract: warn on a
+    // URL that does not match it rather than refusing to read it (#105).
     if (!OdpSubscriptionRepository::IsValidOdpUrl(entity_set_url_)) {
-        throw duckdb::InvalidInputException("Invalid ODP URL: " + entity_set_url_);
+        ERPL_TRACE_WARN("ODP_BIND_DATA",
+            "Entity set URL does not look like an ODP entity set (expected EntityOf*/FactsOf*/AttrOf*): " +
+            entity_set_url_);
     }
     
     ERPL_TRACE_DEBUG("ODP_BIND_DATA", "Entity set URL validation passed");
@@ -346,9 +352,19 @@ bool OdpODataReadBindData::HandleDeltaFetch() {
             ERPL_TRACE_INFO("ODP_BIND_DATA", "Multi-page delta fetch — deferring state transition to last page");
         }
 
-        std::string delta_url = !result.extracted_delta_url.empty()
-            ? result.extracted_delta_url
-            : OdpRequestOrchestrator::BuildDeltaUrl(entity_set_url_, current_token);
+        // The __delta link is server-supplied and becomes the URL the OData
+        // client requests next, with credentials attached. Only adopt it when it
+        // stays on the service's own origin (#101).
+        std::string delta_url = OdpRequestOrchestrator::BuildDeltaUrl(entity_set_url_, current_token);
+        if (!result.extracted_delta_url.empty()) {
+            if (OdpRequestOrchestrator::IsSameOrigin(entity_set_url_, result.extracted_delta_url)) {
+                delta_url = result.extracted_delta_url;
+            } else {
+                ERPL_TRACE_WARN("ODP_BIND_DATA", duckdb::StringUtil::Format(
+                    "Ignoring server-supplied delta link on a different origin than the service (%s -> %s)",
+                    entity_set_url_, result.extracted_delta_url));
+            }
+        }
         ERPL_TRACE_INFO("ODP_BIND_DATA", "Using delta URL for first page injection: " + delta_url);
         UpdateODataClientWithResponse(delta_url, result.response->RawContent());
         return true;
@@ -459,13 +475,26 @@ void OdpODataReadBindData::HandleRequestError(const std::exception& error, const
 }
 
 bool OdpODataReadBindData::IsTokenError(const std::exception& error) const {
-    std::string error_msg = error.what();
-    
-    // Check for common token-related error patterns
-    return error_msg.find("410") != std::string::npos ||  // Gone - token expired
-           error_msg.find("404") != std::string::npos ||  // Not found - token invalid
-           error_msg.find("token") != std::string::npos || // Generic token error
-           error_msg.find("delta") != std::string::npos;   // Delta-related error
+    // Substring-matching the message text used to classify almost any failure as
+    // a token error -- a network message mentioning "delta" was enough -- and
+    // that discards a perfectly good delta token and re-extracts everything
+    // (#94). Only a structured signal counts now.
+    const auto* http_error = dynamic_cast<const OdpHttpException*>(&error);
+    if (!http_error) {
+        return false;
+    }
+
+    // 410 Gone is the OData answer to a delta link that is no longer valid.
+    if (http_error->HttpStatusCode() == 410) {
+        return true;
+    }
+
+    // SAP reports an invalid or expired delta token through the error code in
+    // the payload; the code text carries DELTATOKEN.
+    std::string code = http_error->SapErrorCode();
+    std::transform(code.begin(), code.end(), code.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    return code.find("DELTATOKEN") != std::string::npos;
 }
 
 void OdpODataReadBindData::LogCurrentState() const {

--- a/src/odp_request_orchestrator.cpp
+++ b/src/odp_request_orchestrator.cpp
@@ -1,5 +1,7 @@
 #include "odp_request_orchestrator.hpp"
+#include "odp_trace_redaction.hpp"
 #include "tracing.hpp"
+#include <iomanip>
 #include "yyjson.hpp"
 #include <regex>
 #include <sstream>
@@ -28,6 +30,7 @@ OdpRequestOrchestrator::OdpRequestResult OdpRequestOrchestrator::ExecuteInitialL
     const std::string& url, std::optional<uint32_t> max_page_size) {
     
     ERPL_TRACE_INFO("ODP_ORCHESTRATOR", "Executing initial load for URL: " + url);
+    service_origin_url_ = url;
     
     // Create initial load request with change tracking
     HttpRequest request = http_factory_->CreateInitialLoadRequest(url, max_page_size);
@@ -54,6 +57,7 @@ OdpRequestOrchestrator::OdpRequestResult OdpRequestOrchestrator::ExecuteDeltaFet
             "Normalized delta token from '%s' to '%s",
             delta_token.substr(0, 64), normalized_token.substr(0, 64)));
     }
+    service_origin_url_ = url;
     std::string delta_url = BuildDeltaUrl(url, normalized_token);
     ERPL_TRACE_INFO("ODP_ORCHESTRATOR", "Constructed delta URL: " + delta_url);
     
@@ -68,9 +72,21 @@ OdpRequestOrchestrator::OdpRequestResult OdpRequestOrchestrator::ExecuteNextPage
     
     // Create simple GET request for next page (no special ODP headers needed)
     HttpRequest request(HttpMethod::GET, next_url);
-    
+
+    // The next link comes from the server. Attaching the caller's credentials to
+    // whatever host it names would hand the bearer token to that host, so follow
+    // the rule HttpClient already applies to redirects: same origin keeps the
+    // credentials, anything else does not (#101).
+    const bool same_origin = service_origin_url_.empty() || IsSameOrigin(service_origin_url_, next_url);
+    if (!same_origin) {
+        ERPL_TRACE_WARN("ODP_ORCHESTRATOR", duckdb::StringUtil::Format(
+            "Server-supplied next link points at a different origin than the service (%s -> %s); "
+            "requesting it without credentials",
+            service_origin_url_, next_url));
+    }
+
     // Apply authentication if available
-    if (auth_params_) {
+    if (auth_params_ && same_origin) {
         request.AuthHeadersFromParams(*auth_params_);
     }
     
@@ -136,10 +152,12 @@ std::string OdpRequestOrchestrator::BuildDeltaUrl(const std::string& base_url, c
         has_query = true;
     }
     
-    // Append &!deltatoken=TOKEN
+    // Append &!deltatoken=TOKEN. The token is server-supplied, so it is
+    // percent-encoded rather than pasted in raw: an unescaped '&' or '#' in it
+    // would otherwise change the query the service sees (#105).
     delta_url += has_query ? '&' : '?';
     delta_url += "!deltatoken=";
-    delta_url += delta_token;
+    delta_url += EncodeDeltaToken(delta_token);
     
     ERPL_TRACE_DEBUG("ODP_ORCHESTRATOR", "Built delta URL: " + delta_url);
     return delta_url;
@@ -177,9 +195,15 @@ OdpRequestOrchestrator::OdpRequestResult OdpRequestOrchestrator::ExecuteRequest(
             "HTTP request completed - Status: %d, Size: %zu bytes", 
             result.http_status_code, result.response_size_bytes));
         
-        // Check for HTTP errors
+        // Check for HTTP errors. The status and the SAP error code travel with
+        // the exception so callers do not have to grep the message text (#94),
+        // and the body is truncated before it reaches a log or an audit row.
         if (result.http_status_code >= 400) {
-            throw duckdb::IOException("ODP request failed with HTTP " + std::to_string(result.http_status_code) + ": " + http_response->content);
+            const std::string error_code = ExtractErrorCode(http_response->content);
+            throw OdpHttpException(result.http_status_code, error_code,
+                "ODP request failed with HTTP " + std::to_string(result.http_status_code) +
+                (error_code.empty() ? std::string() : " (" + error_code + ")") + ": " +
+                odp_trace::TruncateBody(http_response->content));
         }
         
         // Process OData response
@@ -229,11 +253,9 @@ void OdpRequestOrchestrator::LogRequestDetails(const HttpRequest& request, const
     log_msg << "Executing " << operation_type << " request:" << std::endl;
     log_msg << "  Method: " << request.method.ToString() << std::endl;
     log_msg << "  URL: " << request.url.ToString() << std::endl;
-    log_msg << "  Headers:";
-    
-    for (const auto& header : request.headers) {
-        log_msg << std::endl << "    " << header.first << ": " << header.second;
-    }
+    // Redacted: an Authorization header written verbatim puts the SAP password
+    // or the Entra bearer token into the trace file (#100).
+    log_msg << "  Headers:" << odp_trace::FormatHeaders(request.headers);
     
     ERPL_TRACE_DEBUG("ODP_ORCHESTRATOR", log_msg.str());
 }
@@ -422,6 +444,62 @@ std::string OdpRequestOrchestrator::EnsureJsonFormat(const std::string& url) {
 
 bool OdpRequestOrchestrator::HasJsonFormat(const std::string& url) {
     return url.find("$format=json") != std::string::npos;
+}
+
+bool OdpRequestOrchestrator::IsSameOrigin(const std::string& reference_url, const std::string& candidate_url) {
+    if (reference_url.empty() || candidate_url.empty()) {
+        return false;
+    }
+    try {
+        HttpUrl reference(reference_url);
+        HttpUrl candidate = HttpUrl::MergeWithBaseUrlIfRelative(reference, candidate_url);
+        return reference.IsSameOrigin(candidate);
+    } catch (const std::exception& e) {
+        // An unparseable link is not a link we should send credentials to.
+        ERPL_TRACE_WARN("ODP_ORCHESTRATOR", "Could not compare origins: " + std::string(e.what()));
+        return false;
+    }
+}
+
+std::string OdpRequestOrchestrator::EncodeDeltaToken(const std::string& delta_token) {
+    std::ostringstream encoded;
+    encoded << std::hex << std::uppercase << std::setfill('0');
+    for (const unsigned char c : delta_token) {
+        const bool is_unreserved = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+                                   c == '-' || c == '_' || c == '.' || c == '~';
+        if (is_unreserved) {
+            encoded << static_cast<char>(c);
+        } else {
+            encoded << '%' << std::setw(2) << static_cast<int>(c);
+        }
+    }
+    return encoded.str();
+}
+
+std::string OdpRequestOrchestrator::ExtractErrorCode(const std::string& response_content) {
+    if (response_content.empty()) {
+        return "";
+    }
+
+    // Both OData v2 and v4 error payloads carry {"error":{"code":"..."}}.
+    auto doc = duckdb_yyjson::yyjson_read(response_content.c_str(), response_content.length(), 0);
+    if (!doc) {
+        return "";
+    }
+
+    std::string code;
+    auto root = duckdb_yyjson::yyjson_doc_get_root(doc);
+    if (root) {
+        auto error_obj = duckdb_yyjson::yyjson_obj_get(root, "error");
+        if (error_obj) {
+            auto code_val = duckdb_yyjson::yyjson_obj_get(error_obj, "code");
+            if (code_val && duckdb_yyjson::yyjson_is_str(code_val)) {
+                code = duckdb_yyjson::yyjson_get_str(code_val);
+            }
+        }
+    }
+    duckdb_yyjson::yyjson_doc_free(doc);
+    return code;
 }
 
 std::string OdpRequestOrchestrator::NormalizeDeltaToken(const std::string& raw) {

--- a/src/odp_subscription_repository.cpp
+++ b/src/odp_subscription_repository.cpp
@@ -1,18 +1,82 @@
 #include "odp_subscription_repository.hpp"
 #include "tracing.hpp"
-#include <sstream>
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/common/exception/transaction_exception.hpp"
+#include "duckdb/main/attached_database.hpp"
+#include "duckdb/main/database_manager.hpp"
+
+#include <algorithm>
+#include <ctime>
 #include <iomanip>
 #include <regex>
-#include <algorithm>
+#include <sstream>
 
 namespace erpl_web {
+
+namespace {
+
+constexpr const char* SCHEMA_NAME = "erpl_web";
+constexpr const char* SUBSCRIPTIONS_TABLE = "odp_subscriptions";
+constexpr const char* AUDIT_TABLE = "odp_subscription_audit";
+constexpr const char* AUDIT_SEQUENCE = "odp_audit_id_seq";
+
+// The full projection of a subscription row; every read uses it so the column
+// indices below stay in one place.
+constexpr const char* SUBSCRIPTION_COLUMNS =
+    "subscription_id, service_url, entity_set_name, secret_name, delta_token, "
+    "created_at, last_updated, subscription_status, preference_applied, schema_version";
+
+enum SubscriptionColumn : duckdb::idx_t {
+    COL_SUBSCRIPTION_ID = 0,
+    COL_SERVICE_URL = 1,
+    COL_ENTITY_SET_NAME = 2,
+    COL_SECRET_NAME = 3,
+    COL_DELTA_TOKEN = 4,
+    COL_CREATED_AT = 5,
+    COL_LAST_UPDATED = 6,
+    COL_SUBSCRIPTION_STATUS = 7,
+    COL_PREFERENCE_APPLIED = 8,
+    COL_SCHEMA_VERSION = 9
+};
+
+std::string QuoteIdentifier(const std::string& name) {
+    return "\"" + duckdb::StringUtil::Replace(name, "\"", "\"\"") + "\"";
+}
+
+// nextval() needs a constant sequence name, so it cannot take a bound
+// parameter; the qualified name goes into a SQL string literal instead.
+std::string QuoteStringLiteral(const std::string& value) {
+    return "'" + duckdb::StringUtil::Replace(value, "'", "''") + "'";
+}
+
+// std::localtime is not reentrant and this runs on DuckDB worker threads.
+std::tm ToLocalTm(std::time_t value) {
+    std::tm out {};
+#ifdef _WIN32
+    localtime_s(&out, &value);
+#else
+    localtime_r(&value, &out);
+#endif
+    return out;
+}
+
+bool IsUsableStateCatalog(duckdb::AttachedDatabase& database) {
+    if (database.IsSystem() || database.IsTemporary()) {
+        return false;
+    }
+    auto& catalog = database.GetCatalog();
+    return catalog.IsDuckCatalog() && !catalog.InMemory();
+}
+
+} // namespace
 
 // ============================================================================
 // OdpSubscription Implementation
 // ============================================================================
 
-OdpSubscription::OdpSubscription(const std::string& service_url, 
-                               const std::string& entity_set_name, 
+OdpSubscription::OdpSubscription(const std::string& service_url,
+                               const std::string& entity_set_name,
                                const std::string& secret_name)
     : service_url(service_url)
     , entity_set_name(entity_set_name)
@@ -30,7 +94,7 @@ OdpSubscription::OdpSubscription(const std::string& service_url,
 // ============================================================================
 
 OdpAuditEntry::OdpAuditEntry(const std::string& subscription_id, const std::string& operation_type)
-    : audit_id(0) // Will be set by database auto-increment
+    : audit_id(0) // Allocated from the audit sequence on insert
     , subscription_id(subscription_id)
     , operation_type(operation_type)
     , request_timestamp(std::chrono::system_clock::now())
@@ -51,404 +115,328 @@ OdpSubscriptionRepository::OdpSubscriptionRepository(duckdb::ClientContext& cont
     ERPL_TRACE_INFO("ODP_REPOSITORY", "OdpSubscriptionRepository initialized");
 }
 
+const std::string& OdpSubscriptionRepository::GetStateCatalog() {
+    ResolveStateCatalog();
+    return state_catalog;
+}
+
+void OdpSubscriptionRepository::ResolveStateCatalog() {
+    if (!state_catalog.empty()) {
+        return;
+    }
+
+    auto& database_manager = duckdb::DatabaseManager::Get(context);
+
+    // Prefer the catalog that is currently default, so an explicit USE keeps
+    // working -- but only when it can actually hold the state durably.
+    const std::string default_name = duckdb::DatabaseManager::GetDefaultDatabase(context);
+    auto default_database = database_manager.GetDatabase(context, default_name);
+    if (default_database && IsUsableStateCatalog(*default_database)) {
+        state_catalog = default_database->GetName();
+    } else {
+        // Otherwise take the first persistent DuckDB catalog, by name, so the
+        // choice does not depend on hash-map iteration order.
+        std::vector<std::string> candidates;
+        for (auto& database : database_manager.GetDatabases(context)) {
+            if (database && IsUsableStateCatalog(*database)) {
+                candidates.push_back(database->GetName());
+            }
+        }
+        std::sort(candidates.begin(), candidates.end());
+        if (!candidates.empty()) {
+            state_catalog = candidates.front();
+        }
+    }
+
+    if (state_catalog.empty()) {
+        throw duckdb::InvalidInputException(
+            "ODP delta state requires a persistent DuckDB database, but this session has none "
+            "attached (the current catalog '" + default_name + "' is in-memory or not a DuckDB "
+            "catalog). Delta tokens stored there are discarded when the session ends, so every "
+            "read would silently become a full extraction. Start DuckDB with a database file "
+            "(for example `duckdb odp_state.db`), or ATTACH one before reading ODP sources "
+            "(for example ATTACH 'odp_state.db' AS odp_state).");
+    }
+
+    qualified_schema = QuoteIdentifier(state_catalog) + "." + QuoteIdentifier(SCHEMA_NAME);
+    ERPL_TRACE_INFO("ODP_REPOSITORY", "Resolved ODP state catalog: " + state_catalog);
+}
+
+std::string OdpSubscriptionRepository::QualifiedTable(const std::string& table_name) const {
+    return qualified_schema + "." + QuoteIdentifier(table_name);
+}
+
 void OdpSubscriptionRepository::EnsureSchemaExists() {
     if (schema_initialized) {
         return;
     }
-    
-    ERPL_TRACE_DEBUG("ODP_REPOSITORY", "Ensuring erpl_web schema exists");
-    
-    try {
-        InitializeSchema();
-        schema_initialized = true;
-        ERPL_TRACE_INFO("ODP_REPOSITORY", "Schema erpl_web initialized successfully");
-    } catch (const std::exception& e) {
-        ERPL_TRACE_ERROR("ODP_REPOSITORY", "Failed to initialize schema: " + std::string(e.what()));
-        throw;
-    }
+
+    ResolveStateCatalog();
+    ERPL_TRACE_DEBUG("ODP_REPOSITORY", "Ensuring erpl_web schema exists in catalog " + state_catalog);
+
+    InitializeSchema();
+    schema_initialized = true;
+    ERPL_TRACE_INFO("ODP_REPOSITORY", "Schema erpl_web initialized successfully");
 }
 
 void OdpSubscriptionRepository::EnsureTablesExist() {
     if (tables_initialized) {
         return;
     }
-    
-    EnsureSchemaExists(); // Ensure schema exists first
-    
+
+    EnsureSchemaExists();
     ERPL_TRACE_DEBUG("ODP_REPOSITORY", "Ensuring ODP tables exist");
-    
-    try {
-        InitializeTables();
-        tables_initialized = true;
-        ERPL_TRACE_INFO("ODP_REPOSITORY", "ODP tables initialized successfully");
-    } catch (const std::exception& e) {
-        ERPL_TRACE_ERROR("ODP_REPOSITORY", "Failed to initialize tables: " + std::string(e.what()));
-        throw;
-    }
+
+    InitializeTables();
+    VerifySchemaVersion();
+    tables_initialized = true;
+    ERPL_TRACE_INFO("ODP_REPOSITORY", "ODP tables initialized successfully");
 }
 
 std::string OdpSubscriptionRepository::CreateSubscription(const std::string& service_url,
                                                         const std::string& entity_set_name,
                                                         const std::string& secret_name) {
     ERPL_TRACE_INFO("ODP_REPOSITORY", duckdb::StringUtil::Format(
-        "Creating subscription for URL: %s, Entity: %s, Secret: %s", 
+        "Creating subscription for URL: %s, Entity: %s, Secret: %s",
         service_url, entity_set_name, secret_name));
-    
+
     EnsureTablesExist();
-    
-    // Validate URL
+
     if (!IsValidOdpUrl(service_url)) {
-        throw duckdb::InvalidInputException("Invalid ODP URL: " + service_url);
+        // A URL that does not look like an ODP entity set is suspicious but not
+        // provably wrong -- the naming convention is a convention, not a rule.
+        ERPL_TRACE_WARN("ODP_REPOSITORY",
+            "Service URL does not look like an ODP entity set (expected EntityOf*/FactsOf*/AttrOf*): " + service_url);
     }
-    
-    // Check if subscription already exists
-    auto existing = FindActiveSubscription(service_url, entity_set_name);
-    if (existing.has_value()) {
-        ERPL_TRACE_WARN("ODP_REPOSITORY", "Active subscription already exists: " + existing->subscription_id);
-        return existing->subscription_id;
-    }
-    
-    // Create new subscription
-    OdpSubscription subscription(service_url, entity_set_name, secret_name);
-    
-    try {
-        auto query = BuildInsertSubscriptionQuery(subscription);
-        ERPL_TRACE_DEBUG("ODP_REPOSITORY", "Executing insert query: " + query);
-        
-        auto result = ExecuteQuery(query);
-        if (!result->HasError()) {
-            ERPL_TRACE_INFO("ODP_REPOSITORY", "Subscription created successfully: " + subscription.subscription_id);
+
+    // (service_url, entity_set_name) is unique, so a stale non-active row for
+    // the same pair is revived rather than duplicated.
+    auto existing = Execute(
+        "SELECT " + std::string(SUBSCRIPTION_COLUMNS) + " FROM " + QualifiedTable(SUBSCRIPTIONS_TABLE) +
+        " WHERE service_url = ? AND entity_set_name = ?",
+        {duckdb::Value(service_url), duckdb::Value(entity_set_name)});
+
+    if (existing->RowCount() > 0) {
+        auto subscription = RowToSubscription(*existing, 0);
+        if (subscription.subscription_status == "active") {
+            ERPL_TRACE_WARN("ODP_REPOSITORY", "Active subscription already exists: " + subscription.subscription_id);
             return subscription.subscription_id;
-        } else {
-            throw duckdb::InternalException("Failed to create subscription: " + result->GetError());
         }
-    } catch (const std::exception& e) {
-        ERPL_TRACE_ERROR("ODP_REPOSITORY", "Error creating subscription: " + std::string(e.what()));
-        throw;
+
+        ERPL_TRACE_INFO("ODP_REPOSITORY", "Reactivating subscription: " + subscription.subscription_id);
+        Execute("UPDATE " + QualifiedTable(SUBSCRIPTIONS_TABLE) +
+                " SET subscription_status = 'active', delta_token = '', preference_applied = FALSE, "
+                "secret_name = ?, last_updated = ? WHERE subscription_id = ?",
+                {duckdb::Value(secret_name.empty() ? "default" : secret_name),
+                 TimePointToValue(std::chrono::system_clock::now()),
+                 duckdb::Value(subscription.subscription_id)});
+        return subscription.subscription_id;
     }
+
+    OdpSubscription subscription(service_url, entity_set_name, secret_name);
+    Execute("INSERT INTO " + QualifiedTable(SUBSCRIPTIONS_TABLE) + " (" + SUBSCRIPTION_COLUMNS + ") "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            {duckdb::Value(subscription.subscription_id),
+             duckdb::Value(subscription.service_url),
+             duckdb::Value(subscription.entity_set_name),
+             duckdb::Value(subscription.secret_name),
+             duckdb::Value(subscription.delta_token),
+             TimePointToValue(subscription.created_at),
+             TimePointToValue(subscription.last_updated),
+             duckdb::Value(subscription.subscription_status),
+             duckdb::Value::BOOLEAN(subscription.preference_applied),
+             duckdb::Value::INTEGER(SCHEMA_VERSION)});
+
+    ERPL_TRACE_INFO("ODP_REPOSITORY", "Subscription created successfully: " + subscription.subscription_id);
+    return subscription.subscription_id;
 }
 
 std::optional<OdpSubscription> OdpSubscriptionRepository::GetSubscription(const std::string& subscription_id) {
     ERPL_TRACE_DEBUG("ODP_REPOSITORY", "Getting subscription: " + subscription_id);
-    
+
     EnsureTablesExist();
-    
-    std::string query = duckdb::StringUtil::Format(
-        "SELECT subscription_id, service_url, entity_set_name, secret_name, delta_token, "
-        "created_at, last_updated, subscription_status, preference_applied "
-        "FROM erpl_web.odp_subscriptions WHERE subscription_id = '%s'",
-        subscription_id);
-    
-    try {
-        auto result = ExecuteQuery(query);
-        if (result->HasError()) {
-            ERPL_TRACE_ERROR("ODP_REPOSITORY", "Query error: " + result->GetError());
-            return std::nullopt;
-        }
-        
-        if (result->RowCount() == 0) {
-            ERPL_TRACE_DEBUG("ODP_REPOSITORY", "Subscription not found: " + subscription_id);
-            return std::nullopt;
-        }
-        
-        // Parse result into OdpSubscription
-        OdpSubscription subscription;
-        subscription.subscription_id = result->GetValue(0, 0).ToString();
-        subscription.service_url = result->GetValue(1, 0).ToString();
-        subscription.entity_set_name = result->GetValue(2, 0).ToString();
-        subscription.secret_name = result->GetValue(3, 0).ToString();
-        subscription.delta_token = result->GetValue(4, 0).ToString();
-        ERPL_TRACE_INFO("ODP_REPOSITORY", duckdb::StringUtil::Format(
-            "Loaded subscription %s with token: %s",
-            subscription_id,
-            subscription.delta_token.empty() ? "<EMPTY>" : subscription.delta_token.substr(0, 64)));
-        subscription.created_at = StringToTimestamp(result->GetValue(5, 0).ToString());
-        subscription.last_updated = StringToTimestamp(result->GetValue(6, 0).ToString());
-        subscription.subscription_status = result->GetValue(7, 0).ToString();
-        subscription.preference_applied = result->GetValue(8, 0).GetValue<bool>();
-        
-        ERPL_TRACE_DEBUG("ODP_REPOSITORY", "Subscription found: " + subscription_id);
-        return subscription;
-        
-    } catch (const std::exception& e) {
-        ERPL_TRACE_ERROR("ODP_REPOSITORY", "Error getting subscription: " + std::string(e.what()));
+
+    auto result = Execute(
+        "SELECT " + std::string(SUBSCRIPTION_COLUMNS) + " FROM " + QualifiedTable(SUBSCRIPTIONS_TABLE) +
+        " WHERE subscription_id = ?",
+        {duckdb::Value(subscription_id)});
+
+    if (result->RowCount() == 0) {
+        ERPL_TRACE_DEBUG("ODP_REPOSITORY", "Subscription not found: " + subscription_id);
         return std::nullopt;
     }
+
+    return RowToSubscription(*result, 0);
 }
 
 std::optional<OdpSubscription> OdpSubscriptionRepository::FindActiveSubscription(
     const std::string& service_url, const std::string& entity_set_name) {
-    
+
     ERPL_TRACE_DEBUG("ODP_REPOSITORY", duckdb::StringUtil::Format(
         "Finding active subscription for URL: %s, Entity: %s", service_url, entity_set_name));
-    
+
     EnsureTablesExist();
-    
-    std::string query = duckdb::StringUtil::Format(
-        "SELECT subscription_id, service_url, entity_set_name, secret_name, delta_token, "
-        "created_at, last_updated, subscription_status, preference_applied "
-        "FROM erpl_web.odp_subscriptions "
-        "WHERE service_url = '%s' AND entity_set_name = '%s' AND subscription_status = 'active' "
+
+    // Note the absence of a try/catch: a failing query must surface, not be
+    // reported as "no subscription" -- that answer silently restarts the whole
+    // extraction from scratch (#96).
+    auto result = Execute(
+        "SELECT " + std::string(SUBSCRIPTION_COLUMNS) + " FROM " + QualifiedTable(SUBSCRIPTIONS_TABLE) +
+        " WHERE service_url = ? AND entity_set_name = ? AND subscription_status = 'active' "
         "ORDER BY created_at DESC LIMIT 1",
-        service_url, entity_set_name);
-    
-    try {
-        auto result = ExecuteQuery(query);
-        if (result->HasError() || result->RowCount() == 0) {
-            return std::nullopt;
-        }
-        
-        // Parse result into OdpSubscription (same logic as GetSubscription)
-        OdpSubscription subscription;
-        subscription.subscription_id = result->GetValue(0, 0).ToString();
-        subscription.service_url = result->GetValue(1, 0).ToString();
-        subscription.entity_set_name = result->GetValue(2, 0).ToString();
-        subscription.secret_name = result->GetValue(3, 0).ToString();
-        subscription.delta_token = result->GetValue(4, 0).ToString();
-        subscription.created_at = StringToTimestamp(result->GetValue(5, 0).ToString());
-        subscription.last_updated = StringToTimestamp(result->GetValue(6, 0).ToString());
-        subscription.subscription_status = result->GetValue(7, 0).ToString();
-        subscription.preference_applied = result->GetValue(8, 0).GetValue<bool>();
-        
-        ERPL_TRACE_DEBUG("ODP_REPOSITORY", "Active subscription found: " + subscription.subscription_id);
-        return subscription;
-        
-    } catch (const std::exception& e) {
-        ERPL_TRACE_ERROR("ODP_REPOSITORY", "Error finding active subscription: " + std::string(e.what()));
+        {duckdb::Value(service_url), duckdb::Value(entity_set_name)});
+
+    if (result->RowCount() == 0) {
         return std::nullopt;
     }
+
+    auto subscription = RowToSubscription(*result, 0);
+    ERPL_TRACE_DEBUG("ODP_REPOSITORY", "Active subscription found: " + subscription.subscription_id);
+    return subscription;
 }
 
 std::vector<OdpSubscription> OdpSubscriptionRepository::ListAllSubscriptions() {
     ERPL_TRACE_DEBUG("ODP_REPOSITORY", "Listing all subscriptions");
-    
+
     EnsureTablesExist();
-    
-    std::string query = 
-        "SELECT subscription_id, service_url, entity_set_name, secret_name, delta_token, "
-        "created_at, last_updated, subscription_status, preference_applied "
-        "FROM erpl_web.odp_subscriptions "
-        "ORDER BY created_at DESC";
-    
+
+    auto result = Execute(
+        "SELECT " + std::string(SUBSCRIPTION_COLUMNS) + " FROM " + QualifiedTable(SUBSCRIPTIONS_TABLE) +
+        " ORDER BY created_at DESC", {});
+
     std::vector<OdpSubscription> subscriptions;
-    
-    try {
-        auto result = ExecuteQuery(query);
-        if (result->HasError()) {
-            ERPL_TRACE_ERROR("ODP_REPOSITORY", "Query error: " + result->GetError());
-            return subscriptions;
-        }
-        
-        for (duckdb::idx_t i = 0; i < result->RowCount(); i++) {
-            OdpSubscription subscription;
-            subscription.subscription_id = result->GetValue(0, i).ToString();
-            subscription.service_url = result->GetValue(1, i).ToString();
-            subscription.entity_set_name = result->GetValue(2, i).ToString();
-            subscription.secret_name = result->GetValue(3, i).ToString();
-            subscription.delta_token = result->GetValue(4, i).ToString();
-            subscription.created_at = StringToTimestamp(result->GetValue(5, i).ToString());
-            subscription.last_updated = StringToTimestamp(result->GetValue(6, i).ToString());
-            subscription.subscription_status = result->GetValue(7, i).ToString();
-            subscription.preference_applied = result->GetValue(8, i).GetValue<bool>();
-            
-            subscriptions.push_back(subscription);
-        }
-        
-        ERPL_TRACE_INFO("ODP_REPOSITORY", duckdb::StringUtil::Format("Found %d subscriptions", subscriptions.size()));
-        return subscriptions;
-        
-    } catch (const std::exception& e) {
-        ERPL_TRACE_ERROR("ODP_REPOSITORY", "Error listing subscriptions: " + std::string(e.what()));
-        return subscriptions;
+    subscriptions.reserve(result->RowCount());
+    for (duckdb::idx_t i = 0; i < result->RowCount(); i++) {
+        subscriptions.push_back(RowToSubscription(*result, i));
     }
+
+    ERPL_TRACE_INFO("ODP_REPOSITORY", duckdb::StringUtil::Format("Found %d subscriptions", subscriptions.size()));
+    return subscriptions;
 }
 
-bool OdpSubscriptionRepository::UpdateDeltaToken(const std::string& subscription_id, 
-                                                const std::string& delta_token) {
-    ERPL_TRACE_DEBUG("ODP_REPOSITORY", duckdb::StringUtil::Format(
-        "Updating delta token for subscription %s: %s", subscription_id, delta_token));
-    
+void OdpSubscriptionRepository::AdvanceDeltaToken(const std::string& subscription_id,
+                                                  const std::string& expected_delta_token,
+                                                  const std::string& new_delta_token) {
+    ERPL_TRACE_DEBUG("ODP_REPOSITORY", "Advancing delta token for subscription " + subscription_id);
+
     EnsureTablesExist();
-    
-    // First check if subscription exists
-    auto existing = GetSubscription(subscription_id);
-    if (!existing.has_value()) {
-        ERPL_TRACE_WARN("ODP_REPOSITORY", "No subscription found with ID: " + subscription_id);
-        return false;
+
+    auto result = Execute(
+        "UPDATE " + QualifiedTable(SUBSCRIPTIONS_TABLE) +
+        " SET delta_token = ?, last_updated = ? "
+        "WHERE subscription_id = ? AND delta_token IS NOT DISTINCT FROM ?",
+        {duckdb::Value(new_delta_token),
+         TimePointToValue(std::chrono::system_clock::now()),
+         duckdb::Value(subscription_id),
+         duckdb::Value(expected_delta_token)});
+
+    if (RowsChanged(*result) > 0) {
+        ERPL_TRACE_INFO("ODP_REPOSITORY", "Delta token advanced for subscription " + subscription_id);
+        return;
     }
-    
-    // Escape single quotes in delta token to prevent SQL injection
-    auto escape_sql = [](const std::string &s) {
-        std::string out;
-        out.reserve(s.size() + 8);
-        for (char c : s) {
-            if (c == '\'') {
-                out += "''";
-            } else {
-                out += c;
-            }
-        }
-        return out;
-    };
-    
-    std::string query = duckdb::StringUtil::Format(
-        "UPDATE erpl_web.odp_subscriptions "
-        "SET delta_token = '%s', last_updated = NOW() "
-        "WHERE subscription_id = '%s'",
-        escape_sql(delta_token), escape_sql(subscription_id));
-    
-    try {
-        auto result = ExecuteQuery(query);
-        if (result->HasError()) {
-            ERPL_TRACE_ERROR("ODP_REPOSITORY", "Update error: " + result->GetError());
-            return false;
-        }
-        
-        ERPL_TRACE_INFO("ODP_REPOSITORY", "Delta token updated successfully");
-        return true;
-        
-    } catch (const std::exception& e) {
-        ERPL_TRACE_ERROR("ODP_REPOSITORY", "Error updating delta token: " + std::string(e.what()));
-        return false;
+
+    // Nothing changed: either the subscription is gone, or another session
+    // advanced the same delta stream while this one was fetching.
+    auto current = Execute(
+        "SELECT delta_token FROM " + QualifiedTable(SUBSCRIPTIONS_TABLE) + " WHERE subscription_id = ?",
+        {duckdb::Value(subscription_id)});
+
+    if (current->RowCount() == 0) {
+        throw duckdb::InvalidInputException(
+            "ODP subscription '" + subscription_id + "' no longer exists; its delta token could not be advanced.");
     }
+
+    throw duckdb::TransactionException(
+        "Concurrent modification of ODP subscription '" + subscription_id + "': the stored delta token changed "
+        "while this read was running, so another session is reading the same delta stream. Continuing would split "
+        "the change stream between the two readers. Re-run the query once the other reader has finished.");
 }
 
-bool OdpSubscriptionRepository::UpdateSubscription(const OdpSubscription& subscription) {
-    ERPL_TRACE_DEBUG("ODP_REPOSITORY", "Updating subscription: " + subscription.subscription_id);
-    
-    EnsureTablesExist();
-    
-    std::string query = duckdb::StringUtil::Format(
-        "UPDATE erpl_web.odp_subscriptions "
-        "SET service_url = '%s', entity_set_name = '%s', secret_name = '%s', "
-        "delta_token = '%s', subscription_status = '%s', preference_applied = %s, "
-        "last_updated = NOW() "
-        "WHERE subscription_id = '%s'",
-        subscription.service_url, subscription.entity_set_name, subscription.secret_name,
-        subscription.delta_token, subscription.subscription_status, 
-        subscription.preference_applied ? "true" : "false",
-        subscription.subscription_id);
-    
-    try {
-        auto result = ExecuteQuery(query);
-        if (result->HasError()) {
-            ERPL_TRACE_ERROR("ODP_REPOSITORY", "Update error: " + result->GetError());
-            return false;
-        }
-        
-        // Check if any rows were affected
-        if (result->RowCount() == 0) {
-            ERPL_TRACE_WARN("ODP_REPOSITORY", "No subscription found with ID: " + subscription.subscription_id);
-            return false;
-        }
-        
-        ERPL_TRACE_DEBUG("ODP_REPOSITORY", "Subscription updated successfully");
-        return true;
-        
-    } catch (const std::exception& e) {
-        ERPL_TRACE_ERROR("ODP_REPOSITORY", "Error updating subscription: " + std::string(e.what()));
-        return false;
-    }
-}
-
-bool OdpSubscriptionRepository::UpdateSubscriptionStatus(const std::string& subscription_id, 
+bool OdpSubscriptionRepository::UpdateSubscriptionStatus(const std::string& subscription_id,
                                                        const std::string& status) {
     ERPL_TRACE_DEBUG("ODP_REPOSITORY", duckdb::StringUtil::Format(
         "Updating subscription status for %s: %s", subscription_id, status));
-    
+
     EnsureTablesExist();
-    
-    // First check if subscription exists
-    auto existing = GetSubscription(subscription_id);
-    if (!existing.has_value()) {
+
+    auto result = Execute(
+        "UPDATE " + QualifiedTable(SUBSCRIPTIONS_TABLE) + " SET subscription_status = ?, last_updated = ? "
+        "WHERE subscription_id = ?",
+        {duckdb::Value(status),
+         TimePointToValue(std::chrono::system_clock::now()),
+         duckdb::Value(subscription_id)});
+
+    if (RowsChanged(*result) == 0) {
         ERPL_TRACE_WARN("ODP_REPOSITORY", "No subscription found with ID: " + subscription_id);
         return false;
     }
-    
-    std::string query = duckdb::StringUtil::Format(
-        "UPDATE erpl_web.odp_subscriptions "
-        "SET subscription_status = '%s', last_updated = NOW() "
-        "WHERE subscription_id = '%s'",
-        status, subscription_id);
-    
-    try {
-        auto result = ExecuteQuery(query);
-        if (result->HasError()) {
-            ERPL_TRACE_ERROR("ODP_REPOSITORY", "Update error: " + result->GetError());
-            return false;
-        }
-        
-        ERPL_TRACE_DEBUG("ODP_REPOSITORY", "Subscription status updated successfully");
-        return true;
-        
-    } catch (const std::exception& e) {
-        ERPL_TRACE_ERROR("ODP_REPOSITORY", "Error updating subscription status: " + std::string(e.what()));
-        return false;
-    }
+
+    ERPL_TRACE_DEBUG("ODP_REPOSITORY", "Subscription status updated successfully");
+    return true;
 }
 
 bool OdpSubscriptionRepository::RemoveSubscription(const std::string& subscription_id) {
     ERPL_TRACE_INFO("ODP_REPOSITORY", "Removing subscription: " + subscription_id);
-    
+
     EnsureTablesExist();
-    
-    // First check if subscription exists
-    auto existing = GetSubscription(subscription_id);
-    if (!existing.has_value()) {
+
+    auto result = Execute(
+        "DELETE FROM " + QualifiedTable(SUBSCRIPTIONS_TABLE) + " WHERE subscription_id = ?",
+        {duckdb::Value(subscription_id)});
+
+    if (RowsChanged(*result) == 0) {
         ERPL_TRACE_WARN("ODP_REPOSITORY", "No subscription found with ID: " + subscription_id);
         return false;
     }
-    
-    std::string query = duckdb::StringUtil::Format(
-        "DELETE FROM erpl_web.odp_subscriptions WHERE subscription_id = '%s'",
-        subscription_id);
-    
-    try {
-        auto result = ExecuteQuery(query);
-        if (result->HasError()) {
-            ERPL_TRACE_ERROR("ODP_REPOSITORY", "Delete error: " + result->GetError());
-            return false;
-        }
-        
-        ERPL_TRACE_INFO("ODP_REPOSITORY", "Subscription removed successfully");
-        return true;
-        
-    } catch (const std::exception& e) {
-        ERPL_TRACE_ERROR("ODP_REPOSITORY", "Error removing subscription: " + std::string(e.what()));
-        return false;
-    }
+
+    ERPL_TRACE_INFO("ODP_REPOSITORY", "Subscription removed successfully");
+    return true;
 }
 
 int64_t OdpSubscriptionRepository::CreateAuditEntry(const OdpAuditEntry& entry) {
     ERPL_TRACE_DEBUG("ODP_REPOSITORY", duckdb::StringUtil::Format(
-        "Creating audit entry for subscription %s, operation: %s", 
+        "Creating audit entry for subscription %s, operation: %s",
         entry.subscription_id, entry.operation_type));
-    
+
     EnsureTablesExist();
-    
+
     try {
-        // Generate a unique audit_id using timestamp + random component
-        auto now = std::chrono::system_clock::now();
-        auto timestamp = std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count();
-        int64_t audit_id = timestamp;
-        
-        // Create a copy of the entry with the generated ID
-        OdpAuditEntry entry_with_id = entry;
-        entry_with_id.audit_id = audit_id;
-        
-        auto query = BuildInsertAuditQuery(entry_with_id);
-        ERPL_TRACE_DEBUG("ODP_REPOSITORY", "Executing audit insert query: " + query);
-        
-        auto result = ExecuteQuery(query);
-        if (result->HasError()) {
-            ERPL_TRACE_ERROR("ODP_REPOSITORY", "Audit insert error: " + result->GetError());
+        // The id comes from a sequence: a max(audit_id)+1 read-modify-write hands
+        // the same id to two concurrent readers (#95).
+        auto result = Execute(
+            "INSERT INTO " + QualifiedTable(AUDIT_TABLE) +
+            " (audit_id, subscription_id, operation_type, request_timestamp, response_timestamp, "
+            "request_url, http_status_code, rows_fetched, package_size_bytes, "
+            "delta_token_before, delta_token_after, error_message, duration_ms) "
+            "VALUES (nextval(" + QuoteStringLiteral(qualified_schema + "." + QuoteIdentifier(AUDIT_SEQUENCE)) + "), "
+            "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING audit_id",
+            {duckdb::Value(entry.subscription_id),
+             duckdb::Value(entry.operation_type),
+             TimePointToValue(entry.request_timestamp),
+             entry.response_timestamp.has_value() ? TimePointToValue(entry.response_timestamp.value())
+                                                  : duckdb::Value(duckdb::LogicalType::TIMESTAMP),
+             duckdb::Value(entry.request_url),
+             entry.http_status_code.has_value() ? duckdb::Value::INTEGER(entry.http_status_code.value())
+                                                : duckdb::Value(duckdb::LogicalType::INTEGER),
+             duckdb::Value::BIGINT(entry.rows_fetched),
+             duckdb::Value::BIGINT(entry.package_size_bytes),
+             duckdb::Value(entry.delta_token_before),
+             duckdb::Value(entry.delta_token_after),
+             duckdb::Value(TruncateForAudit(entry.error_message)),
+             entry.duration_ms.has_value() ? duckdb::Value::BIGINT(entry.duration_ms.value())
+                                           : duckdb::Value(duckdb::LogicalType::BIGINT)});
+
+        if (result->RowCount() == 0) {
+            ERPL_TRACE_WARN("ODP_REPOSITORY", "Audit insert returned no id");
             return -1;
         }
-        
+
+        int64_t audit_id = result->GetValue(0, 0).GetValue<int64_t>();
         ERPL_TRACE_INFO("ODP_REPOSITORY", duckdb::StringUtil::Format("Audit entry created with ID: %lld", audit_id));
         return audit_id;
-        
+
     } catch (const std::exception& e) {
+        // Audit is a side channel: losing a row must not fail the read.
         ERPL_TRACE_ERROR("ODP_REPOSITORY", "Error creating audit entry: " + std::string(e.what()));
         return -1;
     }
@@ -456,53 +444,30 @@ int64_t OdpSubscriptionRepository::CreateAuditEntry(const OdpAuditEntry& entry) 
 
 bool OdpSubscriptionRepository::UpdateAuditEntry(const OdpAuditEntry& entry) {
     ERPL_TRACE_DEBUG("ODP_REPOSITORY", duckdb::StringUtil::Format(
-        "Updating audit entry %lld for subscription %s", 
+        "Updating audit entry %lld for subscription %s",
         entry.audit_id, entry.subscription_id));
-    
+
     EnsureTablesExist();
-    
-    // Escape single quotes in string fields to prevent SQL injection
-    auto escape_sql = [](const std::string &s) {
-        std::string out;
-        out.reserve(s.size() + 8);
-        for (char c : s) {
-            if (c == '\'') {
-                out += "''";
-            } else {
-                out += c;
-            }
-        }
-        return out;
-    };
-    
-    std::string query = duckdb::StringUtil::Format(
-        "UPDATE erpl_web.odp_subscription_audit "
-        "SET response_timestamp = NOW(), "
-        "http_status_code = %s, "
-        "rows_fetched = %lld, "
-        "package_size_bytes = %lld, "
-        "delta_token_after = '%s', "
-        "error_message = '%s', "
-        "duration_ms = %s "
-        "WHERE audit_id = %lld",
-        entry.http_status_code.has_value() ? std::to_string(entry.http_status_code.value()) : "NULL",
-        entry.rows_fetched,
-        entry.package_size_bytes,
-        escape_sql(entry.delta_token_after),
-        escape_sql(entry.error_message),
-        entry.duration_ms.has_value() ? std::to_string(entry.duration_ms.value()) : "NULL",
-        entry.audit_id);
-    
+
     try {
-        auto result = ExecuteQuery(query);
-        if (result->HasError()) {
-            ERPL_TRACE_ERROR("ODP_REPOSITORY", "Audit update error: " + result->GetError());
-            return false;
-        }
-        
+        auto result = Execute(
+            "UPDATE " + QualifiedTable(AUDIT_TABLE) + " SET response_timestamp = ?, http_status_code = ?, "
+            "rows_fetched = ?, package_size_bytes = ?, delta_token_after = ?, error_message = ?, duration_ms = ? "
+            "WHERE audit_id = ?",
+            {TimePointToValue(std::chrono::system_clock::now()),
+             entry.http_status_code.has_value() ? duckdb::Value::INTEGER(entry.http_status_code.value())
+                                                : duckdb::Value(duckdb::LogicalType::INTEGER),
+             duckdb::Value::BIGINT(entry.rows_fetched),
+             duckdb::Value::BIGINT(entry.package_size_bytes),
+             duckdb::Value(entry.delta_token_after),
+             duckdb::Value(TruncateForAudit(entry.error_message)),
+             entry.duration_ms.has_value() ? duckdb::Value::BIGINT(entry.duration_ms.value())
+                                           : duckdb::Value(duckdb::LogicalType::BIGINT),
+             duckdb::Value::BIGINT(entry.audit_id)});
+
         ERPL_TRACE_DEBUG("ODP_REPOSITORY", "Audit entry updated successfully");
-        return true;
-        
+        return RowsChanged(*result) > 0;
+
     } catch (const std::exception& e) {
         ERPL_TRACE_ERROR("ODP_REPOSITORY", "Error updating audit entry: " + std::string(e.what()));
         return false;
@@ -517,18 +482,17 @@ std::string OdpSubscriptionRepository::GenerateSubscriptionId(const std::string&
                                                              const std::string& entity_set_name) {
     // Generate timestamp prefix: YYYYMMDD_HHMMSS
     auto now = std::chrono::system_clock::now();
-    auto time_t = std::chrono::system_clock::to_time_t(now);
-    auto tm = *std::localtime(&time_t);
-    
+    auto now_time = std::chrono::system_clock::to_time_t(now);
+    auto local_tm = ToLocalTm(now_time);
+
     std::ostringstream timestamp_stream;
-    timestamp_stream << std::put_time(&tm, "%Y%m%d_%H%M%S");
-    
-    // Clean and combine URL and entity set name
+    timestamp_stream << std::put_time(&local_tm, "%Y%m%d_%H%M%S");
+
     std::string cleaned_url = CleanUrlForId(service_url);
     std::string cleaned_entity = CleanUrlForId(entity_set_name);
-    
+
     std::string subscription_id = timestamp_stream.str() + "_" + cleaned_url + "_" + cleaned_entity;
-    
+
     ERPL_TRACE_DEBUG("ODP_REPOSITORY", "Generated subscription ID: " + subscription_id);
     return subscription_id;
 }
@@ -536,44 +500,60 @@ std::string OdpSubscriptionRepository::GenerateSubscriptionId(const std::string&
 std::string OdpSubscriptionRepository::CleanUrlForId(const std::string& url) {
     // Remove protocol, replace special characters with underscores
     std::string cleaned = url;
-    
-    // Remove http:// or https://
+
     std::regex protocol_regex("^https?://");
     cleaned = std::regex_replace(cleaned, protocol_regex, "");
-    
-    // Replace special characters with underscores
+
     std::regex special_chars_regex("[^a-zA-Z0-9_]");
     cleaned = std::regex_replace(cleaned, special_chars_regex, "_");
-    
-    // Remove multiple consecutive underscores
+
     std::regex multiple_underscores_regex("_{2,}");
     cleaned = std::regex_replace(cleaned, multiple_underscores_regex, "_");
-    
-    // Remove leading/trailing underscores
+
     if (!cleaned.empty() && cleaned.front() == '_') {
         cleaned = cleaned.substr(1);
     }
     if (!cleaned.empty() && cleaned.back() == '_') {
         cleaned = cleaned.substr(0, cleaned.length() - 1);
     }
-    
-    // Limit length to reasonable size
+
     if (cleaned.length() > 100) {
         cleaned = cleaned.substr(0, 100);
     }
-    
+
     return cleaned;
 }
 
 bool OdpSubscriptionRepository::IsValidOdpUrl(const std::string& url) {
-    // Check for ODP naming patterns: EntityOf* or FactsOf* or AttrOf*
+    // Match on the path only. Matching the whole URL made every service URL that
+    // already carried a query string (?$format=json, ?$select=...) fail (#105).
+    std::string path = url;
+    auto fragment_pos = path.find('#');
+    if (fragment_pos != std::string::npos) {
+        path = path.substr(0, fragment_pos);
+    }
+    auto query_pos = path.find('?');
+    if (query_pos != std::string::npos) {
+        path = path.substr(0, query_pos);
+    }
+    while (!path.empty() && path.back() == '/') {
+        path.pop_back();
+    }
+
     std::regex odp_pattern(".*/(EntityOf|FactsOf|AttrOf)[^/]*$", std::regex_constants::icase);
-    bool is_odp = std::regex_search(url, odp_pattern);
-    
+    bool is_odp = std::regex_search(path, odp_pattern);
+
     ERPL_TRACE_DEBUG("ODP_REPOSITORY", duckdb::StringUtil::Format(
         "URL validation for %s: %s", url, is_odp ? "VALID" : "INVALID"));
-    
+
     return is_odp;
+}
+
+std::string OdpSubscriptionRepository::TruncateForAudit(const std::string& message) {
+    if (message.length() <= MAX_AUDIT_ERROR_LENGTH) {
+        return message;
+    }
+    return message.substr(0, MAX_AUDIT_ERROR_LENGTH) + "... [truncated]";
 }
 
 // ============================================================================
@@ -581,171 +561,138 @@ bool OdpSubscriptionRepository::IsValidOdpUrl(const std::string& url) {
 // ============================================================================
 
 void OdpSubscriptionRepository::InitializeSchema() {
-    std::string query = "CREATE SCHEMA IF NOT EXISTS erpl_web";
-    auto result = ExecuteQuery(query);
-    if (result->HasError()) {
-        throw duckdb::InternalException("Failed to create schema: " + result->GetError());
-    }
+    Execute("CREATE SCHEMA IF NOT EXISTS " + qualified_schema, {});
 }
 
 void OdpSubscriptionRepository::InitializeTables() {
-    // Create subscriptions table
-    std::string subscriptions_query = R"(
-        CREATE TABLE IF NOT EXISTS erpl_web.odp_subscriptions (
-            subscription_id VARCHAR PRIMARY KEY,
-            service_url VARCHAR NOT NULL,
-            entity_set_name VARCHAR NOT NULL,
-            secret_name VARCHAR,
-            delta_token VARCHAR,
-            created_at TIMESTAMP DEFAULT NOW(),
-            last_updated TIMESTAMP DEFAULT NOW(),
-            subscription_status VARCHAR DEFAULT 'active',
-            preference_applied BOOLEAN DEFAULT FALSE
-        )
-    )";
-    
-    auto result = ExecuteQuery(subscriptions_query);
-    if (result->HasError()) {
-        throw duckdb::InternalException("Failed to create subscriptions table: " + result->GetError());
-    }
-    
-    // Create audit table
-    std::string audit_query = R"(
-        CREATE TABLE IF NOT EXISTS erpl_web.odp_subscription_audit (
-            audit_id BIGINT PRIMARY KEY,
-            subscription_id VARCHAR NOT NULL,
-            operation_type VARCHAR NOT NULL,
-            request_timestamp TIMESTAMP DEFAULT NOW(),
-            response_timestamp TIMESTAMP,
-            request_url VARCHAR,
-            http_status_code INTEGER,
-            rows_fetched BIGINT DEFAULT 0,
-            package_size_bytes BIGINT DEFAULT 0,
-            delta_token_before VARCHAR,
-            delta_token_after VARCHAR,
-            error_message VARCHAR,
-            duration_ms BIGINT
-        )
-    )";
-    
-    result = ExecuteQuery(audit_query);
-    if (result->HasError()) {
-        throw duckdb::InternalException("Failed to create audit table: " + result->GetError());
+    Execute("CREATE TABLE IF NOT EXISTS " + QualifiedTable(SUBSCRIPTIONS_TABLE) + " ("
+            "subscription_id VARCHAR PRIMARY KEY, "
+            "service_url VARCHAR NOT NULL, "
+            "entity_set_name VARCHAR NOT NULL, "
+            "secret_name VARCHAR, "
+            "delta_token VARCHAR, "
+            "created_at TIMESTAMP DEFAULT NOW(), "
+            "last_updated TIMESTAMP DEFAULT NOW(), "
+            "subscription_status VARCHAR DEFAULT 'active', "
+            "preference_applied BOOLEAN DEFAULT FALSE, "
+            "schema_version INTEGER NOT NULL DEFAULT 1, "
+            // One subscription per source: without it two sessions racing on the
+            // first read each insert their own row and split the delta stream.
+            "UNIQUE (service_url, entity_set_name))", {});
+
+    Execute("CREATE SEQUENCE IF NOT EXISTS " + qualified_schema + "." + QuoteIdentifier(AUDIT_SEQUENCE) +
+            " START 1", {});
+
+    Execute("CREATE TABLE IF NOT EXISTS " + QualifiedTable(AUDIT_TABLE) + " ("
+            "audit_id BIGINT PRIMARY KEY, "
+            "subscription_id VARCHAR NOT NULL, "
+            "operation_type VARCHAR NOT NULL, "
+            "request_timestamp TIMESTAMP DEFAULT NOW(), "
+            "response_timestamp TIMESTAMP, "
+            "request_url VARCHAR, "
+            "http_status_code INTEGER, "
+            "rows_fetched BIGINT DEFAULT 0, "
+            "package_size_bytes BIGINT DEFAULT 0, "
+            "delta_token_before VARCHAR, "
+            "delta_token_after VARCHAR, "
+            "error_message VARCHAR, "
+            "duration_ms BIGINT)", {});
+}
+
+void OdpSubscriptionRepository::VerifySchemaVersion() {
+    // CREATE TABLE IF NOT EXISTS silently accepts a pre-existing table with an
+    // older layout. Detect that here instead of misreading its rows (#96).
+    auto result = Execute(
+        "SELECT count(*) FROM duckdb_columns() WHERE database_name = ? AND schema_name = ? "
+        "AND table_name = ? AND column_name = 'schema_version'",
+        {duckdb::Value(state_catalog), duckdb::Value(SCHEMA_NAME), duckdb::Value(SUBSCRIPTIONS_TABLE)});
+
+    const int64_t column_count = result->RowCount() > 0 ? result->GetValue(0, 0).GetValue<int64_t>() : 0;
+    if (column_count == 0) {
+        throw duckdb::InvalidInputException(
+            "The ODP state table " + state_catalog + ".erpl_web." + SUBSCRIPTIONS_TABLE + " was written by an "
+            "older version of erpl_web and has no schema_version column. Its delta tokens cannot be read safely. "
+            "Drop the erpl_web schema in that database (DROP SCHEMA " + state_catalog + ".erpl_web CASCADE) and "
+            "re-subscribe, or point ODP at a different database.");
     }
 }
 
-duckdb::unique_ptr<duckdb::MaterializedQueryResult> OdpSubscriptionRepository::ExecuteQuery(const std::string& query) {
-    ERPL_TRACE_DEBUG("ODP_REPOSITORY", "Executing query: " + query);
+duckdb::unique_ptr<duckdb::MaterializedQueryResult> OdpSubscriptionRepository::Execute(
+    const std::string& sql, duckdb::vector<duckdb::Value> params) {
+    // Only the statement label is traced: the SQL carries no caller data now
+    // that every value is bound, and the values themselves may be credentials.
+    ERPL_TRACE_DEBUG("ODP_REPOSITORY", duckdb::StringUtil::Format(
+        "Executing ODP state statement (%zu bound parameters)", params.size()));
+
     duckdb::Connection connection(context.db->GetDatabase(context));
-    auto result = connection.Query(query);
-    if (!result) {
-        throw duckdb::InternalException("Failed to execute query: no result returned");
+    auto prepared = connection.Prepare(sql);
+    if (!prepared || prepared->HasError()) {
+        throw duckdb::InternalException("Failed to prepare ODP state statement: " +
+                                        (prepared ? prepared->GetError() : std::string("no statement returned")));
     }
+
+    auto result = prepared->Execute(params, false);
+    if (!result) {
+        throw duckdb::InternalException("Failed to execute ODP state statement: no result returned");
+    }
+    if (result->HasError()) {
+        throw duckdb::InternalException("Failed to execute ODP state statement: " + result->GetError());
+    }
+
     auto* materialized = dynamic_cast<duckdb::MaterializedQueryResult*>(result.get());
     if (!materialized) {
-        throw duckdb::InternalException("Failed to execute query: non-materialized result returned");
+        throw duckdb::InternalException("Failed to execute ODP state statement: non-materialized result returned");
     }
     result.release();
     return duckdb::unique_ptr<duckdb::MaterializedQueryResult>(materialized);
 }
 
-std::string OdpSubscriptionRepository::BuildInsertSubscriptionQuery(const OdpSubscription& subscription) {
-    // Escape single quotes in string fields to prevent SQL injection
-    auto escape_sql = [](const std::string &s) {
-        std::string out;
-        out.reserve(s.size() + 8);
-        for (char c : s) {
-            if (c == '\'') {
-                out += "''";
-            } else {
-                out += c;
-            }
-        }
-        return out;
-    };
-    
-    return duckdb::StringUtil::Format(
-        "INSERT INTO erpl_web.odp_subscriptions "
-        "(subscription_id, service_url, entity_set_name, secret_name, delta_token, "
-        "created_at, last_updated, subscription_status, preference_applied) "
-        "VALUES ('%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', %s)",
-        escape_sql(subscription.subscription_id),
-        escape_sql(subscription.service_url),
-        escape_sql(subscription.entity_set_name),
-        escape_sql(subscription.secret_name),
-        escape_sql(subscription.delta_token),
-        TimestampToString(subscription.created_at),
-        TimestampToString(subscription.last_updated),
-        escape_sql(subscription.subscription_status),
-        subscription.preference_applied ? "TRUE" : "FALSE"
-    );
+int64_t OdpSubscriptionRepository::RowsChanged(duckdb::MaterializedQueryResult& result) {
+    if (result.RowCount() == 0 || result.ColumnCount() == 0) {
+        return 0;
+    }
+    auto value = result.GetValue(0, 0);
+    if (value.IsNull()) {
+        return 0;
+    }
+    return value.GetValue<int64_t>();
 }
 
-std::string OdpSubscriptionRepository::BuildInsertAuditQuery(const OdpAuditEntry& entry) {
-    // Escape single quotes in string fields to prevent SQL injection
-    auto escape_sql = [](const std::string &s) {
-        std::string out;
-        out.reserve(s.size() + 8);
-        for (char c : s) {
-            if (c == '\'') {
-                out += "''";
-            } else {
-                out += c;
-            }
-        }
-        return out;
-    };
-    
-    std::string response_ts = entry.response_timestamp.has_value() 
-        ? "'" + TimestampToString(entry.response_timestamp.value()) + "'"
-        : "NULL";
-    
-    std::string http_code = entry.http_status_code.has_value() 
-        ? std::to_string(entry.http_status_code.value())
-        : "NULL";
-    
-    std::string duration = entry.duration_ms.has_value() 
-        ? std::to_string(entry.duration_ms.value())
-        : "NULL";
-    
-    return duckdb::StringUtil::Format(
-        "INSERT INTO erpl_web.odp_subscription_audit "
-        "(audit_id, subscription_id, operation_type, request_timestamp, response_timestamp, "
-        "request_url, http_status_code, rows_fetched, package_size_bytes, "
-        "delta_token_before, delta_token_after, error_message, duration_ms) "
-        "VALUES (%lld, '%s', '%s', '%s', %s, '%s', %s, %lld, %lld, '%s', '%s', '%s', %s)",
-        entry.audit_id,
-        escape_sql(entry.subscription_id),
-        escape_sql(entry.operation_type),
-        TimestampToString(entry.request_timestamp),
-        response_ts,
-        escape_sql(entry.request_url),
-        http_code,
-        entry.rows_fetched,
-        entry.package_size_bytes,
-        escape_sql(entry.delta_token_before),
-        escape_sql(entry.delta_token_after),
-        escape_sql(entry.error_message),
-        duration
-    );
+duckdb::Value OdpSubscriptionRepository::TimePointToValue(const std::chrono::system_clock::time_point& tp) {
+    const auto micros = std::chrono::duration_cast<std::chrono::microseconds>(tp.time_since_epoch()).count();
+    return duckdb::Value::TIMESTAMP(duckdb::timestamp_t(micros));
 }
 
-std::string OdpSubscriptionRepository::TimestampToString(const std::chrono::system_clock::time_point& tp) {
-    auto time_t = std::chrono::system_clock::to_time_t(tp);
-    auto tm = *std::gmtime(&time_t);
-    
-    std::ostringstream oss;
-    oss << std::put_time(&tm, "%Y-%m-%d %H:%M:%S");
-    return oss.str();
+std::chrono::system_clock::time_point OdpSubscriptionRepository::ValueToTimePoint(const duckdb::Value& value) {
+    if (value.IsNull()) {
+        return std::chrono::system_clock::time_point {};
+    }
+    const auto timestamp = value.GetValue<duckdb::timestamp_t>();
+    return std::chrono::system_clock::time_point(std::chrono::microseconds(timestamp.value));
 }
 
-std::chrono::system_clock::time_point OdpSubscriptionRepository::StringToTimestamp(const std::string& str) {
-    std::tm tm = {};
-    std::istringstream ss(str);
-    ss >> std::get_time(&tm, "%Y-%m-%d %H:%M:%S");
-    
-    auto time_t = std::mktime(&tm);
-    return std::chrono::system_clock::from_time_t(time_t);
+OdpSubscription OdpSubscriptionRepository::RowToSubscription(duckdb::MaterializedQueryResult& result,
+                                                             duckdb::idx_t row) {
+    const int32_t row_version = result.GetValue(COL_SCHEMA_VERSION, row).GetValue<int32_t>();
+    if (row_version != SCHEMA_VERSION) {
+        throw duckdb::InvalidInputException(duckdb::StringUtil::Format(
+            "ODP subscription row has schema version %d but this build understands version %d. "
+            "Its delta token cannot be interpreted safely; drop the erpl_web schema and re-subscribe.",
+            row_version, SCHEMA_VERSION));
+    }
+
+    OdpSubscription subscription;
+    subscription.subscription_id = result.GetValue(COL_SUBSCRIPTION_ID, row).ToString();
+    subscription.service_url = result.GetValue(COL_SERVICE_URL, row).ToString();
+    subscription.entity_set_name = result.GetValue(COL_ENTITY_SET_NAME, row).ToString();
+    subscription.secret_name = result.GetValue(COL_SECRET_NAME, row).ToString();
+    auto token_value = result.GetValue(COL_DELTA_TOKEN, row);
+    subscription.delta_token = token_value.IsNull() ? std::string() : token_value.ToString();
+    subscription.created_at = ValueToTimePoint(result.GetValue(COL_CREATED_AT, row));
+    subscription.last_updated = ValueToTimePoint(result.GetValue(COL_LAST_UPDATED, row));
+    subscription.subscription_status = result.GetValue(COL_SUBSCRIPTION_STATUS, row).ToString();
+    subscription.preference_applied = result.GetValue(COL_PREFERENCE_APPLIED, row).GetValue<bool>();
+    return subscription;
 }
 
 } // namespace erpl_web

--- a/src/odp_subscription_repository.cpp
+++ b/src/odp_subscription_repository.cpp
@@ -125,11 +125,19 @@ void OdpSubscriptionRepository::ResolveStateCatalog() {
         return;
     }
 
+    // Enumerating attached catalogs reads through the client's transaction context, so a
+    // transaction has to be active. When the repository is driven from a table function
+    // there already is one - and RunFunctionInTransaction would DEADLOCK there, because it
+    // takes the client-context lock the running query already holds. So the caller's
+    // transaction is used when it exists, and one is started only for standalone callers
+    // such as unit tests.
+    std::string default_name;
+    const auto resolve = [&]() {
     auto& database_manager = duckdb::DatabaseManager::Get(context);
 
     // Prefer the catalog that is currently default, so an explicit USE keeps
     // working -- but only when it can actually hold the state durably.
-    const std::string default_name = duckdb::DatabaseManager::GetDefaultDatabase(context);
+    default_name = duckdb::DatabaseManager::GetDefaultDatabase(context);
     auto default_database = database_manager.GetDatabase(context, default_name);
     if (default_database && IsUsableStateCatalog(*default_database)) {
         state_catalog = default_database->GetName();
@@ -146,6 +154,13 @@ void OdpSubscriptionRepository::ResolveStateCatalog() {
         if (!candidates.empty()) {
             state_catalog = candidates.front();
         }
+    }
+    };
+
+    if (context.transaction.HasActiveTransaction()) {
+        resolve();
+    } else {
+        context.RunFunctionInTransaction(resolve);
     }
 
     if (state_catalog.empty()) {
@@ -624,7 +639,10 @@ duckdb::unique_ptr<duckdb::MaterializedQueryResult> OdpSubscriptionRepository::E
     ERPL_TRACE_DEBUG("ODP_REPOSITORY", duckdb::StringUtil::Format(
         "Executing ODP state statement (%zu bound parameters)", params.size()));
 
-    duckdb::Connection connection(context.db->GetDatabase(context));
+    // Constructed from the DatabaseInstance rather than via GetDatabase(context):
+    // the latter resolves through the client's transaction context, which is not
+    // active when the repository is driven from bind or from a scan callback.
+    duckdb::Connection connection(*context.db);
     auto prepared = connection.Prepare(sql);
     if (!prepared || prepared->HasError()) {
         throw duckdb::InternalException("Failed to prepare ODP state statement: " +

--- a/src/odp_subscription_state_manager.cpp
+++ b/src/odp_subscription_state_manager.cpp
@@ -59,9 +59,12 @@ void OdpSubscriptionStateManager::TransitionToDeltaFetch(const std::string& delt
         delta_token, preference_applied ? "true" : "false"));
     
     current_phase_ = SubscriptionPhase::DELTA_FETCH;
-    current_subscription_.delta_token = delta_token;
     current_subscription_.preference_applied = preference_applied;
-    
+
+    // UpdateDeltaToken takes the currently-held token as the compare-and-swap
+    // expectation, so the new one must NOT be assigned first - doing so compares the
+    // new value against the stored old one and reports a phantom concurrent modification
+    // on every transition. UpdateDeltaToken assigns it once the swap succeeds.
     UpdateDeltaToken(delta_token);
     LogCurrentState();
 }

--- a/src/odp_subscription_state_manager.cpp
+++ b/src/odp_subscription_state_manager.cpp
@@ -41,7 +41,12 @@ void OdpSubscriptionStateManager::TransitionToInitialLoad() {
     ERPL_TRACE_INFO("ODP_STATE_MANAGER", "Transitioning to INITIAL_LOAD phase");
     
     current_phase_ = SubscriptionPhase::INITIAL_LOAD;
-    current_subscription_.delta_token = ""; // Clear any existing delta token
+    // Clear the token in the database as well, not just in memory: the next
+    // advance compares against the stored value, and an in-memory-only clear
+    // would make that comparison fail against a token nobody changed.
+    if (!current_subscription_.delta_token.empty()) {
+        UpdateDeltaToken("");
+    }
     current_subscription_.preference_applied = false;
     
     UpdateSubscriptionStatus("active");
@@ -83,36 +88,18 @@ void OdpSubscriptionStateManager::TransitionToError(const std::string& error_msg
     LogCurrentState();
 }
 
-void OdpSubscriptionStateManager::PersistSubscription() {
-    ERPL_TRACE_DEBUG("ODP_STATE_MANAGER", "Persisting subscription: " + current_subscription_.subscription_id);
-    
-    try {
-        bool success = repository_->UpdateSubscription(current_subscription_);
-        if (!success) {
-            ERPL_TRACE_WARN("ODP_STATE_MANAGER", "Failed to persist subscription, may need to recreate");
-        }
-    } catch (const std::exception& e) {
-        ERPL_TRACE_ERROR("ODP_STATE_MANAGER", "Error persisting subscription: " + std::string(e.what()));
-        throw;
-    }
-}
-
 void OdpSubscriptionStateManager::UpdateDeltaToken(const std::string& token) {
-    ERPL_TRACE_DEBUG("ODP_STATE_MANAGER", duckdb::StringUtil::Format(
-        "Updating delta token from '%s' to '%s'", current_subscription_.delta_token, token));
-    
+    const std::string expected_token = current_subscription_.delta_token;
+    ERPL_TRACE_DEBUG("ODP_STATE_MANAGER", "Advancing delta token for subscription " +
+                                          current_subscription_.subscription_id);
+
+    // Compare-and-swap: the stored token must still be the one this session read,
+    // otherwise another session is reading the same delta stream and advancing
+    // here would split the changes between the two readers.
+    repository_->AdvanceDeltaToken(current_subscription_.subscription_id, expected_token, token);
+
     current_subscription_.delta_token = token;
     UpdateLastModified();
-    
-    try {
-        bool success = repository_->UpdateDeltaToken(current_subscription_.subscription_id, token);
-        if (!success) {
-            throw duckdb::InternalException("Failed to update delta token in database");
-        }
-    } catch (const std::exception& e) {
-        ERPL_TRACE_ERROR("ODP_STATE_MANAGER", "Error updating delta token: " + std::string(e.what()));
-        throw;
-    }
 }
 
 void OdpSubscriptionStateManager::UpdateSubscriptionStatus(const std::string& status) {
@@ -250,8 +237,9 @@ void OdpSubscriptionStateManager::LoadExistingSubscription() {
         
         // Handle imported delta token
         if (!import_delta_token_.empty()) {
-            ERPL_TRACE_INFO("ODP_STATE_MANAGER", "Importing delta token: " + import_delta_token_);
-            current_subscription_.delta_token = import_delta_token_;
+            ERPL_TRACE_INFO("ODP_STATE_MANAGER", "Importing delta token for existing subscription");
+            // UpdateDeltaToken compares against the token currently held, so the
+            // in-memory copy must not be overwritten before the swap.
             UpdateDeltaToken(import_delta_token_);
         }
     } else {
@@ -275,8 +263,7 @@ void OdpSubscriptionStateManager::CreateNewSubscription() {
         
         // Handle imported delta token for new subscription
         if (!import_delta_token_.empty()) {
-            ERPL_TRACE_INFO("ODP_STATE_MANAGER", "Setting imported delta token on new subscription: " + import_delta_token_);
-            current_subscription_.delta_token = import_delta_token_;
+            ERPL_TRACE_INFO("ODP_STATE_MANAGER", "Setting imported delta token on new subscription");
             UpdateDeltaToken(import_delta_token_);
         }
         
@@ -312,8 +299,43 @@ void OdpSubscriptionStateManager::ValidateSubscriptionData() const {
         throw duckdb::InvalidInputException("Entity set name cannot be empty");
     }
     
+    // The EntityOf*/FactsOf*/AttrOf* naming is a convention, not a guarantee --
+    // an unexpected name is worth a warning, not a refusal to read (#105).
     if (!OdpSubscriptionRepository::IsValidOdpUrl(service_url_)) {
-        throw duckdb::InvalidInputException("Invalid ODP URL: " + service_url_);
+        ERPL_TRACE_WARN("ODP_STATE_MANAGER",
+            "Service URL does not look like an ODP entity set (expected EntityOf*/FactsOf*/AttrOf*): " + service_url_);
+    }
+
+    if (!import_delta_token_.empty()) {
+        if (force_full_load_) {
+            // Silently discarding the token here left the caller believing they
+            // had resumed a delta stream when they had restarted it (#105).
+            throw duckdb::InvalidInputException(
+                "force_full_load and import_delta_token cannot be combined: a full load starts a new change stream "
+                "and would discard the imported token. Pass one or the other.");
+        }
+        ValidateDeltaTokenShape(import_delta_token_);
+    }
+}
+
+void OdpSubscriptionStateManager::ValidateDeltaTokenShape(const std::string& token) {
+    constexpr size_t MAX_DELTA_TOKEN_LENGTH = 512;
+
+    if (token.length() > MAX_DELTA_TOKEN_LENGTH) {
+        throw duckdb::InvalidInputException(duckdb::StringUtil::Format(
+            "import_delta_token is %zu characters long; ODP delta tokens are at most %zu.",
+            token.length(), MAX_DELTA_TOKEN_LENGTH));
+    }
+
+    for (const char c : token) {
+        const bool is_allowed = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+                                c == '_' || c == '-' || c == '.' || c == ':' || c == '+' || c == '/' ||
+                                c == '=' || c == '~';
+        if (!is_allowed) {
+            throw duckdb::InvalidInputException(
+                "import_delta_token contains characters that are not valid in an ODP delta token. Expected only "
+                "letters, digits and _-.:+/=~ ; pass the token exactly as odp_list_subscriptions() reports it.");
+        }
     }
 }
 

--- a/test/cpp/include/odp_test_db.hpp
+++ b/test/cpp/include/odp_test_db.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "duckdb.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <string>
+
+namespace odp_test {
+
+// ODP delta state now refuses to live in an in-memory catalog -- tokens stored
+// there vanish at exit, which turns every delta read into a silent full
+// extraction (GitHub #92). Every ODP state test therefore needs a real database
+// file; this owns one for the duration of a test and deletes it afterwards.
+class TempDatabase {
+public:
+    explicit TempDatabase(const std::string& name_hint = "odp_state") {
+        path = MakeUniquePath(name_hint);
+        duckdb::DBConfig config;
+        config.SetOption("allocator_background_threads", duckdb::Value::BOOLEAN(true));
+        database = duckdb::make_uniq<duckdb::DuckDB>(path.string(), &config);
+        connection = duckdb::make_uniq<duckdb::Connection>(*database);
+    }
+
+    ~TempDatabase() {
+        connection.reset();
+        database.reset();
+        std::error_code ignored;
+        std::filesystem::remove(path, ignored);
+        std::filesystem::remove(path.string() + ".wal", ignored);
+    }
+
+    TempDatabase(const TempDatabase&) = delete;
+    TempDatabase& operator=(const TempDatabase&) = delete;
+
+    duckdb::Connection& Conn() { return *connection; }
+    duckdb::ClientContext& Context() { return *connection->context; }
+    const std::filesystem::path& Path() const { return path; }
+
+    // A second, independent connection -- two connections stand in for two
+    // sessions racing on the same ODP subscription.
+    duckdb::unique_ptr<duckdb::Connection> NewConnection() {
+        return duckdb::make_uniq<duckdb::Connection>(*database);
+    }
+
+    static std::filesystem::path MakeUniquePath(const std::string& name_hint) {
+        static std::atomic<uint64_t> counter {0};
+        const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+        auto file = name_hint + "_" + std::to_string(stamp) + "_" + std::to_string(counter++) + ".db";
+        return std::filesystem::temp_directory_path() / file;
+    }
+
+private:
+    std::filesystem::path path;
+    duckdb::unique_ptr<duckdb::DuckDB> database;
+    duckdb::unique_ptr<duckdb::Connection> connection;
+};
+
+} // namespace odp_test

--- a/test/cpp/test_odp_http_request_factory.cpp
+++ b/test/cpp/test_odp_http_request_factory.cpp
@@ -3,7 +3,14 @@
 #include "duckdb.hpp"
 
 #include "odp_http_request_factory.hpp"
+#include "odp_trace_redaction.hpp"
+#include "tracing.hpp"
 #include "datazoo/oauth2/http_client.hpp"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
 
 using namespace erpl_web;
 using namespace std;
@@ -247,4 +254,84 @@ TEST_CASE("OdpHttpRequestFactory URL Format Parameter Handling", "[odp_http_fact
         auto request = factory.CreateMetadataRequest(url);
         REQUIRE(request.url.ToString() == "https://example.com/test/$metadata");
     }
+}
+
+
+// ============================================================================
+// GitHub #100 -- credentials must never reach the trace log
+// ============================================================================
+
+TEST_CASE("Odp trace redaction - header values", "[odp_http_factory][odp_redaction]") {
+    SECTION("Authorization keeps its scheme and loses its credential") {
+        // Pre-fix: there was no redaction at all -- the value was written as-is.
+        REQUIRE(odp_trace::RedactHeaderValue("Authorization", "Bearer eyJhbGciOi.SECRET") == "Bearer ***");
+        REQUIRE(odp_trace::RedactHeaderValue("authorization", "Basic dXNlcjpwYXNz") == "Basic ***");
+        REQUIRE(odp_trace::RedactHeaderValue("Proxy-Authorization", "Basic dXNlcjpwYXNz") == "Basic ***");
+    }
+
+    SECTION("Cookies are dropped entirely") {
+        REQUIRE(odp_trace::RedactHeaderValue("Cookie", "SAP_SESSIONID=abc") == "***");
+        REQUIRE(odp_trace::RedactHeaderValue("Set-Cookie", "SAP_SESSIONID=abc") == "***");
+    }
+
+    SECTION("Ordinary headers are untouched") {
+        REQUIRE(odp_trace::RedactHeaderValue("Accept", "application/json") == "application/json");
+        REQUIRE(odp_trace::RedactHeaderValue("Prefer", "odata.track-changes") == "odata.track-changes");
+    }
+}
+
+TEST_CASE("OdpHttpRequestFactory - the trace file carries no credentials",
+          "[odp_http_factory][odp_redaction]") {
+    const std::string secret_password = "sup3rSecretSapPassw0rd";
+    const std::string bearer_token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.NOT_IN_THE_LOG";
+
+    auto trace_dir = std::filesystem::temp_directory_path() /
+                     ("erpl_odp_trace_" + std::to_string(
+                         std::chrono::steady_clock::now().time_since_epoch().count()));
+    std::filesystem::create_directories(trace_dir);
+    const auto trace_file = trace_dir / "erpl_web_trace.log";
+
+    auto& tracer = ErplTracer::Instance();
+    const bool was_enabled = tracer.IsEnabled();
+    const TraceLevel previous_level = tracer.GetLevel();
+    const std::string previous_output = tracer.GetOutputMode();
+
+    tracer.SetTraceDirectory(trace_dir.string());
+    tracer.SetOutputMode("file");
+    tracer.SetLevel(TraceLevel::DEBUG_LEVEL);
+    tracer.SetEnabled(true);
+
+    {
+        auto basic_auth = std::make_shared<HttpAuthParams>();
+        basic_auth->basic_credentials = std::make_tuple("SAPUSER", secret_password);
+        OdpHttpRequestFactory basic_factory(basic_auth);
+        basic_factory.CreateInitialLoadRequest("https://sap.example.com/sap/opu/odata/sap/TEST_SRV/EntityOfTest");
+
+        auto bearer_auth = std::make_shared<HttpAuthParams>();
+        bearer_auth->bearer_token = bearer_token;
+        OdpHttpRequestFactory bearer_factory(bearer_auth);
+        bearer_factory.CreateDeltaFetchRequest("https://sap.example.com/sap/opu/odata/sap/TEST_SRV/EntityOfTest");
+    }
+
+    tracer.SetEnabled(false);
+
+    std::ifstream log(trace_file);
+    std::stringstream contents;
+    contents << log.rdbuf();
+    log.close();
+    const std::string trace_text = contents.str();
+
+    // The requests were traced at all...
+    REQUIRE(trace_text.find("Created ODP HTTP request") != std::string::npos);
+    // ...but the credentials did not travel with them. Pre-fix both of these
+    // substrings were present in the log verbatim.
+    REQUIRE(trace_text.find(bearer_token) == std::string::npos);
+    REQUIRE(trace_text.find(HttpAuthParams::Base64Encode("SAPUSER:" + secret_password)) == std::string::npos);
+    REQUIRE(trace_text.find("Bearer ***") != std::string::npos);
+
+    tracer.SetLevel(previous_level);
+    tracer.SetOutputMode(previous_output);
+    tracer.SetEnabled(was_enabled);
+    std::error_code ignored;
+    std::filesystem::remove_all(trace_dir, ignored);
 }

--- a/test/cpp/test_odp_request_orchestrator.cpp
+++ b/test/cpp/test_odp_request_orchestrator.cpp
@@ -295,3 +295,99 @@ TEST_CASE("OdpRequestOrchestrator - NormalizeDeltaToken", "[odp_normalize_token]
         REQUIRE(OdpRequestOrchestrator::NormalizeDeltaToken("'abc123\"") == "'abc123\"");
     }
 }
+
+
+// ============================================================================
+// GitHub #105 -- the delta token must be percent-encoded into the URL
+// ============================================================================
+
+TEST_CASE("OdpRequestOrchestrator - delta token encoding", "[odp_orchestrator][odp_url_encoding]") {
+    SECTION("Unreserved characters are left alone") {
+        // SAP's own tokens are alphanumeric with underscores; encoding them must
+        // not change them, or every existing subscription would break.
+        REQUIRE(OdpRequestOrchestrator::EncodeDeltaToken("D20240101120000_000000000") ==
+                "D20240101120000_000000000");
+        REQUIRE(OdpRequestOrchestrator::EncodeDeltaToken("abc-123.def~ghi") == "abc-123.def~ghi");
+    }
+
+    SECTION("Query syntax inside the token is escaped") {
+        // Pre-fix: the token went into the URL verbatim, so a '&' in it split
+        // the query and appended a parameter of the server's choosing.
+        const std::string url = OdpRequestOrchestrator::BuildDeltaUrl(
+            "https://test.com/sap/opu/odata/sap/TEST_SRV/EntityOfTest", "D2024&$top=1");
+
+        REQUIRE(url.find("&$top=1") == std::string::npos);
+        REQUIRE(url.find("!deltatoken=D2024%26%24top%3D1") != std::string::npos);
+    }
+
+    SECTION("Spaces and fragments are escaped") {
+        REQUIRE(OdpRequestOrchestrator::EncodeDeltaToken("a b") == "a%20b");
+        REQUIRE(OdpRequestOrchestrator::EncodeDeltaToken("a#b") == "a%23b");
+    }
+}
+
+// ============================================================================
+// GitHub #101 -- server-supplied links must be checked against the service origin
+// ============================================================================
+
+TEST_CASE("OdpRequestOrchestrator - origin comparison for server-supplied links",
+          "[odp_orchestrator][odp_same_origin]") {
+    const std::string service = "https://sap.example.com/sap/opu/odata/sap/TEST_SRV/EntityOfTest";
+
+    SECTION("The same host, scheme and port is same-origin") {
+        REQUIRE(OdpRequestOrchestrator::IsSameOrigin(
+            service, "https://sap.example.com/sap/opu/odata/sap/TEST_SRV/EntityOfTest?$skiptoken=2"));
+    }
+
+    SECTION("A relative link resolves against the service and stays same-origin") {
+        REQUIRE(OdpRequestOrchestrator::IsSameOrigin(service, "/sap/opu/odata/sap/TEST_SRV/EntityOfTest?$skiptoken=2"));
+    }
+
+    SECTION("Another host is not same-origin") {
+        // Pre-fix: there was no check at all, and this link was fetched with the
+        // caller's bearer token attached.
+        REQUIRE(!OdpRequestOrchestrator::IsSameOrigin(service, "https://attacker.example.net/collect"));
+    }
+
+    SECTION("A scheme downgrade is not same-origin") {
+        REQUIRE(!OdpRequestOrchestrator::IsSameOrigin(service, "http://sap.example.com/sap/opu/odata/sap/TEST_SRV"));
+    }
+
+    SECTION("A different port is not same-origin") {
+        REQUIRE(!OdpRequestOrchestrator::IsSameOrigin(service, "https://sap.example.com:8443/sap/opu/odata"));
+    }
+
+    SECTION("An empty candidate is not same-origin") {
+        REQUIRE(!OdpRequestOrchestrator::IsSameOrigin(service, ""));
+        REQUIRE(!OdpRequestOrchestrator::IsSameOrigin("", service));
+    }
+}
+
+// ============================================================================
+// GitHub #94 -- a token error must be recognised structurally, not by substring
+// ============================================================================
+
+TEST_CASE("OdpRequestOrchestrator - error codes are parsed from the payload",
+          "[odp_orchestrator][odp_token_errors]") {
+    SECTION("An OData v2 SAP error payload yields its code") {
+        const std::string body =
+            R"({"error":{"code":"/IWBEP/CM_MGW_RT/021","message":{"lang":"en","value":"Delta token invalid"}}})";
+        REQUIRE(OdpRequestOrchestrator::ExtractErrorCode(body) == "/IWBEP/CM_MGW_RT/021");
+    }
+
+    SECTION("A payload without an error object yields nothing") {
+        REQUIRE(OdpRequestOrchestrator::ExtractErrorCode(R"({"d":{"results":[]}})").empty());
+        REQUIRE(OdpRequestOrchestrator::ExtractErrorCode("not json at all").empty());
+        REQUIRE(OdpRequestOrchestrator::ExtractErrorCode("").empty());
+    }
+
+    SECTION("The exception carries the status and the code") {
+        // Pre-fix: the failure was a plain IOException whose message was the
+        // only thing a caller could inspect, which is why the caller resorted to
+        // substring-matching it.
+        OdpHttpException error(410, "DELTATOKEN_EXPIRED", "ODP request failed with HTTP 410");
+        REQUIRE(error.HttpStatusCode() == 410);
+        REQUIRE(error.SapErrorCode() == "DELTATOKEN_EXPIRED");
+        REQUIRE(std::string(error.what()).find("410") != std::string::npos);
+    }
+}

--- a/test/cpp/test_odp_subscription_repository.cpp
+++ b/test/cpp/test_odp_subscription_repository.cpp
@@ -1,5 +1,6 @@
 #include "catch.hpp"
 #include "odp_subscription_repository.hpp"
+#include "odp_test_db.hpp"
 #include "duckdb.hpp"
 #include <chrono>
 #include <thread>
@@ -8,11 +9,9 @@ using namespace erpl_web;
 using namespace duckdb;
 
 TEST_CASE("OdpSubscriptionRepository - Basic Operations", "[odp_repository]") {
-    DBConfig config;
-    config.SetOption("allocator_background_threads", Value(true));
-    DuckDB db(nullptr, &config);
-    Connection conn(db);
-    ClientContext& context = *conn.context;
+    odp_test::TempDatabase temp_db;
+    Connection& conn = temp_db.Conn();
+    ClientContext& context = temp_db.Context();
     
     OdpSubscriptionRepository repo(context);
     
@@ -77,10 +76,9 @@ TEST_CASE("OdpSubscriptionRepository - Basic Operations", "[odp_repository]") {
         // Create subscription
         std::string subscription_id = repo.CreateSubscription(service_url, entity_set_name);
         
-        // Update delta token
+        // Advance the delta token from its initial empty value
         std::string delta_token = "test_delta_token_12345";
-        bool success = repo.UpdateDeltaToken(subscription_id, delta_token);
-        REQUIRE(success);
+        REQUIRE_NOTHROW(repo.AdvanceDeltaToken(subscription_id, "", delta_token));
         
         // Verify update
         auto subscription = repo.GetSubscription(subscription_id);
@@ -213,6 +211,13 @@ TEST_CASE("OdpSubscriptionRepository - Utility Methods", "[odp_repository_utils]
         REQUIRE(OdpSubscriptionRepository::IsValidOdpUrl("https://test.com/FactsOfTest"));
         REQUIRE(OdpSubscriptionRepository::IsValidOdpUrl("https://test.com/sap/opu/odata/sap/TEST_SRV/EntityOfSEPM_ISO"));
         REQUIRE(OdpSubscriptionRepository::IsValidOdpUrl("https://test.com/sap/opu/odata/sap/TEST_SRV/FactsOf0D_NW_C01"));
+        // A query string must not make a valid service URL fail the check (#105)
+        REQUIRE(OdpSubscriptionRepository::IsValidOdpUrl(
+            "https://test.com/sap/opu/odata/sap/TEST_SRV/EntityOfSEPM_ISO?$format=json"));
+        REQUIRE(OdpSubscriptionRepository::IsValidOdpUrl(
+            "https://test.com/sap/opu/odata/sap/TEST_SRV/FactsOf0D_NW_C01?$format=json&!deltatoken=D20240101"));
+        REQUIRE(OdpSubscriptionRepository::IsValidOdpUrl(
+            "https://test.com/sap/opu/odata/sap/TEST_SRV/EntityOfSEPM_ISO/"));
         
         // Invalid URLs
         REQUIRE(!OdpSubscriptionRepository::IsValidOdpUrl("https://test.com/RegularEntity"));
@@ -223,20 +228,16 @@ TEST_CASE("OdpSubscriptionRepository - Utility Methods", "[odp_repository_utils]
 }
 
 TEST_CASE("OdpSubscriptionRepository - Error Handling", "[odp_repository_errors]") {
-    DBConfig config;
-    config.SetOption("allocator_background_threads", Value(true));
-    DuckDB db(nullptr, &config);
-    Connection conn(db);
-    ClientContext& context = *conn.context;
+    odp_test::TempDatabase temp_db;
+    ClientContext& context = temp_db.Context();
     
     OdpSubscriptionRepository repo(context);
     repo.EnsureTablesExist();
     
-    SECTION("Invalid URL creation") {
-        REQUIRE_THROWS_AS(
-            repo.CreateSubscription("https://invalid.com/RegularEntity", "RegularEntity"),
-            InvalidInputException
-        );
+    SECTION("A URL that does not follow the ODP naming convention is accepted with a warning") {
+        // The EntityOf*/FactsOf*/AttrOf* convention is a hint, not a contract:
+        // refusing such a URL blocked legitimate services (#105).
+        REQUIRE_NOTHROW(repo.CreateSubscription("https://valid.com/RegularEntity", "RegularEntity"));
     }
     
     SECTION("Non-existent subscription operations") {
@@ -246,11 +247,11 @@ TEST_CASE("OdpSubscriptionRepository - Error Handling", "[odp_repository_errors]
         auto subscription = repo.GetSubscription(fake_id);
         REQUIRE(!subscription.has_value());
         
-        // Update non-existent subscription
-        bool success = repo.UpdateDeltaToken(fake_id, "test_token");
-        REQUIRE(!success); // Should fail gracefully
+        // Advancing the token of a subscription that is gone must say so, not
+        // report success (#95).
+        REQUIRE_THROWS(repo.AdvanceDeltaToken(fake_id, "", "test_token"));
         
-        success = repo.UpdateSubscriptionStatus(fake_id, "terminated");
+        bool success = repo.UpdateSubscriptionStatus(fake_id, "terminated");
         REQUIRE(!success); // Should fail gracefully
         
         // Remove non-existent subscription
@@ -270,4 +271,242 @@ TEST_CASE("OdpSubscriptionRepository - Error Handling", "[odp_repository_errors]
         std::string id2 = repo.CreateSubscription(service_url, entity_set_name);
         REQUIRE(id1 == id2);
     }
+}
+
+
+// ============================================================================
+// GitHub #99 -- repository SQL must be built from bound parameters
+// ============================================================================
+
+TEST_CASE("OdpSubscriptionRepository - values containing SQL syntax round-trip", "[odp_repository][odp_sql_injection]") {
+    odp_test::TempDatabase temp_db;
+    ClientContext& context = temp_db.Context();
+    OdpSubscriptionRepository repo(context);
+
+    SECTION("A single quote in the service URL and entity set name survives a round-trip") {
+        // Pre-fix: FindActiveSubscription interpolated both values straight into
+        // the SQL text, so the quote produced a parse error that was swallowed
+        // and reported as "no subscription" -- this REQUIRE failed.
+        const std::string service_url = "https://test.com/sap/opu/odata/sap/TEST_SRV/EntityOf'Quote";
+        const std::string entity_set_name = "EntityOf'Quote";
+
+        const std::string subscription_id = repo.CreateSubscription(service_url, entity_set_name, "sec'ret");
+
+        auto found = repo.FindActiveSubscription(service_url, entity_set_name);
+        REQUIRE(found.has_value());
+        REQUIRE(found->subscription_id == subscription_id);
+        REQUIRE(found->service_url == service_url);
+        REQUIRE(found->entity_set_name == entity_set_name);
+        REQUIRE(found->secret_name == "sec'ret");
+    }
+
+    SECTION("A crafted entity set name cannot execute a statement of its own") {
+        // Pre-fix: this value closed the string literal and appended a DROP, and
+        // the repository ran it on a full-privilege connection -- the table was
+        // gone by the time this REQUIRE ran.
+        const std::string malicious = "x'; DROP TABLE erpl_web.odp_subscriptions; --";
+        repo.CreateSubscription("https://test.com/EntityOfInjection", malicious);
+
+        auto surviving = temp_db.Conn().Query(
+            "SELECT count(*) FROM information_schema.tables "
+            "WHERE table_schema = 'erpl_web' AND table_name = 'odp_subscriptions'");
+        REQUIRE(!surviving->HasError());
+        REQUIRE(surviving->GetValue(0, 0).GetValue<int64_t>() == 1);
+
+        auto found = repo.FindActiveSubscription("https://test.com/EntityOfInjection", malicious);
+        REQUIRE(found.has_value());
+        REQUIRE(found->entity_set_name == malicious);
+    }
+
+    SECTION("A delta token containing a quote round-trips") {
+        const std::string url = "https://test.com/EntityOfTokenQuote";
+        const std::string id = repo.CreateSubscription(url, "EntityOfTokenQuote");
+
+        const std::string token = "D2024'0101_120000";
+        REQUIRE_NOTHROW(repo.AdvanceDeltaToken(id, "", token));
+
+        auto reloaded = repo.GetSubscription(id);
+        REQUIRE(reloaded.has_value());
+        REQUIRE(reloaded->delta_token == token);
+    }
+}
+
+// ============================================================================
+// GitHub #92 -- ODP state must live in a named, persistent catalog
+// ============================================================================
+
+TEST_CASE("OdpSubscriptionRepository - state catalog resolution", "[odp_repository][odp_state_catalog]") {
+    SECTION("An in-memory database is refused") {
+        // Pre-fix: the schema was created in the in-memory catalog and every
+        // delta token was discarded at exit -- nothing threw.
+        DBConfig config;
+        config.SetOption("allocator_background_threads", Value(true));
+        DuckDB db(nullptr, &config);
+        Connection conn(db);
+
+        OdpSubscriptionRepository repo(*conn.context);
+        REQUIRE_THROWS_AS(repo.EnsureTablesExist(), InvalidInputException);
+    }
+
+    SECTION("A persistent database is used and named") {
+        odp_test::TempDatabase temp_db;
+        OdpSubscriptionRepository repo(temp_db.Context());
+        REQUIRE_NOTHROW(repo.EnsureTablesExist());
+        REQUIRE(!repo.GetStateCatalog().empty());
+        REQUIRE(repo.GetStateCatalog() != "memory");
+    }
+
+    SECTION("USE of another database does not move the state") {
+        // Pre-fix: the schema name was unqualified, so a USE re-pointed every
+        // later statement -- the subscription landed in the other database and
+        // this count came back 0.
+        odp_test::TempDatabase state_db("odp_state_home");
+        const auto other_path = odp_test::TempDatabase::MakeUniquePath("odp_state_elsewhere");
+
+        OdpSubscriptionRepository repo(state_db.Context());
+        repo.EnsureTablesExist();
+        const std::string home_catalog = repo.GetStateCatalog();
+
+        auto attach = state_db.Conn().Query("ATTACH '" + other_path.string() + "' AS elsewhere");
+        REQUIRE(!attach->HasError());
+        auto use_result = state_db.Conn().Query("USE elsewhere");
+        REQUIRE(!use_result->HasError());
+
+        repo.CreateSubscription("https://test.com/EntityOfHome", "EntityOfHome");
+
+        auto rows = state_db.Conn().Query(
+            "SELECT count(*) FROM \"" + home_catalog + "\".erpl_web.odp_subscriptions");
+        REQUIRE(!rows->HasError());
+        REQUIRE(rows->GetValue(0, 0).GetValue<int64_t>() == 1);
+
+        auto stray = state_db.Conn().Query(
+            "SELECT count(*) FROM duckdb_tables() WHERE database_name = 'elsewhere' AND schema_name = 'erpl_web'");
+        REQUIRE(!stray->HasError());
+        REQUIRE(stray->GetValue(0, 0).GetValue<int64_t>() == 0);
+
+        state_db.Conn().Query("USE \"" + home_catalog + "\"");
+        state_db.Conn().Query("DETACH elsewhere");
+        std::error_code ignored;
+        std::filesystem::remove(other_path, ignored);
+    }
+}
+
+// ============================================================================
+// GitHub #95 -- concurrent readers must not split the delta stream
+// ============================================================================
+
+TEST_CASE("OdpSubscriptionRepository - concurrent delta advance", "[odp_repository][odp_concurrency]") {
+    odp_test::TempDatabase temp_db;
+    auto second_connection = temp_db.NewConnection();
+
+    OdpSubscriptionRepository session_a(temp_db.Context());
+    OdpSubscriptionRepository session_b(*second_connection->context);
+
+    const std::string url = "https://test.com/sap/opu/odata/sap/TEST_SRV/EntityOfRace";
+    const std::string entity = "EntityOfRace";
+    const std::string id = session_a.CreateSubscription(url, entity);
+
+    SECTION("The second advance from a stale token fails loudly") {
+        // Both sessions read the same starting token.
+        auto seen_by_a = session_a.FindActiveSubscription(url, entity);
+        auto seen_by_b = session_b.FindActiveSubscription(url, entity);
+        REQUIRE(seen_by_a.has_value());
+        REQUIRE(seen_by_b.has_value());
+        REQUIRE(seen_by_a->delta_token == seen_by_b->delta_token);
+
+        session_a.AdvanceDeltaToken(id, seen_by_a->delta_token, "TOKEN_FROM_A");
+
+        // Pre-fix: this was an unconditional UPDATE, so it quietly overwrote A's
+        // token and the two sessions each got half of the change stream.
+        REQUIRE_THROWS(session_b.AdvanceDeltaToken(id, seen_by_b->delta_token, "TOKEN_FROM_B"));
+
+        auto final_state = session_a.GetSubscription(id);
+        REQUIRE(final_state.has_value());
+        REQUIRE(final_state->delta_token == "TOKEN_FROM_A");
+    }
+
+    SECTION("An advance from the current token succeeds") {
+        session_a.AdvanceDeltaToken(id, "", "TOKEN_1");
+        REQUIRE_NOTHROW(session_b.AdvanceDeltaToken(id, "TOKEN_1", "TOKEN_2"));
+        REQUIRE(session_a.GetSubscription(id)->delta_token == "TOKEN_2");
+    }
+
+    SECTION("Only one subscription can exist per (service_url, entity_set_name)") {
+        // Pre-fix: there was no unique constraint, so two sessions racing on the
+        // first read each inserted their own row -- this INSERT succeeded.
+        auto duplicate = temp_db.Conn().Query(
+            "INSERT INTO \"" + session_a.GetStateCatalog() + "\".erpl_web.odp_subscriptions "
+            "(subscription_id, service_url, entity_set_name, secret_name, delta_token, "
+            "subscription_status, preference_applied, schema_version) "
+            "VALUES ('other_id', '" + url + "', '" + entity + "', 'default', '', 'active', FALSE, 1)");
+        REQUIRE(duplicate->HasError());
+    }
+
+    SECTION("Audit ids come from a sequence") {
+        // Pre-fix: the id was the current time in microseconds, so it was a
+        // 16-digit number rather than a sequence value.
+        OdpAuditEntry first(id, "initial_load");
+        OdpAuditEntry second(id, "delta_fetch");
+
+        const int64_t first_id = session_a.CreateAuditEntry(first);
+        const int64_t second_id = session_a.CreateAuditEntry(second);
+
+        REQUIRE(first_id == 1);
+        REQUIRE(second_id == 2);
+    }
+}
+
+// ============================================================================
+// GitHub #96 -- a failing query is not the same answer as "no subscription"
+// ============================================================================
+
+TEST_CASE("OdpSubscriptionRepository - failures are distinguished from not-found",
+          "[odp_repository][odp_error_reporting]") {
+    SECTION("A broken state table throws instead of reporting no subscription") {
+        odp_test::TempDatabase temp_db;
+        OdpSubscriptionRepository repo(temp_db.Context());
+        repo.EnsureTablesExist();
+        repo.CreateSubscription("https://test.com/EntityOfBroken", "EntityOfBroken");
+
+        auto dropped = temp_db.Conn().Query(
+            "DROP TABLE \"" + repo.GetStateCatalog() + "\".erpl_web.odp_subscriptions");
+        REQUIRE(!dropped->HasError());
+
+        // Pre-fix: the query error was caught and turned into nullopt, which the
+        // caller read as "never subscribed" and answered with a full reload.
+        REQUIRE_THROWS(repo.FindActiveSubscription("https://test.com/EntityOfBroken", "EntityOfBroken"));
+    }
+
+    SECTION("A state table written by an older version is detected") {
+        odp_test::TempDatabase temp_db;
+        auto& conn = temp_db.Conn();
+        REQUIRE(!conn.Query("CREATE SCHEMA erpl_web")->HasError());
+        // The pre-#92 layout: no schema_version column.
+        REQUIRE(!conn.Query(
+            "CREATE TABLE erpl_web.odp_subscriptions ("
+            "subscription_id VARCHAR PRIMARY KEY, service_url VARCHAR, entity_set_name VARCHAR, "
+            "secret_name VARCHAR, delta_token VARCHAR, created_at TIMESTAMP, last_updated TIMESTAMP, "
+            "subscription_status VARCHAR, preference_applied BOOLEAN)")->HasError());
+
+        OdpSubscriptionRepository repo(temp_db.Context());
+        // Pre-fix: CREATE TABLE IF NOT EXISTS accepted the old table and the
+        // repository read its columns by position, misreading every row.
+        REQUIRE_THROWS_AS(repo.EnsureTablesExist(), InvalidInputException);
+    }
+}
+
+// ============================================================================
+// GitHub #100 -- an error body is truncated before it is persisted
+// ============================================================================
+
+TEST_CASE("OdpSubscriptionRepository - audit error bodies are truncated", "[odp_repository][odp_redaction]") {
+    const std::string huge(OdpSubscriptionRepository::MAX_AUDIT_ERROR_LENGTH + 500, 'x');
+    const std::string truncated = OdpSubscriptionRepository::TruncateForAudit(huge);
+
+    // Pre-fix: the whole body went into the audit row verbatim.
+    REQUIRE(truncated.length() < huge.length());
+    REQUIRE(truncated.find("[truncated]") != std::string::npos);
+
+    const std::string small = "short error";
+    REQUIRE(OdpSubscriptionRepository::TruncateForAudit(small) == small);
 }

--- a/test/cpp/test_odp_subscription_state_manager.cpp
+++ b/test/cpp/test_odp_subscription_state_manager.cpp
@@ -1,16 +1,14 @@
 #include "catch.hpp"
 #include "odp_subscription_state_manager.hpp"
+#include "odp_test_db.hpp"
 #include "duckdb.hpp"
 
 using namespace erpl_web;
 using namespace duckdb;
 
 TEST_CASE("OdpSubscriptionStateManager - Basic State Management", "[odp_state_manager]") {
-    DBConfig config;
-    config.SetOption("allocator_background_threads", Value(true));
-    DuckDB db(nullptr, &config);
-    Connection conn(db);
-    ClientContext& context = *conn.context;
+    odp_test::TempDatabase temp_db;
+    ClientContext& context = temp_db.Context();
     
     std::string service_url = "https://test.com/sap/opu/odata/sap/TEST_SRV/EntityOfTest";
     std::string entity_set_name = "EntityOfTest";
@@ -45,7 +43,7 @@ TEST_CASE("OdpSubscriptionStateManager - Basic State Management", "[odp_state_ma
     }
     
     SECTION("Import delta token") {
-        std::string import_token = "imported_delta_token_456";
+        std::string import_token = "D20240101_120000_456";
         OdpSubscriptionStateManager manager(context, service_url + "2", "EntityOfTest2", secret_name, false, import_token);
         
         REQUIRE(manager.GetCurrentPhase() == OdpSubscriptionStateManager::SubscriptionPhase::DELTA_FETCH);
@@ -55,11 +53,8 @@ TEST_CASE("OdpSubscriptionStateManager - Basic State Management", "[odp_state_ma
 }
 
 TEST_CASE("OdpSubscriptionStateManager - State Transitions", "[odp_state_transitions]") {
-    DBConfig config;
-    config.SetOption("allocator_background_threads", Value(true));
-    DuckDB db(nullptr, &config);
-    Connection conn(db);
-    ClientContext& context = *conn.context;
+    odp_test::TempDatabase temp_db;
+    ClientContext& context = temp_db.Context();
     
     std::string service_url = "https://test.com/sap/opu/odata/sap/TEST_SRV/EntityOfTransition";
     std::string entity_set_name = "EntityOfTransition";
@@ -116,11 +111,8 @@ TEST_CASE("OdpSubscriptionStateManager - State Transitions", "[odp_state_transit
 }
 
 TEST_CASE("OdpSubscriptionStateManager - Delta Token Management", "[odp_delta_tokens]") {
-    DBConfig config;
-    config.SetOption("allocator_background_threads", Value(true));
-    DuckDB db(nullptr, &config);
-    Connection conn(db);
-    ClientContext& context = *conn.context;
+    odp_test::TempDatabase temp_db;
+    ClientContext& context = temp_db.Context();
     
     std::string service_url = "https://test.com/sap/opu/odata/sap/TEST_SRV/EntityOfDelta";
     std::string entity_set_name = "EntityOfDelta";
@@ -162,11 +154,8 @@ TEST_CASE("OdpSubscriptionStateManager - Delta Token Management", "[odp_delta_to
 }
 
 TEST_CASE("OdpSubscriptionStateManager - Audit Operations", "[odp_audit]") {
-    DBConfig config;
-    config.SetOption("allocator_background_threads", Value(true));
-    DuckDB db(nullptr, &config);
-    Connection conn(db);
-    ClientContext& context = *conn.context;
+    odp_test::TempDatabase temp_db;
+    ClientContext& context = temp_db.Context();
     
     std::string service_url = "https://test.com/sap/opu/odata/sap/TEST_SRV/EntityOfAudit";
     std::string entity_set_name = "EntityOfAudit";
@@ -220,11 +209,8 @@ TEST_CASE("OdpSubscriptionStateManager - Utility Methods", "[odp_state_utils]") 
     }
     
     SECTION("Log current state (should not throw)") {
-        DBConfig config;
-        config.SetOption("allocator_background_threads", Value(true));
-        DuckDB db(nullptr, &config);
-        Connection conn(db);
-        ClientContext& context = *conn.context;
+        odp_test::TempDatabase temp_db;
+        ClientContext& context = temp_db.Context();
         
         OdpSubscriptionStateManager manager(context, 
             "https://test.com/sap/opu/odata/sap/TEST_SRV/EntityOfLog", "EntityOfLog");
@@ -241,11 +227,8 @@ TEST_CASE("OdpSubscriptionStateManager - Utility Methods", "[odp_state_utils]") 
 }
 
 TEST_CASE("OdpSubscriptionStateManager - Error Handling", "[odp_state_errors]") {
-    DBConfig config;
-    config.SetOption("allocator_background_threads", Value(true));
-    DuckDB db(nullptr, &config);
-    Connection conn(db);
-    ClientContext& context = *conn.context;
+    odp_test::TempDatabase temp_db;
+    ClientContext& context = temp_db.Context();
     
     SECTION("Invalid URL validation") {
         REQUIRE_THROWS_AS(
@@ -253,10 +236,10 @@ TEST_CASE("OdpSubscriptionStateManager - Error Handling", "[odp_state_errors]") 
             InvalidInputException
         );
         
-        REQUIRE_THROWS_AS(
-            OdpSubscriptionStateManager(context, "https://invalid.com/RegularEntity", "RegularEntity"),
-            InvalidInputException
-        );
+        // A URL that does not follow the ODP naming convention is accepted with
+        // a warning; refusing it blocked valid services (#105).
+        REQUIRE_NOTHROW(
+            OdpSubscriptionStateManager(context, "https://valid.com/RegularEntity", "RegularEntity"));
     }
     
     SECTION("Empty entity set name") {
@@ -265,4 +248,77 @@ TEST_CASE("OdpSubscriptionStateManager - Error Handling", "[odp_state_errors]") 
             InvalidInputException
         );
     }
+}
+
+
+// ============================================================================
+// GitHub #105 -- import_delta_token must be validated, not trusted
+// ============================================================================
+
+TEST_CASE("OdpSubscriptionStateManager - imported delta token validation", "[odp_state_manager][odp_token_validation]") {
+    odp_test::TempDatabase temp_db;
+    ClientContext& context = temp_db.Context();
+
+    const std::string service_url = "https://test.com/sap/opu/odata/sap/TEST_SRV/EntityOfImport";
+    const std::string entity_set_name = "EntityOfImport";
+
+    SECTION("A well-formed token is accepted") {
+        REQUIRE_NOTHROW(OdpSubscriptionStateManager(
+            context, service_url, entity_set_name, "", false, "D20240101120000_000000000"));
+    }
+
+    SECTION("A token carrying URL syntax is rejected") {
+        // Pre-fix: anything at all was accepted and pasted into the delta URL,
+        // so a '&' or a space silently changed the request the service saw.
+        REQUIRE_THROWS_AS(OdpSubscriptionStateManager(
+            context, service_url, entity_set_name, "", false, "D2024&$top=1"), InvalidInputException);
+        REQUIRE_THROWS_AS(OdpSubscriptionStateManager(
+            context, service_url, entity_set_name, "", false, "token with spaces"), InvalidInputException);
+        REQUIRE_THROWS_AS(OdpSubscriptionStateManager(
+            context, service_url, entity_set_name, "", false, "tok\nen"), InvalidInputException);
+    }
+
+    SECTION("An implausibly long token is rejected") {
+        REQUIRE_THROWS_AS(OdpSubscriptionStateManager(
+            context, service_url, entity_set_name, "", false, std::string(4096, 'A')), InvalidInputException);
+    }
+
+    SECTION("force_full_load combined with import_delta_token is rejected") {
+        // Pre-fix: the token was accepted and then thrown away by the forced
+        // full load, leaving the caller believing they had resumed a stream.
+        REQUIRE_THROWS_AS(OdpSubscriptionStateManager(
+            context, service_url, entity_set_name, "", true, "D20240101120000_000000000"),
+            InvalidInputException);
+    }
+}
+
+// ============================================================================
+// GitHub #95 -- the delta token advance is a compare-and-swap
+// ============================================================================
+
+TEST_CASE("OdpSubscriptionStateManager - two sessions on one subscription",
+          "[odp_state_manager][odp_concurrency]") {
+    odp_test::TempDatabase temp_db;
+    auto second_connection = temp_db.NewConnection();
+
+    const std::string service_url = "https://test.com/sap/opu/odata/sap/TEST_SRV/EntityOfTwoSessions";
+    const std::string entity_set_name = "EntityOfTwoSessions";
+
+    OdpSubscriptionStateManager session_a(temp_db.Context(), service_url, entity_set_name);
+    OdpSubscriptionStateManager session_b(*second_connection->context, service_url, entity_set_name);
+
+    // Both sessions attached to the same subscription and see the same state.
+    REQUIRE(session_a.GetSubscriptionId() == session_b.GetSubscriptionId());
+    REQUIRE(session_a.GetCurrentDeltaToken() == session_b.GetCurrentDeltaToken());
+
+    // A finishes its read first and advances the stream.
+    session_a.TransitionToDeltaFetch("D20240101_AAA", true);
+    REQUIRE(session_a.GetCurrentDeltaToken() == "D20240101_AAA");
+
+    // Pre-fix: B's advance silently overwrote A's, and the two sessions each
+    // held half of the change stream with no error anywhere.
+    REQUIRE_THROWS(session_b.TransitionToDeltaFetch("D20240101_BBB", true));
+
+    OdpSubscriptionStateManager reader(temp_db.Context(), service_url, entity_set_name);
+    REQUIRE(reader.GetCurrentDeltaToken() == "D20240101_AAA");
 }


### PR DESCRIPTION
Eight ODP issues, including three security ones. No SAP ODP system is available here, so these are unit- and DB-verified rather than exercised against a real ODQ; that limit is stated per issue below.

## Security

**#99 — SQL injection.** The subscription repository interpolated URLs, entity set names, secret names and delta tokens straight into SQL on a full-privilege connection, reachable from a PRAGMA argument and a crafted URL. Now prepared statements with bound parameters throughout; timestamps bind as values instead of being formatted into strings. Tested with a quote-bearing round trip and with `x'; DROP TABLE …; --` — pre-fix the DROP executed.

**#100 — credentials in trace logs.** A DEBUG trace wrote SAP passwords and Entra tokens to disk verbatim. `Authorization`, `Cookie` and `Proxy-Authorization` are redacted; SQL is logged without values; error bodies are truncated in both the exception and the audit row. Tested by tracing to a temp file and asserting the token is absent.

**#101 — credentials followed to any host.** Server-supplied `__next`/`__delta` links were followed with the bearer token and no origin check. Now same-origin checked, **following the precedent already in the HTTP client** for redirects: credentials are withheld cross-origin and the reason logged, rather than refusing outright — refusing would break SAP behind a reverse proxy that rewrites the hostname.

## Correctness

**#92 — delta state landed anywhere.** The schema was unqualified, so on the documented dev workflow (`:memory:`) delta tokens evaporated at exit and every read silently became a full extraction; a `USE` on an attached foreign database exported service URLs and secret names into it. The catalog is resolved once and in-memory sessions are refused with a message naming the remedy.

**#95 — concurrent readers split the delta stream.** Token advance was a read-modify-write with no CAS, so two sessions silently split or duplicated changes with no error. Now `UPDATE … WHERE delta_token IS NOT DISTINCT FROM <expected>`, failing loudly on zero rows, plus a sequence for audit ids (previously a racy max+1), a unique key on `(service_url, entity_set_name)` and a `schema_version` column.

**#96, #94, #105** — repository errors are distinguished from "no subscription" (a transient failure no longer degrades into a full re-extraction); `IsTokenError` keys off HTTP 410 or a structured SAP code rather than substring-matching the message; delta tokens are percent-encoded and shape-validated; `force_full_load` + `import_delta_token` is rejected rather than silently discarding the token; `IsValidOdpUrl` strips the query before matching, so it stops rejecting valid service URLs; the non-reentrant `localtime`/`gmtime`/`mktime` calls are gone.

## Three defects found while integrating this, and fixed here

1. **A deadlock.** Resolving the state catalog needs an active transaction, so it was wrapped in `RunFunctionInTransaction` — which passes in unit tests and **deadlocks in production**, because it takes the client-context lock a running query already holds. `odp_odata_read` hung indefinitely. Now the caller's transaction is used when one exists, and one is started only for standalone callers.
2. **A phantom CAS failure.** `TransitionToDeltaFetch` assigned the new token to the in-memory subscription *before* calling `UpdateDeltaToken`, which reads that same field as the compare-and-swap expectation — so it compared the new value against the stored old one and reported a concurrent modification on **every** transition.
3. `Connection` was built via `GetDatabase(context)`, which itself resolves through the transaction context and threw when the repository ran outside a query.

Each was caught by running the code, not by reading it.

## Verification

Full C++ suite **376 cases / 1929 assertions**. Live E2E: `odata_conformance_e2e` (22), `odata_v2`, `odata_v4`, `odata_expand` (46), `odata_scan_reexecution` (19), `web_core`, `web_http` — all green.

Behaviour checked end to end: an in-memory session now fails fast with the explanatory error; with a database file the subscription row is created and persisted.

## Known limits

- **The SAP token-invalid signal is a guess** — HTTP 410, or an `error.code` containing `DELTATOKEN`. If SAP uses an `/IWBEP/…` code without that substring, token expiry surfaces as an error instead of auto-falling back to a full load. That is the safer direction, but it needs a real expiry to confirm.
- **Refusing `:memory:` is a hard behaviour break** for anyone running `odp_odata_read` in an in-memory session. That is what #92 asks for, but it deserves a release note.
- No `odp_state_catalog` setting was added (registering one needs the extension entry point, outside this change); the error names the concrete remedy instead.

Closes #92, #94, #95, #96, #99, #100, #101, #105.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791625982&installation_model_id=425457&pr_number=134&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F134&signature=85ea37e1e01a121279297a190e0fb7d07c7d8fbdf5f1c5d686491942ce448553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->