### PR TITLE
fix: COUNT(*) on an ATTACHed OData table no longer fails to cast (#132)

### DIFF
--- a/src/include/odata_read_functions.hpp
+++ b/src/include/odata_read_functions.hpp
@@ -165,6 +165,12 @@ private:
     // Projection, settled in ActivateColumns during global-state init.
     std::vector<duckdb::column_t> active_column_ids;
     std::vector<duckdb::column_t> activated_to_original_mapping;
+
+    // One entry per OUTPUT column, in output order, marking the slots DuckDB asked to be
+    // filled with row ids rather than data. Row ids are dropped from the data projection
+    // but they still occupy a position in the chunk, so the positional correspondence has
+    // to be recorded or every later slot reads the wrong column. See GitHub #132.
+    std::vector<bool> output_column_is_row_id;
     
     // Configuration
     std::map<std::string, std::string> input_parameters;

--- a/src/odata_read_functions.cpp
+++ b/src/odata_read_functions.cpp
@@ -1220,9 +1220,19 @@ void ODataReadBindData::EmitSingleRowToOutput(
     
     auto null_value = duckdb::Value();
     
+    idx_t data_slot = 0;
     for (idx_t j = 0; j < output.ColumnCount(); j++) {
-        duckdb::idx_t original_column_index = GetOriginalColumnIndex(j);
-        
+        if (j < output_column_is_row_id.size() && output_column_is_row_id[j]) {
+            // A synthetic row id: monotonically increasing over the scan, which is all a
+            // row id has to be here. Emitting a data value would be a type mismatch.
+            output.SetValue(j, row_index,
+                            duckdb::Value::BIGINT(static_cast<int64_t>(emitted_row_index_)));
+            continue;
+        }
+
+        duckdb::idx_t original_column_index = GetOriginalColumnIndex(data_slot);
+        data_slot++;
+
         if (original_column_index < schema_info.all_result_names.size()) {
             auto value = GetColumnValue(original_column_index, row, schema_info);
             output.SetValue(j, row_index, value);
@@ -1361,11 +1371,18 @@ void ODataReadBindData::ActivateColumns(
                    duckdb::StringUtil::Format("Activating columns: %s",
                                               column_ids_str.str().c_str()));
     
-    // Filter out ROW_ID columns from activation
+    // Row ids are not data columns, so they take no part in $select - but they DO occupy a
+    // slot in the output chunk, so which slots they are must be remembered. COUNT(*) asks
+    // for nothing but a row id; forgetting that made the emit path fall back to "output
+    // slot j is data column j" and write the first column's string into a BIGINT row-id
+    // vector. See GitHub #132.
     std::vector<duckdb::column_t> visible_ids;
     visible_ids.reserve(column_ids.size());
-    for (auto &column_id : column_ids) {
+    output_column_is_row_id.assign(column_ids.size(), false);
+    for (size_t output_index = 0; output_index < column_ids.size(); ++output_index) {
+        const auto column_id = column_ids[output_index];
         if (duckdb::IsRowIdColumnId(column_id)) {
+            output_column_is_row_id[output_index] = true;
       ERPL_TRACE_DEBUG("ODATA_READ_BIND",
                        "Skipping ROW_ID column from activation mapping");
             continue;

--- a/test/sql/odata_scan_reexecution.test
+++ b/test/sql/odata_scan_reexecution.test
@@ -125,5 +125,40 @@ EXECUTE airlines_nonempty;
 ----
 true
 
+# ============================================================================
+# GitHub #132 - COUNT(*) over an ATTACHed OData table
+# ============================================================================
+
+# COUNT(*) makes DuckDB request only COLUMN_IDENTIFIER_ROW_ID. Row ids are not
+# data columns and take no part in $select, but they still occupy a slot in the
+# output chunk. Dropping them from the projection without remembering WHICH
+# slots they were made the emit path fall back to "output slot j is data column
+# j", writing the first column's string into a BIGINT row-id vector:
+#   Error: Failed to cast value: Could not convert string 'AA' to INT64
+query I
+SELECT COUNT(*) FROM trippin.Airlines;
+----
+3
+
+# The same shape with a filter, so the row-id slot coexists with pushdown.
+query I
+SELECT COUNT(*) FROM trippin.Airlines WHERE AirlineCode = 'AA';
+----
+1
+
+# A projected count must keep working - this is the case that accidentally
+# passed before, and it guards against over-correcting.
+query I
+SELECT COUNT(AirlineCode) FROM trippin.Airlines;
+----
+3
+
+# A row id alongside real data columns: the data must not shift into the row-id
+# slot or vice versa.
+query II
+SELECT COUNT(*), COUNT(DISTINCT AirlineCode) FROM trippin.Airlines;
+----
+3	3
+
 statement ok
 DETACH trippin;


### PR DESCRIPTION
```sql
ATTACH 'https://services.odata.org/TripPinRESTierService/' AS t (TYPE odata);
SELECT COUNT(*) FROM t.Airlines;
-- before: Error: Failed to cast value: Could not convert string 'AA' to INT64
-- after:  3
```

`COUNT(*)` is one of the first things anyone runs against a newly attached service, and the error pointed at data conversion — exactly the wrong place to look.

## Cause

`COUNT(*)` makes DuckDB request **only** `COLUMN_IDENTIFIER_ROW_ID`. Row ids are not data columns and take no part in `$select`, so they were correctly dropped from the projection — but they still occupy a **slot in the output chunk**, and which slots they were was never recorded.

With `activated_to_original_mapping` left empty, `GetOriginalColumnIndex(j)` falls back to returning `j`, i.e. "output slot j is data column j". So the row-id slot at index 0 was filled with data column 0 — an `AirlineCode` string written into a BIGINT vector.

That fallback also explains the odd symptom pattern:

| query | before |
|---|---|
| `SELECT * FROM t.Airlines` | worked — no row id requested |
| `SELECT COUNT(*) FROM t.Airlines a JOIN … ` | worked — the join projects a real column |
| `SELECT COUNT(*) FROM t.Airlines` | **failed** |
| `DESCRIBE t.Airlines` | correct |

The plain table function was never affected; only the catalog-backed scan is asked for a bare row id.

## Fix

Row-id positions are recorded alongside the data projection and filled with the emitted row index — monotonically increasing over the scan, which is all a row id has to be here. Data slots keep their own counter, so a row id sitting *between* data columns no longer shifts everything after it.

## Verification

Live, against TripPin:

| query | result |
|---|---|
| `SELECT COUNT(*) FROM t.Airlines` | 3 |
| `SELECT COUNT(*) FROM t.People` | 20 |
| `SELECT COUNT(AirlineCode) FROM t.Airlines` | 3 |
| `SELECT COUNT(*) … WHERE AirlineCode = 'AA'` | 1 |
| `SELECT COUNT(*), COUNT(DISTINCT AirlineCode) …` | 3, 3 |

Four E2E assertions added to `test/sql/odata_scan_reexecution.test`, including the projected-count case that passed accidentally before (so the fix cannot over-correct) and a mixed row-id-plus-data case.

Full C++ suite **376 cases / 1929 assertions**; `odata_conformance_e2e`, `odata_v2`, `odata_v4`, `odata_expand`, both storage suites, `odata_describe` and `web_core` all green.

Closes #132.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791627485&installation_model_id=425457&pr_number=135&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F135&signature=490b66f97ba0d17ce0ff22e1e364f55ff129ffbbbf4daa72d65d7d4c8082df93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->