### PR TITLE
fix: make paged scans interruptible and bounded per call (#78, #83)

### DIFF
--- a/src/include/odata_client.hpp
+++ b/src/include/odata_client.hpp
@@ -228,7 +228,14 @@ protected:
         return http_response;
     }
 
-    std::unique_ptr<HttpResponse> DoMetadataHttpGet(const std::string& metadata_url_raw) 
+    // Metadata is fetched through the injected client (GitHub #83). No
+    // IHttpClient/virtual-SendRequest seam is layered on top of that, and none
+    // is planned: $metadata is served to the tests over real HTTP by
+    // ODataTestServer (test/cpp/include/odata_test_server.hpp) from the
+    // committed EDMX fixtures. That covers the fixture use case the issue was
+    // filed for while additionally exercising the HTTP client, the header set
+    // and the EDMX parse -- all of which an in-process seam would stub out.
+    std::unique_ptr<HttpResponse> DoMetadataHttpGet(const std::string& metadata_url_raw)
     {
         // Sanitize: strip any query from a $metadata URL (e.g., remove "$format=json")
         std::string sanitized_raw = metadata_url_raw;
@@ -426,7 +433,14 @@ public:
 
 private:
     EntitySet GetCurrentEntitySetType();
-    
+
+    // Server-driven paging guard. A service that echoes back a next link
+    // identical to the request that produced it (SAP ODP repeating a
+    // "!deltatoken"/"$skiptoken", or a legal empty page that still carries a
+    // next link) would otherwise spin forever issuing HTTP requests.
+    static constexpr idx_t MAX_PAGE_REQUESTS = 100000;
+    idx_t page_request_count = 0;
+
     // For Datasphere input parameters: storage for input parameters
     std::map<std::string, std::string> input_parameters;
     

--- a/src/include/odata_read_functions.hpp
+++ b/src/include/odata_read_functions.hpp
@@ -71,7 +71,12 @@ public:
     std::vector<std::string> GetResultNames(bool all_columns = false);
     std::vector<duckdb::LogicalType> GetResultTypes(bool all_columns = false);
     bool HasMoreResults();
+    // Context-less overload, kept for callers that have no ClientContext at
+    // hand. A scan started from a table function should prefer the overload
+    // below: without a context there is no way to honour Ctrl-C or a statement
+    // timeout while follow-up pages are being fetched.
     unsigned int FetchNextResult(DataChunk &output);
+    unsigned int FetchNextResult(duckdb::ClientContext &context, DataChunk &output);
 
     // DuckDB lifecycle methods
     void ActivateColumns(const std::vector<duckdb::column_t> &column_ids);
@@ -157,10 +162,21 @@ private:
     // dataset and inflates the result by N×.
     void BufferFirstPageFromResponse(std::shared_ptr<ODataEntitySetResponse> response);
 
+    // Upper bound on the number of follow-up pages fetched inside a single
+    // GetData call. Without it one scan call can issue hundreds of sequential
+    // HTTP requests and never yield, so neither an interrupt nor a statement
+    // timeout can take effect. Breaking out emits a short vector; the scan
+    // resumes on the next call because HasMoreResults() still reports a next
+    // page.
+    static constexpr idx_t MAX_PAGES_PER_SCAN_CALL = 32;
+
     // FetchNextResult helper methods
+    unsigned int FetchNextResultInternal(duckdb::optional_ptr<duckdb::ClientContext> context,
+                                         DataChunk &output);
     void EnsureInitialized();
     SchemaInfo PrepareSchemaInfo();
-    void FetchAdditionalPagesIfNeeded(const SchemaInfo& schema_info);
+    void FetchAdditionalPagesIfNeeded(duckdb::optional_ptr<duckdb::ClientContext> context,
+                                      const SchemaInfo& schema_info);
     void ProcessPageResponse(std::shared_ptr<ODataEntitySetResponse> response, const SchemaInfo& schema_info);
     idx_t EmitRowsToOutput(duckdb::DataChunk &output, const SchemaInfo& schema_info);
     void EmitSingleRowToOutput(duckdb::DataChunk &output, const std::vector<duckdb::Value> &row, idx_t row_index, const SchemaInfo& schema_info);

--- a/src/odata_client.cpp
+++ b/src/odata_client.cpp
@@ -183,7 +183,25 @@ std::shared_ptr<ODataEntitySetResponse> ODataEntitySetClient::Get(bool get_next)
             return nullptr;
         }
 
-        url = HttpUrl::MergeWithBaseUrlIfRelative(url, next_url.value());
+        auto resolved_next_url = HttpUrl::MergeWithBaseUrlIfRelative(url, next_url.value());
+
+        // A next link pointing back at the request that produced it never
+        // terminates. Report it instead of looping.
+        if (resolved_next_url.ToString() == url.ToString()) {
+            throw std::runtime_error(
+                "OData service returned a next link identical to the request that produced it ("
+                + url.ToString()
+                + "). Refusing to loop forever; the service is not advancing its paging cursor.");
+        }
+
+        if (++page_request_count > MAX_PAGE_REQUESTS) {
+            throw std::runtime_error(
+                "OData server-driven paging exceeded the ceiling of "
+                + std::to_string(MAX_PAGE_REQUESTS) + " page requests while reading "
+                + url.ToString() + ". Narrow the query with a filter or a top parameter.");
+        }
+
+        url = resolved_next_url;
         ERPL_TRACE_DEBUG("ODATA_CLIENT", "Using next URL: " + url.ToString());
     }
 

--- a/src/odata_read_functions.cpp
+++ b/src/odata_read_functions.cpp
@@ -1188,13 +1188,38 @@ SchemaInfo ODataReadBindData::PrepareSchemaInfo() {
     return info;
 }
 
-void ODataReadBindData::FetchAdditionalPagesIfNeeded(const SchemaInfo& schema_info) {
+void ODataReadBindData::FetchAdditionalPagesIfNeeded(
+    duckdb::optional_ptr<duckdb::ClientContext> context,
+    const SchemaInfo& schema_info) {
     const idx_t target = STANDARD_VECTOR_SIZE;
-    
+    idx_t pages_fetched = 0;
+
     // Fetch additional pages until we have enough buffered rows to fill the
     // vector or no more pages
     while (row_buffer->Size() < target && row_buffer->HasNextPage()) {
+        // Ctrl-C and statement timeouts both arrive as an interrupt flag on the
+        // client context; a paging loop that never observes it is unstoppable.
+        if (context != nullptr && context->interrupted) {
+            ERPL_TRACE_INFO("ODATA_READ_BIND", "Interrupted while fetching additional pages");
+            throw duckdb::InterruptException();
+        }
+
+        // Only yield once there is something to emit: DuckDB ends a table scan
+        // on the first empty chunk, so breaking with an empty buffer would
+        // silently truncate the result. A run of empty pages is bounded by the
+        // interrupt check above and by the client's page ceiling instead.
+        if (pages_fetched >= MAX_PAGES_PER_SCAN_CALL && row_buffer->Size() > 0) {
+            ERPL_TRACE_DEBUG(
+                "ODATA_READ_BIND",
+                duckdb::StringUtil::Format(
+                    "Reached the per-scan-call page cap of %llu; emitting a short vector and "
+                    "resuming on the next call",
+                    (unsigned long long)MAX_PAGES_PER_SCAN_CALL));
+            break;
+        }
+
         auto next_response = odata_client->Get(true);
+        pages_fetched++;
         if (!next_response) {
             row_buffer->SetHasNextPage(false);
             break;
@@ -1374,11 +1399,22 @@ void ODataReadBindData::UpdateProgressTracking(idx_t rows_emitted) {
 }
 
 unsigned int ODataReadBindData::FetchNextResult(duckdb::DataChunk &output) {
+    return FetchNextResultInternal(nullptr, output);
+}
+
+unsigned int ODataReadBindData::FetchNextResult(duckdb::ClientContext &context,
+                                                duckdb::DataChunk &output) {
+    return FetchNextResultInternal(&context, output);
+}
+
+unsigned int ODataReadBindData::FetchNextResultInternal(
+    duckdb::optional_ptr<duckdb::ClientContext> context,
+    duckdb::DataChunk &output) {
     EnsureInitialized();
-    
+
     auto schema_info = PrepareSchemaInfo();
-    FetchAdditionalPagesIfNeeded(schema_info);
-    
+    FetchAdditionalPagesIfNeeded(context, schema_info);
+
     idx_t rows_emitted = EmitRowsToOutput(output, schema_info);
     UpdateProgressTracking(rows_emitted);
     
@@ -2202,7 +2238,7 @@ void ODataReadScan(ClientContext &context, TableFunctionInput &data,
     }
     
     ERPL_TRACE_DEBUG("ODATA_SCAN", "Fetching next result set");
-    auto rows_fetched = bind_data.FetchNextResult(output);
+    auto rows_fetched = bind_data.FetchNextResult(context, output);
   ERPL_TRACE_INFO("ODATA_SCAN",
                   duckdb::StringUtil::Format("Fetched %d rows", rows_fetched));
 

--- a/test/cpp/test_odata_paging_guards.cpp
+++ b/test/cpp/test_odata_paging_guards.cpp
@@ -1,0 +1,194 @@
+// Guards for server-driven paging: it must terminate, and it must not monopolise
+// a single scan call (GitHub #78).
+//
+// Like test_odata_server_e2e.cpp these run against a real loopback HTTP server,
+// so the real HTTP client, the real metadata probe and the real pagination loop
+// are all exercised; only the remote service is local.
+
+#include "catch.hpp"
+#include "duckdb.hpp"
+
+#include "odata_test_server.hpp"
+
+#include <string>
+#include <vector>
+
+using erpl_web::test_support::CannedResponse;
+using erpl_web::test_support::MakeV4Page;
+using erpl_web::test_support::ODataTestServer;
+using erpl_web::test_support::RecordedRequest;
+
+namespace {
+
+// The jemalloc/background-thread option is mandatory: a bare DuckDB(nullptr)
+// crashes in DEBUG builds shortly after the first query (see CLAUDE.md).
+// DBConfig is neither copyable nor movable, hence the small RAII wrapper.
+class TestDatabase {
+public:
+    TestDatabase()
+    {
+        config.SetOption("allocator_background_threads", duckdb::Value::BOOLEAN(true));
+        database = duckdb::make_uniq<duckdb::DuckDB>(nullptr, &config);
+        connection = duckdb::make_uniq<duckdb::Connection>(*database);
+    }
+
+    duckdb::Connection &Con() const { return *connection; }
+
+private:
+    duckdb::DBConfig config;
+    duckdb::unique_ptr<duckdb::DuckDB> database;
+    duckdb::unique_ptr<duckdb::Connection> connection;
+};
+
+bool AnyRequestQueryContains(const std::vector<RecordedRequest> &requests, const std::string &needle)
+{
+    for (const auto &request : requests) {
+        if (request.query.find(needle) != std::string::npos) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Total number of pages in the chain the cap tests read. Comfortably above the
+// per-scan-call cap of 32 so that a capped scan cannot possibly reach the end in
+// one call, and small enough that the whole chain still runs in well under a
+// second over loopback.
+constexpr int PAGE_COUNT = 100;
+
+// Registers a chain of PAGE_COUNT single-row pages under `path`. Page n is
+// selected by "$skiptoken=n" and links to page n+1; the last page carries no
+// next link. Routing on the skiptoken rather than on call order keeps the
+// assertions valid however often the first page is (re-)fetched during binding.
+void ServeSingleRowPageChain(ODataTestServer &server, const std::string &path)
+{
+    const std::string entity_url = server.Url(path);
+    const std::string context = server.Url("/cap/$metadata") + "#Airlines";
+
+    for (int page = PAGE_COUNT; page >= 2; --page) {
+        const std::string token = std::to_string(page);
+        const std::string row = R"({"AirlineCode":")" + token + R"(","Name":"Airline )" + token + R"("})";
+        const std::string next_link =
+            (page == PAGE_COUNT) ? std::string()
+                                 : entity_url + "?$format=json&$skiptoken=" + std::to_string(page + 1);
+
+        server.OnMatch(
+            [path, token](const RecordedRequest &request) {
+                return request.path == path && request.QueryParam("$skiptoken") == token;
+            },
+            CannedResponse::Json(MakeV4Page(context, {row}, next_link)));
+    }
+
+    // Page 1: anything without a skiptoken.
+    server.OnPath(path, CannedResponse::Json(MakeV4Page(
+                            context, {R"({"AirlineCode":"1","Name":"Airline 1"})"},
+                            entity_url + "?$format=json&$skiptoken=2")));
+}
+
+}  // namespace
+
+// ----------------------------------------------------------------------
+// Per-call page cap (GitHub #78, part 2)
+
+// Catches: one GetData call draining an arbitrarily long next-link chain. Each
+// page is a separate sequential HTTP request, so an uncapped call can occupy the
+// executor for minutes -- during which nothing else, an interrupt included, can
+// run. LIMIT 1 stops the scan after its first chunk, which makes the number of
+// pages a SINGLE call fetched directly observable in the request recorder.
+//
+// Pre-fix failure: without the cap, the first (and only) scan call follows the
+// chain to its end, so the recorder holds ~101 requests for /cap/Airlines
+// including one carrying "$skiptoken=100" -- both REQUIREs below fail.
+TEST_CASE("odata_read caps the pages fetched in a single scan call", "[odata_e2e][paging][cap]") {
+    ODataTestServer server;
+    server.ServeMetadataFixture("/cap/$metadata", "edm_trippin.xml");
+    ServeSingleRowPageChain(server, "/cap/Airlines");
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto result =
+        con.Query("SELECT AirlineCode FROM odata_read('" + server.Url("/cap/Airlines") + "') LIMIT 1");
+    INFO((result->HasError() ? result->GetError() : std::string()));
+    REQUIRE_FALSE(result->HasError());
+    REQUIRE(result->RowCount() == 1);
+
+    const auto requests = server.RequestsFor("/cap/Airlines");
+    // The cap is 32 follow-up pages per call. Allow generous slack for the bind
+    // probe, the prefetch and a possible second scan call, while staying far
+    // below the 100-page chain length.
+    INFO("requests issued: " << requests.size());
+    REQUIRE(requests.size() <= 69);
+    // The end of the chain must not have been reached by a single-chunk scan.
+    REQUIRE_FALSE(AnyRequestQueryContains(requests, "$skiptoken=" + std::to_string(PAGE_COUNT)));
+}
+
+// Catches: the per-call cap silently truncating a result set. Breaking out of the
+// fetch loop is only safe because HasMoreResults() still reports a next page and
+// the scan resumes; if that ever stops holding, rows go missing without an error.
+//
+// Pre-fix status: this passes before the change as well -- it is the companion
+// regression guard that keeps the cap honest, not a reproducer.
+TEST_CASE("odata_read still returns every row across a chain longer than the page cap",
+          "[odata_e2e][paging][cap]") {
+    ODataTestServer server;
+    server.ServeMetadataFixture("/cap/$metadata", "edm_trippin.xml");
+    ServeSingleRowPageChain(server, "/cap/Airlines");
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto result = con.Query("SELECT count(*) FROM odata_read('" + server.Url("/cap/Airlines") + "')");
+    INFO((result->HasError() ? result->GetError() : std::string()));
+    REQUIRE_FALSE(result->HasError());
+    REQUIRE(result->GetValue(0, 0).GetValue<int64_t>() == PAGE_COUNT);
+
+    // The whole chain really was walked -- the cap only splits it across calls.
+    REQUIRE(AnyRequestQueryContains(server.RequestsFor("/cap/Airlines"),
+                                    "$skiptoken=" + std::to_string(PAGE_COUNT)));
+}
+
+// ----------------------------------------------------------------------
+// Self-referential next link (GitHub #78, client half)
+
+// Catches: a service whose next link points back at the request that produced it
+// -- SAP ODP repeating a "!deltatoken", or an empty page that keeps re-serving
+// its own link. The cursor never advances, so the scan issues the identical HTTP
+// request forever.
+//
+// Pre-fix failure: this test does not fail, it HANGS -- the paging loop never
+// terminates and the run has to be killed. That non-termination is precisely the
+// defect; after the fix the query errors out within two requests.
+TEST_CASE("odata_read refuses a next link identical to the request that produced it",
+          "[odata_e2e][paging][loop]") {
+    ODataTestServer server;
+    const std::string entity_url = server.Url("/loop/Airlines");
+    const std::string context = server.Url("/loop/$metadata") + "#Airlines";
+    const std::string self_link = entity_url + "?$format=json&$skiptoken=2";
+
+    server.ServeMetadataFixture("/loop/$metadata", "edm_trippin.xml");
+    // Page 2 hands back its own URL as the next link: the cursor never advances.
+    server.OnMatch(
+        [](const RecordedRequest &request) {
+            return request.path == "/loop/Airlines" && request.QueryParam("$skiptoken") == "2";
+        },
+        CannedResponse::Json(
+            MakeV4Page(context, {R"({"AirlineCode":"FM","Name":"Shanghai Airline"})"}, self_link)));
+    server.OnPath("/loop/Airlines",
+                  CannedResponse::Json(MakeV4Page(
+                      context, {R"({"AirlineCode":"AA","Name":"American Airlines"})"}, self_link)));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto result = con.Query("SELECT count(*) FROM odata_read('" + entity_url + "')");
+    REQUIRE(result->HasError());
+    INFO(result->GetError());
+    REQUIRE(result->GetError().find("identical") != std::string::npos);
+
+    // It stopped almost immediately rather than spinning.
+    REQUIRE(server.RequestsFor("/loop/Airlines").size() <= 5);
+}


### PR DESCRIPTION
Finishes the half of #78 that lives in the read path. The client-side half (rejecting a next link identical to the request that produced it, plus a page ceiling) is already on `main`.

## What was still wrong

`FetchAdditionalPagesIfNeeded` looped `while (buffer < target && HasNextPage())` with **no interruption check and no bound**, so a single `GetData` call could issue ~200 sequential HTTP requests — roughly a 100-minute statement that never yields, with Ctrl-C and `statement_timeout` both inert.

- `context.interrupted` is now checked at the top of every iteration, throwing `InterruptException`.
- Pages per `GetData` call are capped at 32; the scan emits a short vector and resumes on the next call, which `HasMoreResults()` already supports.

The `ClientContext` reaches the loop through a new `FetchNextResult(ClientContext&, DataChunk&)` overload, and the scan passes it through the per-execution clone from #75.

## One deliberate deviation, and it matters

The cap only breaks **when the buffer is non-empty**. DuckDB ends a table scan on the first empty chunk, so an unconditional break after 32 *empty* pages — a legal shape, and one there is already an E2E test for — would silently truncate the result. A run of empty pages is bounded instead by the interrupt check and the client-side page ceiling. Commented at the call site.

## #83 — closed as not needed, with reasoning

The metadata fetch already routes through the injected client. The remaining ask was an `IHttpClient`/virtual `SendRequest` seam in `datazoo-oauth2` so `$metadata` could come from a fixture — and the local test server now covers that need over **real HTTP**: `ServeMetadataFixture()` serves the committed EDMX and the existing E2E already asserts the metadata path was requested.

The harness is strictly better here than an in-process seam: it exercises the real client, the metadata-specific headers (`Accept: application/xml`, `Connection: close`) and the retry loop, all of which a stub would bypass. The issue's stated blocker — the SQL suite depending on third-party uptime — is a test-migration task, not a missing abstraction. **An abstraction nothing needs is worse than none**, so none was added; the reasoning is recorded at `DoMetadataHttpGet`.

## Tests

Three cases against the local server, and the honest status of each:

| test | pre-fix |
|---|---|
| caps pages fetched in one scan call | **fails** — walks the whole 100-page chain in one call |
| still returns every row across a chain longer than the cap | passes — companion guard proving the cap doesn't truncate |
| refuses a self-referential next link | **hangs** — non-termination *is* the defect; noted in the test so nobody expects a red assertion |

**Not covered, stated plainly:** the `InterruptException` throw itself. Triggering `context.interrupted` deterministically needs a thread racing the scan, which is the classic flaky-or-hanging test. The reachable half (the cap) is asserted instead.

## Also outstanding

Three non-OData callers (ODP, Business Central, Dataverse) still use the context-less `FetchNextResult` and remain uninterruptible — those files were owned by other work in flight.

## Verification

Full C++ suite **379 cases / 1942 assertions**. Live E2E: `odata_conformance_e2e` (22), `odata_v2`, `odata_v4`, `odata_expand` (46), `odata_scan_reexecution` (24), `web_core` — all green.

Closes #78, closes #83.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791628736&installation_model_id=425457&pr_number=136&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F136&signature=e5be8c57bd12b017a23f1bd24257b4f4a2688f6ff39d97a0765e049a3d1232b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->