### PR TITLE
fix: repair two silent-wrong-data regressions found by review

### DIFF
--- a/src/include/odata_content.hpp
+++ b/src/include/odata_content.hpp
@@ -92,6 +92,12 @@ public:
 
     //! The detection order the readers should use: what the service declared in its headers
     //! first, payload sniffing second, V4 as the last resort.
+
+    //! Detects the version to PARSE this body with: payload first, because the body is
+    //! ground truth for its own shape; then the response headers, which are what help when
+    //! the body says nothing (empty, non-JSON, or an error document). The declared protocol
+    //! version does not determine the JSON shape - OData v3 announces "DataServiceVersion:
+    //! 3.0" for both the verbose format ("d" wrapper) and minimalmetadata ("value" array).
     static ODataVersion DetectODataVersion(const std::string& content, const HeaderMap& headers);
 
     //! Decodes a top-level OData error payload (v2 or v4 shape). Returns nullopt when the body

--- a/src/include/odata_read_functions.hpp
+++ b/src/include/odata_read_functions.hpp
@@ -176,6 +176,11 @@ private:
     // but they still occupy a position in the chunk, so the positional correspondence has
     // to be recorded or every later slot reads the wrong column. See GitHub #132.
     std::vector<bool> output_column_is_row_id;
+
+    // Kept on the bind data, not only inside the log: CloneForScan mints a FRESH log per
+    // execution, so a flag stored solely in the log is silently dropped and the documented
+    // strict_typing parameter becomes a no-op. See GitHub #74 and #75.
+    bool strict_typing_ = false;
     
     // Configuration
     std::map<std::string, std::string> input_parameters;

--- a/src/include/odp_odata_read_bind_data.hpp
+++ b/src/include/odp_odata_read_bind_data.hpp
@@ -168,6 +168,17 @@ public:
      */
     void Initialize();
 
+    /**
+     * @brief Called when the scan is finished, however it finished.
+     *
+     * Commits a staged delta token. The scan can end WITHOUT a final zero-row
+     * FetchNextResult - OdpODataReadScan returns early when HasMoreResults() is already
+     * false - so relying on the fetch path alone means a normally drained scan never
+     * advances the subscription and every read re-extracts from the old token.
+     * Idempotent, so it is safe to call from both exits.
+     */
+    void FinalizeScan();
+
 private:
     // ========================================================================
     // Core Components (Composition Pattern)

--- a/src/odata_predicate_pushdown_helper.cpp
+++ b/src/odata_predicate_pushdown_helper.cpp
@@ -175,6 +175,11 @@ void ODataPredicatePushdownHelper::ConsumeColumnSelection(const std::vector<duck
 }
 
 void ODataPredicatePushdownHelper::ConsumeFilters(duckdb::optional_ptr<duckdb::TableFilterSet> filters) {
+    // Recomputed from scratch for this filter set. Leaving it set would make $top/$skip
+    // suppression sticky: one untranslatable filter would keep suppressing them for every
+    // later use of the same helper, even after the filters were replaced.
+    has_untranslated_filter = false;
+
     if (filters && !filters->filters.empty()) {
         std::stringstream filters_str;
         /*

--- a/src/odata_read_functions.cpp
+++ b/src/odata_read_functions.cpp
@@ -445,6 +445,7 @@ ODataReadBindData::~ODataReadBindData() {
 }
 
 void ODataReadBindData::SetStrictTyping(bool strict) {
+  strict_typing_ = strict;
   if (!conversion_failure_log) {
     conversion_failure_log = std::make_shared<ConversionFailureLog>();
   }
@@ -1640,6 +1641,11 @@ duckdb::unique_ptr<ODataReadBindData> ODataReadBindData::CloneForScan() const {
 
   clone->service_root_mode_ = service_root_mode_;
   clone->InitializeComponents(service_root_mode_);
+
+  // InitializeComponents mints a fresh ConversionFailureLog for this execution, which is
+  // what gives the log the right lifetime - but it also resets strict typing, so the
+  // bind-time choice has to be re-applied or strict_typing=true silently does nothing.
+  clone->SetStrictTyping(strict_typing_);
 
   // Schema and configuration: pure values, safe to copy.
   clone->all_result_names = all_result_names;

--- a/src/odp_odata_read_bind_data.cpp
+++ b/src/odp_odata_read_bind_data.cpp
@@ -429,6 +429,10 @@ void OdpODataReadBindData::ProcessRequestResult(const OdpRequestOrchestrator::Od
     }
 }
 
+void OdpODataReadBindData::FinalizeScan() {
+    CommitStagedDeltaToken();
+}
+
 void OdpODataReadBindData::CommitStagedDeltaToken() {
     if (!has_staged_delta_token_) {
         return;
@@ -437,20 +441,23 @@ void OdpODataReadBindData::CommitStagedDeltaToken() {
     ERPL_TRACE_INFO("ODP_BIND_DATA",
                     "Scan drained; committing staged delta token for " + staged_operation_type_);
 
-    // Clear the staging flag first, so a failure to persist cannot be retried in a loop
-    // and cannot be committed twice if the scan is drained more than once.
-    has_staged_delta_token_ = false;
     const auto token = staged_delta_token_;
     const auto operation_type = staged_operation_type_;
     const auto preference_applied = staged_preference_applied_;
-    staged_delta_token_.clear();
-    staged_operation_type_.clear();
 
+    // Persist FIRST. Clearing the staging fields up front would discard the token if the
+    // write then failed, and the next read would re-extract from the previous position.
+    // The flag is cleared only once the write has succeeded, which also makes a second
+    // call a no-op when the scan is drained more than once.
     if (operation_type == "initial_load") {
         state_manager_->TransitionToDeltaFetch(token, preference_applied);
     } else {
         state_manager_->UpdateDeltaToken(token);
     }
+
+    has_staged_delta_token_ = false;
+    staged_delta_token_.clear();
+    staged_operation_type_.clear();
 }
 
 void OdpODataReadBindData::UpdateODataClient(const std::string& url) {

--- a/src/odp_odata_read_functions.cpp
+++ b/src/odp_odata_read_functions.cpp
@@ -95,6 +95,10 @@ void OdpODataReadScan(duckdb::ClientContext &context, duckdb::TableFunctionInput
         // Check if we have more results using ODP logic
         if (!bind_data.HasMoreResults()) {
             ERPL_TRACE_DEBUG("ODP_ODATA_READ_SCAN", "No more results available");
+            // This is a real end of scan, and often the ONLY one: when the buffer is
+            // already drained the scan returns here without a final zero-row fetch, so
+            // the staged delta token has to be committed from this exit too.
+            bind_data.FinalizeScan();
             return;
         }
         
@@ -103,6 +107,10 @@ void OdpODataReadScan(duckdb::ClientContext &context, duckdb::TableFunctionInput
         unsigned int rows_fetched = bind_data.FetchNextResult(output);
         
         ERPL_TRACE_INFO("ODP_ODATA_READ_SCAN", duckdb::StringUtil::Format("Fetched %d rows", rows_fetched));
+
+        if (rows_fetched == 0) {
+            bind_data.FinalizeScan();
+        }
         
     } catch (const std::exception& e) {
         ERPL_TRACE_ERROR("ODP_ODATA_READ_SCAN", "Scan failed: " + std::string(e.what()));

--- a/test/cpp/test_conversion_failure_reporting.cpp
+++ b/test/cpp/test_conversion_failure_reporting.cpp
@@ -248,3 +248,37 @@ TEST_CASE("Out-of-range integers are reported, not zeroed", "[conversion_failure
     REQUIRE(failures[0].first_error_message.find("does not fit") != std::string::npos);
     REQUIRE(failures[0].first_offending_value == "4294967295");
 }
+
+TEST_CASE("strict_typing survives the per-scan clone", "[conversion_failure]") {
+    // CloneForScan mints a fresh ConversionFailureLog per execution, which is what gives
+    // the log the right lifetime - but strict typing lived only inside the log, so the
+    // clone silently reset it and the documented strict_typing=true parameter became a
+    // no-op for every odata_read() query. Neither #74's nor #75's tests caught it,
+    // because no test drove the flag through the table function.
+    auto client = MakeOfflineEntitySetClient();
+    ODataReadBindData bind_data(client);
+
+    bind_data.SetStrictTyping(true);
+    REQUIRE(bind_data.GetConversionFailureLog() != nullptr);
+    REQUIRE(bind_data.GetConversionFailureLog()->IsStrictTyping());
+
+    auto clone = bind_data.CloneForScan();
+    REQUIRE(clone != nullptr);
+    REQUIRE(clone->GetConversionFailureLog() != nullptr);
+    REQUIRE(clone->GetConversionFailureLog()->IsStrictTyping());
+
+    // The clone must own a DIFFERENT log, so failures are reported per execution rather
+    // than accumulating across re-executions of one bound plan.
+    REQUIRE(clone->GetConversionFailureLog() != bind_data.GetConversionFailureLog());
+}
+
+TEST_CASE("a non-strict bind data clones as non-strict", "[conversion_failure]") {
+    auto client = MakeOfflineEntitySetClient();
+    ODataReadBindData bind_data(client);
+    bind_data.SetStrictTyping(false);
+
+    auto clone = bind_data.CloneForScan();
+    REQUIRE(clone != nullptr);
+    REQUIRE(clone->GetConversionFailureLog() != nullptr);
+    REQUIRE_FALSE(clone->GetConversionFailureLog()->IsStrictTyping());
+}


### PR DESCRIPTION
A crew review of the second wave found two **silent-wrong-data regressions introduced by that wave itself**. Both are fixed here. This is the failure mode the review was specifically asked to hunt, and both slipped past the individual PRs' tests.

## F1 — `strict_typing = true` was a no-op

`CloneForScan` (#75) calls `InitializeComponents`, which mints a fresh `ConversionFailureLog` per execution — that is exactly what gives the log the right lifetime. But the strict-typing flag lived **only inside the log**, so the clone reset it to false and the documented `strict_typing` parameter did nothing for every `odata_read()` query.

One new fix silently disabling another new fix, invisible to both PRs because no test drove the flag through the table function. The flag now lives on the bind data and is re-applied to the clone.

**Red proof** — with only the re-application line removed:
```
test_conversion_failure_reporting.cpp:268: FAILED
test cases: 10 | 9 passed | 1 failed
```

## F2 — the staged ODP delta token was never committed

Worse, and also mine. The staged commit (#62) fired from a zero-row `FetchNextResult` — but `OdpODataReadScan` **returns early** when `HasMoreResults()` is already false, which is the common exit. So a normally drained ODP scan never advanced the subscription, and every read re-extracted from the old token.

The fix that was supposed to prevent premature commits ended up preventing commits altogether. Both exits now call an idempotent `FinalizeScan()`.

## F4, F5, F8

- **F4:** `CommitStagedDeltaToken` cleared its staging fields *before* persisting, so a failed write discarded the token rather than leaving it to be retried. Persist first, clear on success.
- **F5:** `has_untranslated_filter` was never reset, making `$top`/`$skip` suppression **sticky** — one untranslatable filter kept suppressing them for every later use of the same helper, even after the filters were replaced.
- **F8:** the comment on the version-detection API described the opposite of the shipped precedence.

## Two findings I disputed, and the review agreed on re-checking

Row-id slots *are* correct on the clone (`ActivateColumns` runs on it in `InitGlobal`), and the ODP compare-and-swap *does* reach the repository (the state manager passes its held token as the expectation). Recorded so they are not re-litigated.

## Still open from the review, not in this PR

- **F3:** `HttpParams` snapshots the TLS policy in its constructor, so `SET erpl_ca_cert_file` after `ATTACH` never reaches a long-lived catalog client — which contradicts `docs/TLS.md`. Needs a submodule change; filing separately.
- **F6:** `tls_settings.test` asserts the settings exist but never that a handshake is actually enforced. The badssl checks were run by hand; they should be in the suite.
- **F7:** the new E2E suites hit the public internet unconditionally and pin literal counts against a *writable* sandbox service.
- **F9:** `Edm.Decimal` with absent Scale now maps to DOUBLE — a deliberate but user-visible type change for shipped schemas.
- **F11:** the claimed unification of quote-aware scanning is incomplete — the expand parser kept a private copy.

## Verification

Full C++ suite **381 cases / 1951 assertions**. Live E2E: `odata_conformance_e2e` (22), `odata_v2`, `odata_v4`, `odata_expand` (46), `odata_scan_reexecution` (24), `web_core`, `tls_settings` — all green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791629909&installation_model_id=425457&pr_number=137&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F137&signature=134065a71bda9e3c3a9ac085def63979ce799e4f3e5547d64ca30cb9c9dd0079"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->