### PR TITLE
fix: ODP 202 handling, real Preference-Applied validation, change-stream contract (#97, #98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,23 @@ SELECT TOP 5 UserName, FirstName FROM trippin.People;
 
 ---
 
+## 🔁 SAP ODP (Operational Data Provisioning)
+
+`odp_odata_read()` reads SAP ODP delta-enabled services, doing a full initial load once and then
+fetching only what changed on each subsequent read.
+
+```sql
+SELECT * FROM odp_odata_read('https://sap.example.com/sap/opu/odata/sap/ZSRV/EntitySet');
+SELECT * FROM odp_odata_list_subscriptions();
+```
+
+> ⚠️ **`odp_odata_read` returns a change stream, not a snapshot.** After the initial load each read
+> returns inserts, updates **and deletes**, marked by the `ODQ_CHANGEMODE` column (`'D'` = delete).
+> A plain `INSERT INTO ... SELECT` will silently apply deletes as inserts. See
+> **[docs/ODP.md](docs/ODP.md)** for the full contract and a correct merge pattern.
+
+---
+
 ## 🟦 SAP Datasphere (DWAAS Core + Catalog)
 
 ERPL Web includes first-class support for SAP Datasphere using a secured OAuth2 secret. The extension integrates both the DWAAS core APIs and the Catalog OData service to provide discovery and rich metadata.

--- a/docs/ODP.md
+++ b/docs/ODP.md
@@ -1,0 +1,165 @@
+# SAP ODP (Operational Data Provisioning)
+
+`odp_odata_read()` reads an SAP ODP delta-enabled OData service. It is the only reader in this
+extension whose result set is **not** a snapshot.
+
+> **Read the [Change stream contract](#change-stream-contract) before you write the target table.**
+> Consuming an ODP read with a plain `INSERT` is silently wrong once the first delta arrives.
+
+---
+
+## Functions
+
+| Function | Purpose |
+|---|---|
+| `odp_odata_read(entity_set_url, ...)` | Read an ODP entity set; performs an initial load, then delta fetches |
+| `odp_odata_show(service_url, ...)` | Discover the ODP-enabled entity sets a service exposes |
+| `odp_odata_list_subscriptions()` | List the local subscriptions and their delta tokens |
+| `PRAGMA odp_odata_remove_subscription(subscription_id, ...)` | Forget a subscription locally |
+
+### `odp_odata_read` named parameters
+
+| Parameter | Type | Meaning |
+|---|---|---|
+| `secret` | `VARCHAR` | Name of the DuckDB secret to authenticate with |
+| `force_full_load` | `BOOLEAN` | Discard the stored delta token and re-run an initial load |
+| `import_delta_token` | `VARCHAR` | Adopt a delta token obtained elsewhere |
+| `max_page_size` | `UINTEGER` | Override the `odata.maxpagesize` preference (default 15000) |
+
+---
+
+## Change stream contract
+
+An ODP subscription has two phases:
+
+1. **Initial load** — the first read returns the full current contents of the operational
+   provider, and SAP's ODQ starts recording changes. The extension sends
+   `Prefer: odata.track-changes` and requires the service to confirm it with
+   `Preference-Applied: odata.track-changes`.
+2. **Delta fetch** — every subsequent read returns **only what changed** since the previous read:
+   inserted rows, updated rows, **and deleted rows**.
+
+So the result of `odp_odata_read` is a stream of change records, not a table state. The row count
+of a delta read is the size of the change set, not the size of the source.
+
+### The change-mode marker
+
+SAP marks each row with its change type. In the EDMX the marker is an ordinary property annotated
+`sap:semantics="change-mode"` — conventionally named **`ODQ_CHANGEMODE`**:
+
+```xml
+<Property Name="ODQ_CHANGEMODE" Type="Edm.String" Nullable="false" MaxLength="1"
+          sap:semantics="change-mode" .../>
+```
+
+Because it is a normal EDM property (and, in BW extractors, part of the entity key), **it is
+already present in the result set of `odp_odata_read` as an ordinary column**. The extension does
+not add it, rename it, hide it, or interpret it — it passes through like any other column.
+
+Values you should expect:
+
+| Value | Meaning |
+|---|---|
+| `''` (empty) or `'C'` | Insert / new image. Rows of an **initial load** carry this. |
+| `'U'` | Update — an after-image of a changed record |
+| `'D'` | **Delete** — the record identified by the key no longer exists |
+
+A companion property annotated `sap:semantics="entity-counter"` (conventionally
+`ODQ_ENTITYCNTR`) orders the records within a package; where one record is changed more than once
+in a delta, the highest counter is the winning image.
+
+> **Unverified against a live system.** The exact set of marker values, and their per-provider
+> spelling, is SAP-side behaviour that could not be exercised here (no ODP system or credentials
+> were available during this work). `'D'` for delete is well established; treat the rest as
+> indicative and confirm against your own provider before relying on it. Prefer testing for
+> "is it a delete" (`ODQ_CHANGEMODE = 'D'`) over enumerating every other value.
+
+### Consuming a change stream correctly
+
+Do **not** do this — deletes are appended as if they were new rows, and updates duplicate keys:
+
+```sql
+-- WRONG for anything after the initial load
+INSERT INTO target SELECT * FROM odp_odata_read('...');
+```
+
+Land the change set and apply it as a merge, deletes first:
+
+```sql
+CREATE TEMP TABLE changes AS
+SELECT * FROM odp_odata_read('https://sap.example.com/sap/opu/odata/sap/ZSRV/EntitySet');
+
+-- 1. remove everything the change set touches (handles both updates and deletes)
+DELETE FROM target
+WHERE (key_a, key_b) IN (SELECT key_a, key_b FROM changes);
+
+-- 2. re-insert only the surviving after-images
+INSERT INTO target
+SELECT * FROM changes
+WHERE ODQ_CHANGEMODE <> 'D'
+QUALIFY row_number() OVER (PARTITION BY key_a, key_b ORDER BY ODQ_ENTITYCNTR DESC) = 1;
+```
+
+If you only ever want current state and never want to think about this, use `force_full_load =>
+true` on every read. That is correct but re-transfers the whole provider each time, which is the
+cost ODP exists to avoid.
+
+### Why there is no separate normalised marker column
+
+The marker is already in the result set under its SAP name, and it is part of the entity key on
+BW extractors. Adding a second, normalised column (say `_change_type`) would:
+
+- widen the schema of every existing `SELECT *` against `odp_odata_read`, breaking positional
+  consumers and any `CREATE TABLE AS` target already in production;
+- duplicate a value that is already present, creating a second source of truth to keep in sync;
+- still not remove the need to understand the contract above, because the merge logic is the
+  hard part, not the column name.
+
+The contract is therefore documented rather than encoded. If a future change does surface a
+normalised marker, it should be opt-in via a named parameter so that existing schemas are
+unaffected.
+
+---
+
+## Change tracking must be confirmed, not assumed
+
+The extension advances a subscription from initial load to delta fetch **only** when the service
+answered the initial load with `Preference-Applied: odata.track-changes`. If that header is
+missing, the subscription deliberately stays in initial-load mode and logs a warning:
+
+```
+Initial load response did not carry 'Preference-Applied: odata.track-changes'.
+Change tracking was NOT established; ...
+```
+
+This is the safe failure: you get a full re-read (correct data, more traffic) rather than a
+"delta" computed over data that was never change-tracked, which would silently miss every change
+made in between. Turn on tracing (`SET erpl_trace_enabled = TRUE`) if you see repeated full loads
+— an absent `Preference-Applied` is the usual cause, and it normally means the entity set is not
+actually delta-enabled.
+
+## Long-running extractions (HTTP 202)
+
+A large extraction can take SAP longer to prepare than one request will wait for. The service then
+answers `202 Accepted` and the extension re-polls, honouring the `Retry-After` header in both of
+its permitted forms (a number of seconds, or an HTTP date), following the `Location` header when
+one is supplied. Re-polling is bounded: it stops after a maximum number of attempts or once a total
+wait budget is exhausted, and then raises an error naming the URL and how long it waited, rather
+than stalling indefinitely.
+
+## Subscriptions are persistent, and live on the SAP side too
+
+`odp_odata_list_subscriptions()` shows the subscriptions this extension is tracking, stored in a
+persistent DuckDB database. The corresponding **ODQ subscription exists on the SAP system** and is
+not managed by that table.
+
+`PRAGMA odp_odata_remove_subscription(...)` forgets a subscription **locally only**. It does not
+terminate the subscription in ODQ. An orphaned ODQ subscription keeps the SAP system retaining
+delta queue data for a consumer that will never come back — which consumes space and can hold up
+housekeeping on the provider.
+
+If you remove a subscription locally and do not intend to resume it, terminate it on the SAP side
+as well, via ODQMON (transaction `ODQMON`) or your Basis team's usual process. This extension
+deliberately does **not** implement remote termination: doing it correctly requires a CSRF token
+fetch and a retry, and a half-working implementation that appears to clean up but does not is worse
+than an explicit hand-off.

--- a/src/include/odp_client_integration.hpp
+++ b/src/include/odp_client_integration.hpp
@@ -53,20 +53,6 @@ public:
     std::unique_ptr<HttpResponse> ExecuteMetadataRequest(const std::string& metadata_url);
 
     /**
-     * @brief Execute an ODP subscription termination request
-     * @param termination_url Termination function URL
-     * @return HTTP response from termination request
-     */
-    std::unique_ptr<HttpResponse> ExecuteTerminationRequest(const std::string& termination_url);
-
-    /**
-     * @brief Execute an ODP delta token discovery request
-     * @param delta_links_url DeltaLinksOf<EntitySet> URL
-     * @return HTTP response containing available delta tokens
-     */
-    std::unique_ptr<HttpResponse> ExecuteDeltaTokenDiscovery(const std::string& delta_links_url);
-
-    /**
      * @brief Get the ODP HTTP request factory instance
      * @return Reference to the factory
      */

--- a/src/include/odp_http_request_factory.hpp
+++ b/src/include/odp_http_request_factory.hpp
@@ -62,20 +62,6 @@ public:
     HttpRequest CreateMetadataRequest(const std::string& metadata_url);
 
     /**
-     * @brief Create HTTP request for ODP subscription termination
-     * @param termination_url URL for termination function
-     * @return Configured HttpRequest for subscription termination
-     */
-    HttpRequest CreateTerminationRequest(const std::string& termination_url);
-
-    /**
-     * @brief Create HTTP request for delta token discovery
-     * @param delta_links_url URL for DeltaLinksOf<EntitySet> endpoint
-     * @return Configured HttpRequest for delta token discovery
-     */
-    HttpRequest CreateDeltaTokenDiscoveryRequest(const std::string& delta_links_url);
-
-    /**
      * @brief Create generic ODP request with custom configuration
      * @param method HTTP method
      * @param url Target URL

--- a/src/include/odp_odata_read_bind_data.hpp
+++ b/src/include/odp_odata_read_bind_data.hpp
@@ -134,12 +134,6 @@ public:
     void ForceInitialLoad();
 
     /**
-     * @brief Terminate the subscription
-     * This will mark the subscription as terminated and clean up resources
-     */
-    void TerminateSubscription();
-
-    /**
      * @brief Get audit history for this subscription
      * @param days_back Number of days to look back (default: 30)
      * @return Vector of audit entries
@@ -201,6 +195,12 @@ private:
     std::string pending_next_url_;
     bool initial_load_in_progress_;
     bool delta_fetch_in_progress_;
+    /// Whether the FIRST response of the current initial load carried
+    /// `Preference-Applied: odata.track-changes`. Only that response answers the `Prefer` header we
+    /// sent; the follow-on `__next` page requests do not carry the preference and so cannot
+    /// re-confirm it. Captured here so the deferred multi-page state transition uses the server's
+    /// actual answer rather than re-inferring it. See GitHub #97.
+    bool initial_load_preference_applied_ = false;
 
     // Column projection: saved in ActivateColumns and re-applied to each replacement
     // odata_bind_data_ created by FetchAndLoadNextPage, so column mapping is consistent

--- a/src/include/odp_request_orchestrator.hpp
+++ b/src/include/odp_request_orchestrator.hpp
@@ -4,6 +4,8 @@
 #include "odata_client.hpp"
 #include "datazoo/oauth2/http_client.hpp"
 #include "tracing.hpp"
+#include <chrono>
+#include <functional>
 #include <memory>
 #include <string>
 #include <optional>
@@ -26,18 +28,44 @@ public:
         std::shared_ptr<ODataEntitySetResponse> response;
         std::string extracted_delta_token;
         std::string extracted_delta_url;
+        /// Headers of the HTTP response that produced `response`. Preserved verbatim so that
+        /// callers can validate server behaviour (notably `Preference-Applied`) rather than
+        /// inferring it from the payload. `HeaderMap` lookup is case-insensitive.
+        HeaderMap response_headers;
+        /// True only when the server actually echoed `Preference-Applied: odata.track-changes`.
+        /// Never inferred from the presence of a delta token - see GitHub #97.
         bool preference_applied;
         bool has_more_pages;
         int http_status_code;
         size_t response_size_bytes;
-        
-        OdpRequestResult() 
+
+        OdpRequestResult()
             : preference_applied(false)
             , has_more_pages(false)
             , http_status_code(0)
-            , response_size_bytes(0) 
+            , response_size_bytes(0)
         {}
     };
+
+    /**
+     * @brief Bounds the re-poll loop that services HTTP 202 Accepted responses.
+     *
+     * SAP answers 202 while an extraction package is still being prepared. The client must
+     * wait and ask again; these limits stop that from becoming an unbounded stall.
+     */
+    struct RetryPolicy {
+        /// Maximum number of 202 responses tolerated before giving up.
+        uint32_t max_attempts = 20;
+        /// Wait used when a 202 carries no (or an unparsable) `Retry-After` header.
+        std::chrono::milliseconds default_delay{std::chrono::seconds(5)};
+        /// Upper bound on the summed wait across all re-polls of a single request.
+        std::chrono::milliseconds max_total_wait{std::chrono::minutes(10)};
+    };
+
+    /// Injection seam for the wait between re-polls. Defaults to `std::this_thread::sleep_for`.
+    /// Tests substitute a recording no-op so that they exercise the retry arithmetic without
+    /// actually sleeping.
+    using SleepFunction = std::function<void(std::chrono::milliseconds)>;
 
     /**
      * @brief Construct orchestrator with authentication parameters
@@ -118,12 +146,35 @@ public:
      */
     uint32_t GetDefaultPageSize() const;
 
+    /**
+     * @brief Replace the bounds applied to the HTTP 202 re-poll loop
+     */
+    void SetRetryPolicy(const RetryPolicy& policy);
+
+    /**
+     * @brief Get the bounds currently applied to the HTTP 202 re-poll loop
+     */
+    const RetryPolicy& GetRetryPolicy() const;
+
+    /**
+     * @brief Replace the function used to wait between re-polls (test seam)
+     * @param sleep_function Callable invoked with the duration to wait; ignored when empty
+     */
+    void SetSleepFunction(SleepFunction sleep_function);
+
 private:
     // Core components
     std::unique_ptr<OdpHttpRequestFactory> http_factory_;
     std::shared_ptr<HttpClient> http_client_;
     std::shared_ptr<HttpAuthParams> auth_params_;
     uint32_t default_page_size_;
+    RetryPolicy retry_policy_;
+    SleepFunction sleep_function_;
+
+    /// Send `request`, servicing any HTTP 202 Accepted responses by waiting for the interval the
+    /// server asks for and asking again, within the bounds of `retry_policy_`.
+    std::unique_ptr<HttpResponse> SendRequestHandlingAccepted(const HttpRequest& request,
+                                                             const std::string& operation_type);
 
     // Helper methods
     OdpRequestResult ExecuteRequest(const HttpRequest& request, const std::string& operation_type);
@@ -139,6 +190,21 @@ public:
     static std::string EnsureJsonFormat(const std::string& url);
     static bool HasJsonFormat(const std::string& url);
     static bool ValidatePreferenceApplied(const HttpResponse& response);
+
+    /**
+     * @brief Parse an HTTP `Retry-After` header value (RFC 7231 section 7.1.3)
+     *
+     * Accepts both permitted forms: delta-seconds (`"120"`) and an HTTP-date
+     * (`"Wed, 21 Oct 2015 07:28:00 GMT"`, plus the two obsolete date formats recipients are
+     * required to tolerate). A date already in the past yields a zero wait.
+     *
+     * @param header_value Raw header value
+     * @param now Reference instant against which an HTTP-date is measured
+     * @return The wait requested, or std::nullopt when the value cannot be parsed
+     */
+    static std::optional<std::chrono::milliseconds> ParseRetryAfter(
+        const std::string& header_value,
+        std::chrono::system_clock::time_point now);
 
     // Strip surrounding single/double quotes from a raw delta token if present.
     static std::string NormalizeDeltaToken(const std::string& raw);

--- a/src/odp_client_integration.cpp
+++ b/src/odp_client_integration.cpp
@@ -40,20 +40,6 @@ std::unique_ptr<HttpResponse> OdpClientIntegration::ExecuteMetadataRequest(const
     return ExecuteRequest(request);
 }
 
-std::unique_ptr<HttpResponse> OdpClientIntegration::ExecuteTerminationRequest(const std::string& termination_url) {
-    ERPL_TRACE_INFO("ODP_CLIENT_INTEGRATION", "Executing ODP termination request for URL: " + termination_url);
-    
-    auto request = request_factory_->CreateTerminationRequest(termination_url);
-    return ExecuteRequest(request);
-}
-
-std::unique_ptr<HttpResponse> OdpClientIntegration::ExecuteDeltaTokenDiscovery(const std::string& delta_links_url) {
-    ERPL_TRACE_INFO("ODP_CLIENT_INTEGRATION", "Executing ODP delta token discovery for URL: " + delta_links_url);
-    
-    auto request = request_factory_->CreateDeltaTokenDiscoveryRequest(delta_links_url);
-    return ExecuteRequest(request);
-}
-
 OdpHttpRequestFactory& OdpClientIntegration::GetRequestFactory() {
     return *request_factory_;
 }

--- a/src/odp_http_request_factory.cpp
+++ b/src/odp_http_request_factory.cpp
@@ -44,28 +44,6 @@ HttpRequest OdpHttpRequestFactory::CreateMetadataRequest(const std::string& meta
     return CreateRequest(HttpMethod::GET, metadata_url, config);
 }
 
-HttpRequest OdpHttpRequestFactory::CreateTerminationRequest(const std::string& termination_url) {
-    ERPL_TRACE_INFO("ODP_HTTP_FACTORY", "Creating termination request for URL: " + termination_url);
-    
-    OdpRequestConfig config;
-    config.enable_change_tracking = false;
-    config.request_json = true;
-    config.odata_version = ODataVersion::V2;
-    
-    return CreateRequest(HttpMethod::GET, termination_url, config);
-}
-
-HttpRequest OdpHttpRequestFactory::CreateDeltaTokenDiscoveryRequest(const std::string& delta_links_url) {
-    ERPL_TRACE_INFO("ODP_HTTP_FACTORY", "Creating delta token discovery request for URL: " + delta_links_url);
-    
-    OdpRequestConfig config;
-    config.enable_change_tracking = false;
-    config.request_json = true;
-    config.odata_version = ODataVersion::V2;
-    
-    return CreateRequest(HttpMethod::GET, delta_links_url, config);
-}
-
 HttpRequest OdpHttpRequestFactory::CreateRequest(HttpMethod method, const std::string& url, const OdpRequestConfig& config) {
     ERPL_TRACE_DEBUG("ODP_HTTP_FACTORY", "Creating HTTP request with method: " + method.ToString() + ", URL: " + url);
     

--- a/src/odp_odata_read_bind_data.cpp
+++ b/src/odp_odata_read_bind_data.cpp
@@ -180,17 +180,9 @@ void OdpODataReadBindData::ForceInitialLoad() {
     pending_next_url_              = "";
     initial_load_in_progress_      = false;
     delta_fetch_in_progress_       = false;
+    initial_load_preference_applied_ = false;
 
     CreateODataBindData();
-}
-
-void OdpODataReadBindData::TerminateSubscription() {
-    ERPL_TRACE_INFO("ODP_BIND_DATA", "Terminating subscription");
-    
-    state_manager_->TransitionToTerminated();
-    
-    // TODO: Call SAP termination endpoint if needed
-    // This would require implementing the termination request in the orchestrator
 }
 
 std::vector<OdpAuditEntry> OdpODataReadBindData::GetAuditHistory(int days_back) const {
@@ -294,6 +286,10 @@ bool OdpODataReadBindData::HandleInitialLoad() {
         if (!result.response) {
             return false;
         }
+
+        // Only this first response answers the `Prefer: odata.track-changes` we sent, so record
+        // the server's answer now; later pages cannot re-confirm it.
+        initial_load_preference_applied_ = result.preference_applied;
 
         auto first_next = result.response->NextUrl();
         pending_next_url_ = (first_next.has_value() && !first_next->empty())
@@ -628,7 +624,11 @@ void OdpODataReadBindData::FetchAndLoadNextPage() {
 
         if (initial_load_in_progress_) {
             initial_load_in_progress_  = false;
-            last_page.preference_applied = !norm_token.empty();
+            // Carry forward the preference the SERVER confirmed on the first page. Deriving it
+            // from "we got a token" here would re-introduce the silent-data-loss path that
+            // GitHub #97 closed: a token without change tracking transitions the subscription to
+            // DELTA_FETCH over data that was never tracked.
+            last_page.preference_applied = initial_load_preference_applied_;
             ProcessRequestResult(last_page, "initial_load");
         } else if (delta_fetch_in_progress_) {
             delta_fetch_in_progress_   = false;

--- a/src/odp_request_orchestrator.cpp
+++ b/src/odp_request_orchestrator.cpp
@@ -1,16 +1,91 @@
 #include "odp_request_orchestrator.hpp"
 #include "tracing.hpp"
 #include "yyjson.hpp"
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <ctime>
+#include <iomanip>
+#include <locale>
 #include <regex>
 #include <sstream>
+#include <thread>
 
 namespace erpl_web {
+
+namespace {
+
+/// HTTP status returned by SAP while an extraction package is still being prepared.
+constexpr int HTTP_STATUS_ACCEPTED = 202;
+
+/// Days since the Unix epoch for a proleptic Gregorian y/m/d, after Howard Hinnant's
+/// `days_from_civil`. Used instead of `timegm` (absent on MSVC) or `_mkgmtime` (absent
+/// everywhere else) so that HTTP-date handling is identical on every supported platform.
+int64_t DaysFromCivil(int64_t year, uint32_t month, uint32_t day)
+{
+    year -= (month <= 2) ? 1 : 0;
+    const int64_t era = (year >= 0 ? year : year - 399) / 400;
+    const uint32_t year_of_era = static_cast<uint32_t>(year - era * 400);
+    const uint32_t day_of_year =
+        (153 * (month + (month > 2 ? -3 : 9)) + 2) / 5 + day - 1;
+    const uint32_t day_of_era =
+        year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    return era * 146097 + static_cast<int64_t>(day_of_era) - 719468;
+}
+
+/// Convert a `std::tm` already expressed in UTC to a Unix timestamp, without consulting
+/// the process timezone (which is what `std::mktime` would do).
+int64_t TimestampFromUtcTm(const std::tm& time_fields)
+{
+    const int64_t days = DaysFromCivil(static_cast<int64_t>(time_fields.tm_year) + 1900,
+                                       static_cast<uint32_t>(time_fields.tm_mon) + 1,
+                                       static_cast<uint32_t>(time_fields.tm_mday));
+    return days * 86400 + time_fields.tm_hour * 3600 + time_fields.tm_min * 60 + time_fields.tm_sec;
+}
+
+std::string TrimWhitespace(const std::string& value)
+{
+    const auto first = value.find_first_not_of(" \t\r\n");
+    if (first == std::string::npos) {
+        return "";
+    }
+    const auto last = value.find_last_not_of(" \t\r\n");
+    return value.substr(first, last - first + 1);
+}
+
+/// Try each of the three date formats RFC 7231 requires a recipient to accept.
+bool ParseHttpDate(const std::string& value, int64_t& out_timestamp)
+{
+    static const std::array<const char*, 3> FORMATS = {
+        "%a, %d %b %Y %H:%M:%S",  // IMF-fixdate  - "Sun, 06 Nov 1994 08:49:37 GMT"
+        "%A, %d-%b-%y %H:%M:%S",  // RFC 850      - "Sunday, 06-Nov-94 08:49:37 GMT"
+        "%a %b %d %H:%M:%S %Y"    // asctime      - "Sun Nov  6 08:49:37 1994"
+    };
+
+    for (const auto* format : FORMATS) {
+        std::tm time_fields = {};
+        std::istringstream stream(value);
+        stream.imbue(std::locale::classic());
+        stream >> std::get_time(&time_fields, format);
+        if (stream.fail()) {
+            continue;
+        }
+        // RFC 850 two-digit years: std::get_time maps %y to 1969..2068, which is what we want.
+        out_timestamp = TimestampFromUtcTm(time_fields);
+        return true;
+    }
+    return false;
+}
+
+} // namespace
 
 OdpRequestOrchestrator::OdpRequestOrchestrator(std::shared_ptr<HttpAuthParams> auth_params,
                                              uint32_t default_page_size)
     : http_factory_(std::make_unique<OdpHttpRequestFactory>(auth_params))
     , auth_params_(auth_params)
     , default_page_size_(default_page_size)
+    , sleep_function_([](std::chrono::milliseconds duration) { std::this_thread::sleep_for(duration); })
 {
     ERPL_TRACE_INFO("ODP_ORCHESTRATOR", duckdb::StringUtil::Format(
         "Initializing request orchestrator with default page size: %u", default_page_size_));
@@ -155,6 +230,61 @@ uint32_t OdpRequestOrchestrator::GetDefaultPageSize() const {
     return default_page_size_;
 }
 
+void OdpRequestOrchestrator::SetRetryPolicy(const RetryPolicy& policy) {
+    retry_policy_ = policy;
+    ERPL_TRACE_INFO("ODP_ORCHESTRATOR", duckdb::StringUtil::Format(
+        "Updated 202 retry policy - MaxAttempts: %u, DefaultDelay: %lld ms, MaxTotalWait: %lld ms",
+        retry_policy_.max_attempts,
+        static_cast<long long>(retry_policy_.default_delay.count()),
+        static_cast<long long>(retry_policy_.max_total_wait.count())));
+}
+
+const OdpRequestOrchestrator::RetryPolicy& OdpRequestOrchestrator::GetRetryPolicy() const {
+    return retry_policy_;
+}
+
+void OdpRequestOrchestrator::SetSleepFunction(SleepFunction sleep_function) {
+    sleep_function_ = std::move(sleep_function);
+}
+
+std::optional<std::chrono::milliseconds> OdpRequestOrchestrator::ParseRetryAfter(
+    const std::string& header_value, std::chrono::system_clock::time_point now) {
+
+    const std::string trimmed = TrimWhitespace(header_value);
+    if (trimmed.empty()) {
+        return std::nullopt;
+    }
+
+    // Form 1: delta-seconds. A bare run of digits, per RFC 7231; anything else falls through
+    // to the date parser rather than being partially consumed.
+    if (std::all_of(trimmed.begin(), trimmed.end(),
+                    [](unsigned char c) { return std::isdigit(c) != 0; })) {
+        try {
+            const auto seconds = std::stoll(trimmed);
+            return std::chrono::milliseconds(std::chrono::seconds(seconds));
+        } catch (const std::exception&) {
+            // Out of range - treat as unparsable so the caller uses its default delay.
+            return std::nullopt;
+        }
+    }
+
+    // Form 2: HTTP-date.
+    int64_t target_timestamp = 0;
+    if (!ParseHttpDate(trimmed, target_timestamp)) {
+        return std::nullopt;
+    }
+
+    const auto now_timestamp =
+        std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
+    const int64_t delta_seconds = target_timestamp - static_cast<int64_t>(now_timestamp);
+    if (delta_seconds <= 0) {
+        // The server named an instant that has already passed - retry immediately.
+        return std::chrono::milliseconds(0);
+    }
+
+    return std::chrono::milliseconds(std::chrono::seconds(delta_seconds));
+}
+
 // ============================================================================
 // Private Helper Methods
 // ============================================================================
@@ -167,9 +297,9 @@ OdpRequestOrchestrator::OdpRequestResult OdpRequestOrchestrator::ExecuteRequest(
     OdpRequestResult result;
     
     try {
-        // Execute HTTP request
-        auto http_response = http_client_->SendRequest(const_cast<HttpRequest&>(request));
-        
+        // Execute HTTP request, absorbing any 202 Accepted "still preparing" responses.
+        auto http_response = SendRequestHandlingAccepted(request, operation_type);
+
         result.http_status_code = http_response->Code();
         result.response_size_bytes = http_response->Content().size();
         
@@ -182,23 +312,32 @@ OdpRequestOrchestrator::OdpRequestResult OdpRequestOrchestrator::ExecuteRequest(
             throw duckdb::IOException("ODP request failed with HTTP " + std::to_string(result.http_status_code) + ": " + http_response->content);
         }
         
+        // Capture the real response headers and validate the server's change-tracking promise
+        // BEFORE the response is moved into the OData wrapper. Inferring `preference_applied`
+        // from the presence of a delta token used to let the reader transition to DELTA_FETCH
+        // over data that was never change-tracked, silently dropping every subsequent change.
+        // See GitHub #97.
+        result.response_headers = http_response->headers;
+        if (operation_type == "initial_load") {
+            result.preference_applied = ValidatePreferenceApplied(*http_response);
+            if (!result.preference_applied) {
+                ERPL_TRACE_WARN("ODP_ORCHESTRATOR",
+                    "Initial load response did not carry 'Preference-Applied: odata.track-changes'. "
+                    "Change tracking was NOT established; the subscription must stay in initial-load "
+                    "mode rather than issue a delta fetch that would miss changes.");
+            }
+        }
+
         // Process OData response
         result.response = ProcessHttpResponse(std::move(http_response));
-        
+
         // Extract delta token if present
         result.extracted_delta_token = ExtractDeltaToken(*result.response);
-        
+
         // Check for next page
         auto next_url = result.response->NextUrl();
         result.has_more_pages = next_url.has_value() && !next_url->empty();
-        
-        // Validate preference applied for initial load
-        if (operation_type == "initial_load") {
-            // We need access to the original HTTP response for header validation
-            // For now, we'll assume preference was applied if we got a delta token
-            result.preference_applied = !result.extracted_delta_token.empty();
-        }
-        
+
         LogResponseDetails(result, operation_type);
         
     } catch (const std::exception& e) {
@@ -208,6 +347,99 @@ OdpRequestOrchestrator::OdpRequestResult OdpRequestOrchestrator::ExecuteRequest(
     }
     
     return result;
+}
+
+std::unique_ptr<HttpResponse> OdpRequestOrchestrator::SendRequestHandlingAccepted(
+    const HttpRequest& request, const std::string& operation_type) {
+
+    HttpRequest current_request = request;
+    std::chrono::milliseconds total_waited{0};
+
+    for (uint32_t attempt = 0; ; ++attempt) {
+        auto http_response = http_client_->SendRequest(current_request);
+        if (!http_response) {
+            throw duckdb::IOException("ODP " + operation_type + " request returned no response for '" +
+                                      current_request.url.ToString() + "'");
+        }
+
+        if (http_response->Code() != HTTP_STATUS_ACCEPTED) {
+            if (attempt > 0) {
+                ERPL_TRACE_INFO("ODP_ORCHESTRATOR", duckdb::StringUtil::Format(
+                    "ODP %s package became ready after %u re-poll(s) and %lld ms of waiting",
+                    operation_type, attempt, static_cast<long long>(total_waited.count())));
+            }
+            return http_response;
+        }
+
+        // SAP is still preparing the extraction package.
+        if (attempt >= retry_policy_.max_attempts) {
+            throw duckdb::IOException(duckdb::StringUtil::Format(
+                "ODP %s did not become ready: the service answered HTTP 202 Accepted %u times for "
+                "'%s' (waited %lld ms in total). The extraction is still being prepared on the SAP "
+                "side; re-run the query later, or raise the retry limit.",
+                operation_type, attempt + 1, current_request.url.ToString(),
+                static_cast<long long>(total_waited.count())));
+        }
+
+        std::chrono::milliseconds wait_for = retry_policy_.default_delay;
+        auto retry_after_header = http_response->headers.find("retry-after");
+        if (retry_after_header != http_response->headers.end()) {
+            auto parsed = ParseRetryAfter(retry_after_header->second, std::chrono::system_clock::now());
+            if (parsed.has_value()) {
+                wait_for = *parsed;
+            } else {
+                ERPL_TRACE_WARN("ODP_ORCHESTRATOR",
+                    "Could not parse Retry-After value '" + retry_after_header->second +
+                    "'; falling back to the default delay");
+            }
+        }
+
+        if (total_waited + wait_for > retry_policy_.max_total_wait) {
+            throw duckdb::IOException(duckdb::StringUtil::Format(
+                "ODP %s did not become ready within the %lld ms wait budget: the service answered "
+                "HTTP 202 Accepted for '%s' and asked to be retried in a further %lld ms (already "
+                "waited %lld ms). The extraction is still being prepared on the SAP side; re-run "
+                "the query later, or raise the wait budget.",
+                operation_type, static_cast<long long>(retry_policy_.max_total_wait.count()),
+                current_request.url.ToString(),
+                static_cast<long long>(wait_for.count()),
+                static_cast<long long>(total_waited.count())));
+        }
+
+        // A 202 may name the resource to poll in `Location`. Honour it when the server sends one,
+        // because re-issuing the original initial-load request (which carries
+        // `Prefer: odata.track-changes`) risks opening a second ODQ subscription. Restrict the
+        // redirect to the same origin, consistent with the rest of the ODP request path.
+        auto location_header = http_response->headers.find("location");
+        if (location_header != http_response->headers.end() && !location_header->second.empty()) {
+            HttpUrl poll_url =
+                HttpUrl::MergeWithBaseUrlIfRelative(current_request.url, location_header->second);
+            if (!poll_url.IsSameOrigin(current_request.url)) {
+                throw duckdb::IOException(
+                    "ODP " + operation_type + " received an HTTP 202 whose Location header points to "
+                    "a different origin ('" + poll_url.ToString() + "' vs '" +
+                    current_request.url.ToSchemeHostAndPort() + "'); refusing to follow it.");
+            }
+            if (!poll_url.Equals(current_request.url)) {
+                ERPL_TRACE_INFO("ODP_ORCHESTRATOR",
+                    "Following 202 Location for polling: " + poll_url.ToString());
+                current_request = HttpRequest(HttpMethod::GET, poll_url.ToString());
+                if (auth_params_) {
+                    current_request.AuthHeadersFromParams(*auth_params_);
+                }
+            }
+        }
+
+        ERPL_TRACE_INFO("ODP_ORCHESTRATOR", duckdb::StringUtil::Format(
+            "ODP %s not ready (HTTP 202, attempt %u of %u); waiting %lld ms before re-polling %s",
+            operation_type, attempt + 1, retry_policy_.max_attempts + 1,
+            static_cast<long long>(wait_for.count()), current_request.url.ToString()));
+
+        if (sleep_function_ && wait_for.count() > 0) {
+            sleep_function_(wait_for);
+        }
+        total_waited += wait_for;
+    }
 }
 
 std::shared_ptr<ODataEntitySetResponse> OdpRequestOrchestrator::ProcessHttpResponse(

--- a/test/cpp/test_odp_http_request_factory.cpp
+++ b/test/cpp/test_odp_http_request_factory.cpp
@@ -113,48 +113,6 @@ TEST_CASE("OdpHttpRequestFactory Metadata Request", "[odp_http_factory]") {
     }
 }
 
-TEST_CASE("OdpHttpRequestFactory Termination Request", "[odp_http_factory]") {
-    OdpHttpRequestFactory factory;
-    std::string termination_url = "https://example.com/sap/opu/odata/sap/TEST_SRV/TerminateDeltasForEntityOfTest";
-
-    SECTION("Create termination request") {
-        auto request = factory.CreateTerminationRequest(termination_url);
-        
-        // Verify method and URL
-        REQUIRE(request.method == HttpMethod::GET);
-        REQUIRE(request.url.ToString().find("$format=json") != std::string::npos);
-        
-        // Verify OData v2 headers
-        REQUIRE(request.headers.at("DataServiceVersion") == "2.0");
-        REQUIRE(request.headers.at("MaxDataServiceVersion") == "2.0");
-        REQUIRE(request.headers.at("Accept") == "application/json;odata=verbose");
-        
-        // Verify no Prefer header for termination requests
-        REQUIRE(request.headers.find("Prefer") == request.headers.end());
-    }
-}
-
-TEST_CASE("OdpHttpRequestFactory Delta Token Discovery Request", "[odp_http_factory]") {
-    OdpHttpRequestFactory factory;
-    std::string delta_links_url = "https://example.com/sap/opu/odata/sap/TEST_SRV/DeltaLinksOfEntityOfTest";
-
-    SECTION("Create delta token discovery request") {
-        auto request = factory.CreateDeltaTokenDiscoveryRequest(delta_links_url);
-        
-        // Verify method and URL
-        REQUIRE(request.method == HttpMethod::GET);
-        REQUIRE(request.url.ToString().find("$format=json") != std::string::npos);
-        
-        // Verify OData v2 headers
-        REQUIRE(request.headers.at("DataServiceVersion") == "2.0");
-        REQUIRE(request.headers.at("MaxDataServiceVersion") == "2.0");
-        REQUIRE(request.headers.at("Accept") == "application/json;odata=verbose");
-        
-        // Verify no Prefer header for discovery requests
-        REQUIRE(request.headers.find("Prefer") == request.headers.end());
-    }
-}
-
 TEST_CASE("OdpHttpRequestFactory Custom Request Configuration", "[odp_http_factory]") {
     OdpHttpRequestFactory factory;
     std::string test_url = "https://example.com/test";

--- a/test/cpp/test_odp_retry_and_preference.cpp
+++ b/test/cpp/test_odp_retry_and_preference.cpp
@@ -1,0 +1,321 @@
+// Coverage for GitHub #97: HTTP 202 Accepted / Retry-After handling in the ODP request layer,
+// and validation (rather than inference) of `Preference-Applied: odata.track-changes`.
+//
+// Every test here drives the real OdpRequestOrchestrator against the local ODP-speaking test
+// server; none of them sleep for a real Retry-After interval - the orchestrator's sleep function
+// is replaced with a recorder so the retry arithmetic is asserted directly.
+
+#include "catch.hpp"
+
+#include "odata_test_server.hpp"
+#include "odp_request_orchestrator.hpp"
+#include "datazoo/oauth2/http_client.hpp"
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+using erpl_web::OdpRequestOrchestrator;
+using erpl_web::test_support::CannedResponse;
+using erpl_web::test_support::ODataTestServer;
+
+namespace {
+
+/// An OData v2 ODP page carrying a delta link, in the shape ExtractDeltaTokenFromV2Response reads.
+/// Built by hand rather than via MakeOdpDeltaPage so that a test can serve the identical BODY with
+/// and without the `Preference-Applied` header - which is exactly the distinction #97 turns on.
+std::string OdpDeltaBody(const std::string &delta_token)
+{
+    return std::string("{\"d\":{\"results\":[{\"ID\":\"1\",\"ODQ_CHANGEMODE\":\"C\"}],")
+           + "\"__delta\":\"http://127.0.0.1/odp/Entity?$format=json&!deltatoken='" + delta_token + "'\"}}";
+}
+
+/// Install a sleep function that records the requested waits instead of performing them.
+void RecordSleepsInto(OdpRequestOrchestrator &orchestrator, std::vector<std::chrono::milliseconds> &sink)
+{
+    orchestrator.SetSleepFunction(
+        [&sink](std::chrono::milliseconds duration) { sink.push_back(duration); });
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Retry-After parsing
+// ---------------------------------------------------------------------------
+
+TEST_CASE("OdpRequestOrchestrator parses both Retry-After forms", "[odp_retry][odp_orchestrator]") {
+    // Pre-fix failure: OdpRequestOrchestrator::ParseRetryAfter did not exist at all, so this
+    // translation unit failed to compile ("no member named 'ParseRetryAfter'"). Nothing anywhere
+    // in src/ read the Retry-After header.
+    const auto now = std::chrono::system_clock::now();
+
+    SECTION("delta-seconds") {
+        auto parsed = OdpRequestOrchestrator::ParseRetryAfter("120", now);
+        REQUIRE(parsed.has_value());
+        REQUIRE(parsed->count() == 120000);
+    }
+
+    SECTION("delta-seconds with surrounding whitespace") {
+        auto parsed = OdpRequestOrchestrator::ParseRetryAfter("  7 ", now);
+        REQUIRE(parsed.has_value());
+        REQUIRE(parsed->count() == 7000);
+    }
+
+    SECTION("zero delta-seconds means retry immediately") {
+        auto parsed = OdpRequestOrchestrator::ParseRetryAfter("0", now);
+        REQUIRE(parsed.has_value());
+        REQUIRE(parsed->count() == 0);
+    }
+
+    SECTION("HTTP-date in the future") {
+        // 1994-11-06T08:49:37Z is 784111777 in Unix seconds; measure from 60s earlier.
+        const auto reference = std::chrono::system_clock::time_point(std::chrono::seconds(784111777 - 60));
+        auto parsed = OdpRequestOrchestrator::ParseRetryAfter("Sun, 06 Nov 1994 08:49:37 GMT", reference);
+        REQUIRE(parsed.has_value());
+        REQUIRE(parsed->count() == 60000);
+    }
+
+    SECTION("HTTP-date already in the past yields no wait") {
+        const auto reference = std::chrono::system_clock::time_point(std::chrono::seconds(784111777 + 500));
+        auto parsed = OdpRequestOrchestrator::ParseRetryAfter("Sun, 06 Nov 1994 08:49:37 GMT", reference);
+        REQUIRE(parsed.has_value());
+        REQUIRE(parsed->count() == 0);
+    }
+
+    SECTION("asctime form is tolerated") {
+        const auto reference = std::chrono::system_clock::time_point(std::chrono::seconds(784111777 - 10));
+        auto parsed = OdpRequestOrchestrator::ParseRetryAfter("Sun Nov  6 08:49:37 1994", reference);
+        REQUIRE(parsed.has_value());
+        REQUIRE(parsed->count() == 10000);
+    }
+
+    SECTION("unparsable values are reported as such") {
+        REQUIRE_FALSE(OdpRequestOrchestrator::ParseRetryAfter("later please", now).has_value());
+        REQUIRE_FALSE(OdpRequestOrchestrator::ParseRetryAfter("", now).has_value());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 202 Accepted re-polling
+// ---------------------------------------------------------------------------
+
+TEST_CASE("ODP initial load re-polls a 202 Accepted and honours Retry-After",
+          "[odp_retry][odp_e2e]") {
+    // Pre-fix failure: ExecuteRequest sent exactly one request and, because 202 is below the 400
+    // error threshold, handed the empty 202 body to the OData parser as if it were the result.
+    // server.RequestsFor("/odp/Entity").size() was 1, not 2, and the delta token came back empty.
+    ODataTestServer server;
+
+    auto accepted = CannedResponse::Json("{}", 202);
+    accepted.WithHeader("Retry-After", "3");
+
+    auto ready = CannedResponse::Json(OdpDeltaBody("TOKEN_A"));
+    ready.WithHeader("Preference-Applied", "odata.track-changes");
+
+    server.OnPathSequence("/odp/Entity", {accepted, ready});
+
+    OdpRequestOrchestrator orchestrator(nullptr, 100);
+    std::vector<std::chrono::milliseconds> sleeps;
+    RecordSleepsInto(orchestrator, sleeps);
+
+    auto result = orchestrator.ExecuteInitialLoad(server.Url("/odp/Entity"));
+
+    REQUIRE(result.http_status_code == 200);
+    REQUIRE(result.extracted_delta_token == "TOKEN_A");
+
+    // The 202 was re-polled exactly once, and the server's stated interval was the one waited.
+    REQUIRE(server.RequestsFor("/odp/Entity").size() == 2);
+    REQUIRE(sleeps.size() == 1);
+    REQUIRE(sleeps.front().count() == 3000);
+}
+
+TEST_CASE("ODP re-polling falls back to the default delay when Retry-After is absent",
+          "[odp_retry][odp_e2e]") {
+    // Pre-fix failure: no re-poll happened at all, so there was no delay to fall back to and
+    // RequestsFor(...).size() was 1.
+    ODataTestServer server;
+
+    auto accepted = CannedResponse::Json("{}", 202); // no Retry-After header
+    auto ready = CannedResponse::Json(OdpDeltaBody("TOKEN_B"));
+    ready.WithHeader("Preference-Applied", "odata.track-changes");
+
+    server.OnPathSequence("/odp/Entity", {accepted, ready});
+
+    OdpRequestOrchestrator orchestrator(nullptr, 100);
+
+    OdpRequestOrchestrator::RetryPolicy policy;
+    policy.default_delay = std::chrono::milliseconds(250);
+    orchestrator.SetRetryPolicy(policy);
+
+    std::vector<std::chrono::milliseconds> sleeps;
+    RecordSleepsInto(orchestrator, sleeps);
+
+    auto result = orchestrator.ExecuteInitialLoad(server.Url("/odp/Entity"));
+
+    REQUIRE(result.http_status_code == 200);
+    REQUIRE(sleeps.size() == 1);
+    REQUIRE(sleeps.front().count() == 250);
+}
+
+TEST_CASE("ODP re-polling gives up with a clear error once the wait budget is exhausted",
+          "[odp_retry][odp_e2e]") {
+    // Pre-fix failure: a server that answered 202 forever was not retried and not reported - the
+    // single 202 was accepted as a successful (empty) result, so no exception was thrown at all
+    // and this REQUIRE_THROWS_AS failed.
+    ODataTestServer server;
+
+    auto accepted = CannedResponse::Json("{}", 202);
+    accepted.WithHeader("Retry-After", "30");
+    // A single-entry sequence repeats forever: the package never becomes ready.
+    server.OnPathSequence("/odp/Entity", {accepted});
+
+    OdpRequestOrchestrator orchestrator(nullptr, 100);
+
+    OdpRequestOrchestrator::RetryPolicy policy;
+    policy.max_attempts = 100;                                  // not the binding limit here
+    policy.max_total_wait = std::chrono::milliseconds(65000);   // room for two 30s waits, not three
+    orchestrator.SetRetryPolicy(policy);
+
+    std::vector<std::chrono::milliseconds> sleeps;
+    RecordSleepsInto(orchestrator, sleeps);
+
+    REQUIRE_THROWS_AS(orchestrator.ExecuteInitialLoad(server.Url("/odp/Entity")), duckdb::IOException);
+
+    // Two waits fit inside the budget; the third would exceed it and aborts instead.
+    REQUIRE(sleeps.size() == 2);
+    REQUIRE(server.RequestsFor("/odp/Entity").size() == 3);
+}
+
+TEST_CASE("ODP re-polling stops after the configured attempt limit", "[odp_retry][odp_e2e]") {
+    // Pre-fix failure: no attempt counting existed; the call returned normally after one request.
+    ODataTestServer server;
+
+    auto accepted = CannedResponse::Json("{}", 202);
+    accepted.WithHeader("Retry-After", "0"); // never blocks, so the attempt cap is what binds
+    server.OnPathSequence("/odp/Entity", {accepted});
+
+    OdpRequestOrchestrator orchestrator(nullptr, 100);
+
+    OdpRequestOrchestrator::RetryPolicy policy;
+    policy.max_attempts = 3;
+    orchestrator.SetRetryPolicy(policy);
+
+    REQUIRE_THROWS_AS(orchestrator.ExecuteInitialLoad(server.Url("/odp/Entity")), duckdb::IOException);
+
+    // Initial request plus max_attempts re-polls.
+    REQUIRE(server.RequestsFor("/odp/Entity").size() == 4);
+}
+
+// ---------------------------------------------------------------------------
+// Preference-Applied validation - the data-loss guard
+// ---------------------------------------------------------------------------
+
+TEST_CASE("ODP initial load reports change tracking only when the server confirms it",
+          "[odp_preference][odp_e2e]") {
+    // This is the highest-value assertion in #97. Before the fix, ExecuteRequest set
+    //     result.preference_applied = !result.extracted_delta_token.empty();
+    // so ANY response carrying a delta token was treated as change-tracked. The "server omits
+    // Preference-Applied" section below therefore observed preference_applied == true, the reader
+    // transitioned to DELTA_FETCH over data that was never change-tracked, and every change made
+    // between that load and the next read was silently lost.
+    //
+    // The `response_headers` assertions also could not compile before the fix: OdpRequestResult
+    // had no such member, because the real headers were discarded when the HttpResponse was moved
+    // into the OData wrapper.
+
+    SECTION("server confirms odata.track-changes") {
+        ODataTestServer server;
+        auto ready = CannedResponse::Json(OdpDeltaBody("TOKEN_OK"));
+        ready.WithHeader("Preference-Applied", "odata.track-changes");
+        server.OnPath("/odp/Entity", ready);
+
+        OdpRequestOrchestrator orchestrator(nullptr, 100);
+        auto result = orchestrator.ExecuteInitialLoad(server.Url("/odp/Entity"));
+
+        REQUIRE(result.extracted_delta_token == "TOKEN_OK");
+        REQUIRE(result.preference_applied);
+        REQUIRE(result.response_headers.find("preference-applied") != result.response_headers.end());
+    }
+
+    SECTION("server omits Preference-Applied although a delta token is present") {
+        ODataTestServer server;
+        // Identical body, no Preference-Applied header.
+        server.OnPath("/odp/Entity", CannedResponse::Json(OdpDeltaBody("TOKEN_UNTRACKED")));
+
+        OdpRequestOrchestrator orchestrator(nullptr, 100);
+        auto result = orchestrator.ExecuteInitialLoad(server.Url("/odp/Entity"));
+
+        // The token is still extracted...
+        REQUIRE(result.extracted_delta_token == "TOKEN_UNTRACKED");
+        // ...but change tracking was NOT established, so the subscription must not advance.
+        REQUIRE_FALSE(result.preference_applied);
+        REQUIRE(result.response_headers.find("preference-applied") == result.response_headers.end());
+    }
+
+    SECTION("server applies other preferences but not track-changes") {
+        ODataTestServer server;
+        auto ready = CannedResponse::Json(OdpDeltaBody("TOKEN_PAGESIZE_ONLY"));
+        ready.WithHeader("Preference-Applied", "odata.maxpagesize=100");
+        server.OnPath("/odp/Entity", ready);
+
+        OdpRequestOrchestrator orchestrator(nullptr, 100);
+        auto result = orchestrator.ExecuteInitialLoad(server.Url("/odp/Entity"));
+
+        REQUIRE_FALSE(result.preference_applied);
+    }
+
+    SECTION("track-changes alongside other applied preferences is accepted") {
+        ODataTestServer server;
+        auto ready = CannedResponse::Json(OdpDeltaBody("TOKEN_BOTH"));
+        ready.WithHeader("Preference-Applied", "odata.maxpagesize=100, odata.track-changes");
+        server.OnPath("/odp/Entity", ready);
+
+        OdpRequestOrchestrator orchestrator(nullptr, 100);
+        auto result = orchestrator.ExecuteInitialLoad(server.Url("/odp/Entity"));
+
+        REQUIRE(result.preference_applied);
+    }
+}
+
+TEST_CASE("ODP preference validation survives a 202 re-poll", "[odp_preference][odp_retry][odp_e2e]") {
+    // The headers that matter are those of the response that actually carries the data, not those
+    // of the intermediate 202. Pre-fix failure: there was no re-poll, so the 202 itself was the
+    // final response and preference_applied was inferred from its empty body as false.
+    ODataTestServer server;
+
+    auto accepted = CannedResponse::Json("{}", 202);
+    accepted.WithHeader("Retry-After", "1");
+
+    auto ready = CannedResponse::Json(OdpDeltaBody("TOKEN_AFTER_WAIT"));
+    ready.WithHeader("Preference-Applied", "odata.track-changes");
+
+    server.OnPathSequence("/odp/Entity", {accepted, ready});
+
+    OdpRequestOrchestrator orchestrator(nullptr, 100);
+    std::vector<std::chrono::milliseconds> sleeps;
+    RecordSleepsInto(orchestrator, sleeps);
+
+    auto result = orchestrator.ExecuteInitialLoad(server.Url("/odp/Entity"));
+
+    REQUIRE(result.preference_applied);
+    REQUIRE(result.extracted_delta_token == "TOKEN_AFTER_WAIT");
+    REQUIRE(sleeps.size() == 1);
+}
+
+TEST_CASE("ODP delta fetch does not claim change tracking", "[odp_preference][odp_e2e]") {
+    // A delta fetch does not send `Prefer: odata.track-changes` - tracking is already established -
+    // so preference_applied stays false and is not consulted for that path.
+    ODataTestServer server;
+    server.OnPath("/odp/Entity", CannedResponse::Json(OdpDeltaBody("TOKEN_NEXT")));
+
+    OdpRequestOrchestrator orchestrator(nullptr, 100);
+    auto result = orchestrator.ExecuteDeltaFetch(server.Url("/odp/Entity"), "TOKEN_PREV");
+
+    REQUIRE(result.extracted_delta_token == "TOKEN_NEXT");
+    REQUIRE_FALSE(result.preference_applied);
+
+    // The delta token really was put on the wire.
+    const auto requests = server.RequestsFor("/odp/Entity");
+    REQUIRE(requests.size() == 1);
+    REQUIRE(requests.front().target.find("TOKEN_PREV") != std::string::npos);
+}


### PR DESCRIPTION
## #97.2 — the one that loses data

`ExecuteRequest` set `preference_applied = !extracted_delta_token.empty()` because the real headers had already been destroyed by `std::move(http_response)` into the OData wrapper. So the code could transition to `DELTA_FETCH` over data that was **never change-tracked** — meaning the next "delta" read silently misses everything that changed in between.

`OdpRequestResult` now carries the response headers, captured before the move, and `ValidatePreferenceApplied` is actually called.

**The agent found a second instance the issue did not mention**, and it matters more: `FetchAndLoadNextPage` re-derived `preference_applied` on the last page. Only the **first** response answers the `Prefer` header we sent — `__next` requests do not carry it — so the server's answer is captured on the initial load and carried to the deferred transition. Fixing only the orchestrator would have left **multi-page initial loads**, i.e. every realistic ODP extraction, still broken.

## #97.1 — 202 Accepted

A 202 was *below* the `>= 400` error threshold, so its empty body was parsed as though it were the result. Now re-polled honouring `Retry-After` in both RFC 7231 forms (delta-seconds and HTTP-date, plus the obsolete date formats recipients must tolerate), bounded by attempts, per-wait and total-wait budget, raising an `IOException` naming the URL and elapsed wait.

HTTP-date conversion uses a `DaysFromCivil` implementation rather than `timegm`/`_mkgmtime`, which are mutually exclusive across Linux/macOS and MSVC — Windows is a shipped platform. The wait is injectable, so tests assert the budget arithmetic without ever sleeping.

## #97.3 — dead termination surface removed

```
TerminateSubscription            -> definition + declaration only, ZERO callers
CreateTerminationRequest         -> only odp_client_integration.cpp + its own test
CreateDeltaTokenDiscoveryRequest -> only odp_client_integration.cpp + its own test
OdpClientIntegration             -> ZERO references outside its own .cpp/.hpp
```

The last line is the finding beyond the issue: **the entire `OdpClientIntegration` class is dead** — nothing constructs it. The five dead functions and two vacuous tests are gone; the file itself remains because deleting it needs a `CMakeLists.txt` edit that was contended. Follow-up: delete `src/odp_client_integration.{cpp,hpp}` and its CMake line. `GetAuditHistory()` is also a stub returning an empty vector regardless of arguments — same category, untouched.

## #98 — documentation, and the reasoning changed my mind

The issue says the change-mode marker "has no handler anywhere in `src/`". True — but `grep -rn "ODQ_" src/` returns **zero hits**, which means nothing filters it out either. `ODQ_CHANGEMODE` is a plain `<Property>` in the EDMX, so the generic schema builder **already surfaces it as an ordinary VARCHAR column**. The marker was never missing from the result set; only the *contract* was.

That makes a normalised marker column strictly additive harm: it would widen every `SELECT *`, break positional consumers and existing `CREATE TABLE AS` targets, and create a second source of truth for a value already present — without touching the hard part, which is the merge logic.

So `docs/ODP.md` documents the contract: `odp_odata_read` emits a **change stream, not a snapshot**, with the marker values and a delete-then-insert merge pattern.

## Guesses at SAP behaviour that could not be verified — the risky ones

1. **`Location` on a 202 is followed** (same-origin enforced) in preference to re-issuing the request, on the reasoning that re-sending an initial load carrying `Prefer: odata.track-changes` might open a *second* ODQ subscription. Neither that SAP sends `Location` on 202, nor that re-issuing is harmful, could be confirmed. **Highest-risk assumption here.**
2. Whether SAP ODP returns 202 at all, and on which operation — implemented to the HTTP spec, not to observed traffic.
3. `'D'` = delete is well established; `'C'`/`''`/`'U'` are indicative, and the docs steer readers to test `= 'D'` rather than enumerate.
4. Default budgets (20 attempts / 5s / 10min) are invented.

## Verification

Full C++ suite **387 cases / 1981 assertions**. Live E2E: `odata_conformance_e2e` (22), `odata_v2`, `odata_v4`, `web_core` — all green.

The `initial_load_preference_applied_` multi-page propagation is compile-verified and reasoned, **not** covered by a test — that needs the full `odp_odata_read` path against a persistent state catalog.

Closes #97, closes #98.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791630643&installation_model_id=425457&pr_number=139&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F139&signature=ca036468a3e4f05f1e8889e4e484c468c546739a2360a42a51a8fd6ac1d9e17c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->