### PR TITLE
fix: EdmCache lifetime race, client factory unification, quote escaping (#104, #106, #102)

### DIFF
--- a/src/business_central_client.cpp
+++ b/src/business_central_client.cpp
@@ -1,4 +1,5 @@
 #include "business_central_client.hpp"
+#include "odata_url_helpers.hpp"
 #include "tracing.hpp"
 #include "duckdb/common/exception.hpp"
 #include <utility>
@@ -36,13 +37,6 @@ std::string BusinessCentralUrlBuilder::BuildCompaniesUrl(const std::string &base
 
 std::string BusinessCentralUrlBuilder::GetResourceUrl() {
     return "https://api.businesscentral.dynamics.com";
-}
-
-// Helper to create HTTP client for OData
-static std::shared_ptr<HttpClient> CreateODataHttpClient() {
-    HttpParams http_params;
-    http_params.url_encode = false;  // OData handles URL encoding
-    return std::make_shared<HttpClient>(http_params);
 }
 
 // Client Factory implementation

--- a/src/datasphere_catalog.cpp
+++ b/src/datasphere_catalog.cpp
@@ -1,4 +1,5 @@
 #include "datasphere_catalog.hpp"
+#include "odata_url_helpers.hpp"
 #include "datasphere_client.hpp"
 #include "odata_client.hpp"
 #include "odata_content.hpp"
@@ -473,8 +474,9 @@ duckdb::Value DatasphereDescribeBindData::FetchDetailedAnalyticalSchema(const st
         
         ERPL_TRACE_INFO("DATASPHERE_CATALOG", "Constructed metadata endpoint URL: " + metadata_endpoint_url);
         
-        // Use the HttpClient directly to get the raw content
-        auto direct_http_client = std::make_shared<HttpClient>();
+        // Same client the rest of the OData stack uses; a default-constructed HttpClient
+        // re-encodes the URL and mangles OData query options (GitHub #102).
+        auto metadata_http_client = CreateODataHttpClient();
         
         // Create a direct HTTP request to the metadata URL
         HttpRequest metadata_request(HttpMethod::GET, HttpUrl(metadata_endpoint_url));
@@ -483,7 +485,7 @@ duckdb::Value DatasphereDescribeBindData::FetchDetailedAnalyticalSchema(const st
         }
         
         // Execute the request
-        auto raw_response = direct_http_client->SendRequest(metadata_request);
+        auto raw_response = metadata_http_client->SendRequest(metadata_request);
         if (!raw_response) {
             return "Failed to get raw metadata response";
         }

--- a/src/dataverse_client.cpp
+++ b/src/dataverse_client.cpp
@@ -1,4 +1,5 @@
 #include "dataverse_client.hpp"
+#include "odata_url_helpers.hpp"
 #include "tracing.hpp"
 
 namespace erpl_web {
@@ -31,13 +32,6 @@ std::string DataverseUrlBuilder::BuildEntityDefinitionUrl(const std::string &bas
 
 std::string DataverseUrlBuilder::BuildEntityAttributesUrl(const std::string &base_url, const std::string &logical_name) {
     return base_url + "/EntityDefinitions(LogicalName='" + logical_name + "')/Attributes";
-}
-
-// Helper to create HTTP client for OData
-static std::shared_ptr<HttpClient> CreateODataHttpClient() {
-    HttpParams http_params;
-    http_params.url_encode = false;  // OData handles URL encoding
-    return std::make_shared<HttpClient>(http_params);
 }
 
 // Client Factory implementation

--- a/src/graph_client.cpp
+++ b/src/graph_client.cpp
@@ -1,4 +1,5 @@
 #include "graph_client.hpp"
+#include "odata_url_helpers.hpp"
 #include "duckdb/common/exception.hpp"
 #include "tracing.hpp"
 
@@ -36,10 +37,8 @@ static void AppendJsonValue(std::string &target, yyjson_val *value) {
 } // namespace
 
 GraphClient::GraphClient(std::shared_ptr<HttpAuthParams> auth_params, std::string trace_component)
-    : auth_params(std::move(auth_params)), trace_component(std::move(trace_component)) {
-    HttpParams http_params;
-    http_params.url_encode = false;
-    http_client = std::make_shared<HttpClient>(http_params);
+    : auth_params(std::move(auth_params)), http_client(CreateODataHttpClient()),
+      trace_component(std::move(trace_component)) {
 }
 
 std::string GraphClient::BaseUrl() {

--- a/src/include/odata_catalog.hpp
+++ b/src/include/odata_catalog.hpp
@@ -136,7 +136,15 @@ public:
     // Throws duckdb::IOException carrying the underlying cause and the service URL when the
     // $metadata request fails, so that authentication, TLS or connectivity problems are not
     // reported to the user as "table does not exist".
-    Edmx &GetCachedMetadata();
+    //
+    // The document is the very snapshot held by the process-global EdmCache, not a private
+    // copy of it, so N catalogs attached to the same service cost one EDMX rather than N+1
+    // (GitHub #106). It is const because it is shared.
+    const Edmx &GetCachedMetadata();
+
+    // Drops this catalog's snapshot and the corresponding EdmCache entry, so the next
+    // GetCachedMetadata() re-fetches $metadata from the service.
+    void InvalidateCachedMetadata();
 
     // True when the entity set is excluded by the IGNORE option of the ATTACH statement.
     bool IsIgnored(const std::string &entity_set_name) const;
@@ -151,7 +159,7 @@ protected:
     std::unique_ptr<ODataSchemaEntry> main_schema;
 
     mutable std::mutex metadata_mutex;
-    std::optional<Edmx> cached_metadata;
+    std::shared_ptr<const Edmx> cached_metadata;
 
 private:
     duckdb::string path_;

--- a/src/include/odata_edm.hpp
+++ b/src/include/odata_edm.hpp
@@ -2065,51 +2065,11 @@ class DuckTypeConverter
     public:
         explicit DuckTypeConverter(const Edmx &edmx) : edmx(edmx) {}
 
-        // Central primitive EDM->DuckDB LogicalType mapping
-        static duckdb::LogicalType ConvertEdmPrimitiveStringToLogicalType(const std::string &type_name) {
-            if (type_name == "Edm.Binary") {
-                return duckdb::LogicalTypeId::BLOB;
-            } else if (type_name == "Edm.Boolean") {
-                return duckdb::LogicalTypeId::BOOLEAN;
-            } else if (type_name == "Edm.Byte") {
-                // Edm.Byte is an UNSIGNED 8-bit integer (0..255); Edm.SByte is the signed
-                // one (-128..127). Mapping both to TINYINT silently NULLed 128..255. (GitHub #68)
-                return duckdb::LogicalTypeId::UTINYINT;
-            } else if (type_name == "Edm.SByte") {
-                return duckdb::LogicalTypeId::TINYINT;
-            } else if (type_name == "Edm.Date") {
-                return duckdb::LogicalTypeId::DATE;
-            } else if (type_name == "Edm.DateTime" || type_name == "Edm.DateTimeOffset") {
-                return duckdb::LogicalTypeId::TIMESTAMP;
-            } else if (type_name == "Edm.Decimal") {
-                return duckdb::LogicalTypeId::DECIMAL;
-            } else if (type_name == "Edm.Double") {
-                return duckdb::LogicalTypeId::DOUBLE;
-            } else if (type_name == "Edm.Duration") {
-                return duckdb::LogicalTypeId::INTERVAL;
-            } else if (type_name == "Edm.Guid") {
-                return duckdb::LogicalTypeId::VARCHAR;
-            } else if (type_name == "Edm.Int16") {
-                return duckdb::LogicalTypeId::SMALLINT;
-            } else if (type_name == "Edm.Int32") {
-                return duckdb::LogicalTypeId::INTEGER;
-            } else if (type_name == "Edm.Int64") {
-                return duckdb::LogicalTypeId::BIGINT;
-            } else if (type_name == "Edm.Single") {
-                return duckdb::LogicalTypeId::FLOAT;
-            } else if (type_name == "Edm.Stream") {
-                return duckdb::LogicalTypeId::BLOB;
-            } else if (type_name == "Edm.String") {
-                return duckdb::LogicalTypeId::VARCHAR;
-            } else if (type_name == "Edm.Time" || type_name == "Edm.TimeOfDay") {
-                return duckdb::LogicalTypeId::TIME;
-            } else if (type_name.find("Edm.Geography") == 0 || type_name.find("Edm.Geometry") == 0) {
-                return duckdb::LogicalTypeId::VARCHAR; // Geography/Geometry types as VARCHAR for now
-            } else {
-                // Fallback for unknown types - treat as VARCHAR
-                return duckdb::LogicalTypeId::VARCHAR;
-            }
-        }
+        // The single EDM primitive -> DuckDB type mapping. Everything that needs to know
+        // what "Edm.Int32" means goes through here (or through the string-valued sibling
+        // below, which reads the same table); there used to be three hand-written copies,
+        // which is how Edm.Byte stayed wrong in all of them at once (GitHub #68).
+        static duckdb::LogicalType ConvertEdmPrimitiveStringToLogicalType(const std::string &type_name);
 
         // Build the DuckDB type for an Edm.Decimal property from its CSDL facets.
         //
@@ -2167,99 +2127,11 @@ class DuckTypeConverter
             return duck_type;
         }
 
-        // Static method to convert EDM type string to DuckDB type string (for catalog functions)
-        static std::string ConvertEdmTypeStringToDuckDbTypeString(const std::string& edm_type) {
-            if (edm_type == "Edm.Binary") {
-                return "BLOB";
-            } else if (edm_type == "Edm.Boolean") {
-                return "BOOLEAN";
-            } else if (edm_type == "Edm.Byte") {
-                return "UTINYINT"; // unsigned 0..255, unlike Edm.SByte (GitHub #68)
-            } else if (edm_type == "Edm.SByte") {
-                return "TINYINT";
-            } else if (edm_type == "Edm.Date") {
-                return "DATE";
-            } else if (edm_type == "Edm.DateTime" || edm_type == "Edm.DateTimeOffset") {
-                return "TIMESTAMP";
-            } else if (edm_type == "Edm.Decimal") {
-                return "DECIMAL";
-            } else if (edm_type == "Edm.Double") {
-                return "DOUBLE";
-            } else if (edm_type == "Edm.Duration") {
-                return "INTERVAL";
-            } else if (edm_type == "Edm.Guid") {
-                return "VARCHAR";
-            } else if (edm_type == "Edm.Int16") {
-                return "SMALLINT";
-            } else if (edm_type == "Edm.Int32") {
-                return "INTEGER";
-            } else if (edm_type == "Edm.Int64") {
-                return "BIGINT";
-            } else if (edm_type == "Edm.Single") {
-                return "FLOAT";
-            } else if (edm_type == "Edm.Stream") {
-                return "BLOB";
-            } else if (edm_type == "Edm.String") {
-                return "VARCHAR";
-            } else if (edm_type == "Edm.Time") {
-                return "TIME";
-            } else if (edm_type == "Edm.TimeOfDay") {
-                return "TIME";
-            } else if (edm_type.find("Edm.Geography") == 0 || edm_type.find("Edm.Geometry") == 0) {
-                return "VARCHAR"; // Geography/Geometry types as VARCHAR for now
-            } else {
-                // Fallback for unknown types - treat as VARCHAR
-                return "VARCHAR";
-            }
-        }
+        // The same mapping expressed as a DuckDB type name, for the catalog functions that
+        // report column types as strings.
+        static std::string ConvertEdmTypeStringToDuckDbTypeString(const std::string& edm_type);
 
-        duckdb::LogicalType operator()(PrimitiveType &type) const 
-        {
-            if (type == erpl_web::Binary) {
-                return duckdb::LogicalTypeId::BLOB;
-            } else if (type == erpl_web::Boolean) {
-                return duckdb::LogicalTypeId::BOOLEAN;
-            } else if (type == erpl_web::Byte) {
-                return duckdb::LogicalTypeId::UTINYINT; // unsigned 0..255 (GitHub #68)
-            } else if (type == erpl_web::Date) {
-                return duckdb::LogicalTypeId::DATE;
-            } else if (type == erpl_web::DateTime) {
-                return duckdb::LogicalTypeId::TIMESTAMP;
-            } else if (type == erpl_web::DateTimeOffset) {
-                return duckdb::LogicalTypeId::TIMESTAMP;
-            } else if (type == erpl_web::Decimal) {
-                return duckdb::LogicalTypeId::DECIMAL;
-            } else if (type == erpl_web::Double) {
-                return duckdb::LogicalTypeId::DOUBLE;
-            } else if (type == erpl_web::Duration) {
-                return duckdb::LogicalTypeId::INTERVAL;
-            } else if (type == erpl_web::Guid) {
-                return duckdb::LogicalTypeId::VARCHAR;
-            } else if (type == erpl_web::Int16) {
-                return duckdb::LogicalTypeId::SMALLINT;
-            } else if (type == erpl_web::Int32) {
-                return duckdb::LogicalTypeId::INTEGER;
-            } else if (type == erpl_web::Int64) {
-                return duckdb::LogicalTypeId::BIGINT;
-            } else if (type == erpl_web::SByte) {
-                return duckdb::LogicalTypeId::TINYINT;
-            } else if (type == erpl_web::Single) {
-                return duckdb::LogicalTypeId::FLOAT;
-            } else if (type == erpl_web::Stream) {
-                return duckdb::LogicalTypeId::BLOB;
-            } else if (type == erpl_web::String) {
-                return duckdb::LogicalTypeId::VARCHAR;
-            } else if (type == erpl_web::Time) {
-                return duckdb::LogicalTypeId::TIME;
-            } else if (type == erpl_web::TimeOfDay) {
-                return duckdb::LogicalTypeId::TIME;
-            } else if (type == erpl_web::GeographyPoint) {
-                return duckdb::LogicalType::LIST(duckdb::LogicalTypeId::DOUBLE);
-            } else {
-                // Fallback for unknown primitive types - treat as VARCHAR
-                return duckdb::LogicalTypeId::VARCHAR;
-            }
-        }
+        duckdb::LogicalType operator()(PrimitiveType &type) const;
 
         duckdb::LogicalType operator()(EnumType &type) const 
         {

--- a/src/include/odata_edm.hpp
+++ b/src/include/odata_edm.hpp
@@ -2493,7 +2493,7 @@ public:
     // Number of entries currently held, expired ones included.
     size_t Size() const;
 
-    // Entry lifetime; a non-positive value disables expiry.
+    // Entry lifetime. Zero expires entries immediately; a negative value disables expiry.
     void SetEntryLifetime(std::chrono::seconds lifetime);
     std::chrono::seconds GetEntryLifetime() const;
 

--- a/src/include/odata_edm.hpp
+++ b/src/include/odata_edm.hpp
@@ -11,6 +11,7 @@
 #include <variant>
 #include <iostream>
 #include <memory>
+#include <chrono>
 
 // Cross-platform string comparison
 #ifdef _WIN32
@@ -2062,7 +2063,7 @@ private:
 class DuckTypeConverter 
 {
     public:
-        DuckTypeConverter(Edmx &edmx) : edmx(edmx) {}
+        explicit DuckTypeConverter(const Edmx &edmx) : edmx(edmx) {}
 
         // Central primitive EDM->DuckDB LogicalType mapping
         static duckdb::LogicalType ConvertEdmPrimitiveStringToLogicalType(const std::string &type_name) {
@@ -2136,7 +2137,7 @@ class DuckTypeConverter
         }
 
         // Central property-aware mapping (handles Decimal p/s and Collection(...))
-        static duckdb::LogicalType BuildLogicalTypeForProperty(const Property &property, Edmx &edmx) {
+        static duckdb::LogicalType BuildLogicalTypeForProperty(const Property &property, const Edmx &edmx) {
             // Detect Collection(T)
             std::regex collection_regex("Collection\\(([^\\)]+)\\)");
             std::smatch match;
@@ -2426,13 +2427,15 @@ class DuckTypeConverter
 
     
     public:
-        Edmx &edmx;
+        // Held by const reference: the EDM is shared, potentially across connections
+        // via EdmCache, and this converter only reads it.
+        const Edmx &edmx;
 };
 
 // Centralized OData EDM-based type builder utilities (for expand schema)
 class ODataEdmTypeBuilder {
 public:
-    explicit ODataEdmTypeBuilder(Edmx &edmx) : edmx(edmx), converter(edmx) {}
+    explicit ODataEdmTypeBuilder(const Edmx &edmx) : edmx(edmx), converter(edmx) {}
 
     // Resolve (is_collection, target_type_name) for a navigation property on an entity type
     std::pair<bool, std::string> ResolveNavTargetOnEntity(const std::string &entity_type_name, const std::string &nav_prop) const;
@@ -2448,26 +2451,67 @@ public:
                                                 const std::vector<std::string> &nested_children) const;
 
 private:
-    Edmx &edmx;
+    const Edmx &edmx;
     DuckTypeConverter converter;
 };
 
+// Process-global cache of parsed $metadata documents, keyed by metadata URL.
+//
+// Ownership: entries are handed out as shared_ptr<const Edmx> snapshots rather than as
+// pointers into the map. The previous optional_ptr<Edmx> was borrowed from a map entry
+// after the lock had already been released, so a concurrent Set() on the same URL --
+// two connections attaching or reading the same service is the normal case -- destroyed
+// the Edmx the first caller was still reading. A shared_ptr keeps the snapshot alive for
+// exactly as long as somebody holds it, and Set() replaces the map slot rather than the
+// object, so readers are never disturbed. The payload is const because it is shared.
 class EdmCache
 {
 public:
+    // A cached document is considered stale after this long. $metadata is not immutable:
+    // a service redeployment changes it, and without an expiry the entry survives for the
+    // lifetime of the process. See GitHub #106.
+    static constexpr int64_t DEFAULT_ENTRY_LIFETIME_SECONDS = 900;
+
     static EdmCache& GetInstance();
 
     EdmCache(const EdmCache&) = delete;
     EdmCache& operator=(const EdmCache&) = delete;
 
-    duckdb::optional_ptr<Edmx> Get(const std::string& key);
-    void Set(const std::string& key, Edmx edmx);
+    // Returns a snapshot, or nullptr when the URL is unknown or its entry has expired.
+    std::shared_ptr<const Edmx> Get(const std::string& metadata_url);
+
+    // Stores a snapshot and returns it, so a caller that has just parsed a document can
+    // hold the cached instance instead of keeping a private copy of it.
+    std::shared_ptr<const Edmx> Set(const std::string& metadata_url, Edmx edmx);
+
+    // Drops one entry (e.g. after a metadata request failed against a redeployed service).
+    void Invalidate(const std::string& metadata_url);
+
+    // Drops every entry. Mainly for tests and for a future `erpl_odata_clear_cache` pragma.
+    void Clear();
+
+    // Number of entries currently held, expired ones included.
+    size_t Size() const;
+
+    // Entry lifetime; a non-positive value disables expiry.
+    void SetEntryLifetime(std::chrono::seconds lifetime);
+    std::chrono::seconds GetEntryLifetime() const;
 
 private:
     EdmCache() = default;
 
-    std::mutex cache_lock;
-    std::unordered_map<std::string, Edmx> cache;
+    struct Entry {
+        std::shared_ptr<const Edmx> edmx;
+        std::chrono::steady_clock::time_point stored_at;
+    };
+
+    // Caller must hold cache_lock.
+    bool IsExpired(const Entry& entry, std::chrono::steady_clock::time_point now) const;
+    void EvictExpired(std::chrono::steady_clock::time_point now);
+
+    mutable std::mutex cache_lock;
+    std::unordered_map<std::string, Entry> cache;
+    std::chrono::seconds entry_lifetime{DEFAULT_ENTRY_LIFETIME_SECONDS};
 
     std::string UrlWithoutFragment(const std::string& url) const;
 };

--- a/src/include/odata_url_helpers.hpp
+++ b/src/include/odata_url_helpers.hpp
@@ -2,7 +2,52 @@
 
 #include "datazoo/oauth2/http_client.hpp"
 
+#include <memory>
+
 namespace erpl_web {
+
+// The HTTP client every OData consumer needs.
+//
+// url_encode is off because the OData layer has already encoded what needs encoding:
+// $filter expressions, $expand option groups and key predicates such as
+// Customers('ALFKI') carry percent-escapes and reserved characters on purpose, and a
+// second encoding pass in the transport corrupts them. This used to be spelled out
+// three times, in the Business Central, Dataverse and Graph clients, plus a fourth
+// spelling in datasphere_catalog.cpp that forgot the flag entirely (GitHub #102).
+std::shared_ptr<HttpClient> CreateODataHttpClient();
+
+// One place that knows how a service hands back a change-tracking (delta) link, and how
+// to read the token out of it.
+//
+// This logic existed twice before GitHub #102, and the second copy looked only at the
+// v2 "__delta" property. SAP ODP routinely delivers the token on the terminal page as a
+// "__next" link carrying the "!deltatoken=" sigil instead, and that copy silently returned
+// no token - which leaves the ODP scan in initial-load mode, so the next read re-extracts
+// the whole entity set rather than fetching deltas.
+//
+// This belongs on ODataEntitySetResponse, next to NextUrl(); it lives here only because
+// odata_client.* was being edited elsewhere when #102 was fixed.
+class ODataDeltaLink {
+public:
+    // The delta link carried by an OData JSON payload, or "" when the page has none.
+    // Recognised, in this order:
+    //   v4  {"@odata.deltaLink": "<url>"}
+    //   v2  {"d": {"__delta": "<url>"}}   (also honoured at the document root)
+    //   v2  {"d": {"__next":  "<url with !deltatoken= or $deltatoken=>"}}
+    // A plain "__next" without a delta sigil is ordinary server-driven paging and is not
+    // a delta link.
+    static std::string ExtractDeltaLink(const std::string &json_body);
+
+    // The token inside a delta link: "!deltatoken=" (v2) or "$deltatoken=" (v4).
+    // Surrounding single or double quotes, which SAP Gateway sometimes emits, are stripped.
+    static std::string ExtractToken(const std::string &delta_link);
+
+    // True when the URL carries a delta token in either dialect.
+    static bool IsDeltaLink(const std::string &url);
+
+    // Convenience: the token carried by a payload, "" when the payload has no delta link.
+    static std::string ExtractDeltaToken(const std::string &json_body);
+};
 
 class ODataUrlResolver {
 public:

--- a/src/odata_catalog.cpp
+++ b/src/odata_catalog.cpp
@@ -409,11 +409,21 @@ ODataServiceClient& ODataCatalog::GetServiceClient() {
     return service_client;
 }
 
-Edmx &ODataCatalog::GetCachedMetadata() {
+const Edmx &ODataCatalog::GetCachedMetadata() {
     std::lock_guard<std::mutex> lock(metadata_mutex);
-    if (!cached_metadata.has_value()) {
+    if (!cached_metadata) {
         try {
-            cached_metadata = service_client.GetMetadata();
+            // GetMetadata() populates the process-global EdmCache as a side effect. Taking the
+            // snapshot back out of the cache - rather than storing the returned value - is what
+            // keeps the catalog from holding a second full EDMX for the whole life of the ATTACH.
+            // See GitHub #106.
+            auto edmx = service_client.GetMetadata();
+            const auto metadata_url = service_client.GetMetadataContextUrl();
+            cached_metadata = EdmCache::GetInstance().Get(metadata_url);
+            if (!cached_metadata) {
+                // The client did not cache it (or the entry expired in between); adopt ours.
+                cached_metadata = EdmCache::GetInstance().Set(metadata_url, std::move(edmx));
+            }
         } catch (const std::exception &e) {
             // Preserve the underlying cause (401, TLS failure, DNS failure, malformed EDMX, ...)
             // together with the service URL instead of degrading it into an empty schema.
@@ -421,7 +431,17 @@ Edmx &ODataCatalog::GetCachedMetadata() {
                 "Failed to load OData metadata from '%s': %s", path_, std::string(e.what())));
         }
     }
-    return cached_metadata.value();
+    return *cached_metadata;
+}
+
+void ODataCatalog::InvalidateCachedMetadata() {
+    std::lock_guard<std::mutex> lock(metadata_mutex);
+    if (cached_metadata) {
+        EdmCache::GetInstance().Invalidate(service_client.GetMetadataContextUrl());
+    }
+    // Any caller still reading the previous snapshot keeps it alive through its own
+    // shared_ptr; resetting ours only detaches this catalog from it.
+    cached_metadata.reset();
 }
 
 bool ODataCatalog::IsIgnored(const std::string &entity_set_name) const {

--- a/src/odata_edm.cpp
+++ b/src/odata_edm.cpp
@@ -8,20 +8,73 @@ EdmCache& EdmCache::GetInstance() {
     return instance;
 }
 
-duckdb::optional_ptr<Edmx> EdmCache::Get(const std::string& metadata_url) {
-    std::lock_guard<std::mutex> lock(cache_lock);
-    auto url_without_fragment = UrlWithoutFragment(metadata_url);
-    auto it = cache.find(url_without_fragment);
-    if (it != cache.end()) {
-        return duckdb::optional_ptr<Edmx>(&(it->second));
+bool EdmCache::IsExpired(const Entry& entry, std::chrono::steady_clock::time_point now) const {
+    if (entry_lifetime <= std::chrono::seconds::zero()) {
+        return false;
     }
-    return duckdb::optional_ptr<Edmx>();
+    return (now - entry.stored_at) >= entry_lifetime;
 }
 
-void EdmCache::Set(const std::string& metadata_url, Edmx edmx) {
+void EdmCache::EvictExpired(std::chrono::steady_clock::time_point now) {
+    if (entry_lifetime <= std::chrono::seconds::zero()) {
+        return;
+    }
+    for (auto it = cache.begin(); it != cache.end();) {
+        it = IsExpired(it->second, now) ? cache.erase(it) : std::next(it);
+    }
+}
+
+std::shared_ptr<const Edmx> EdmCache::Get(const std::string& metadata_url) {
+    const auto now = std::chrono::steady_clock::now();
     std::lock_guard<std::mutex> lock(cache_lock);
-    auto url_without_fragment = UrlWithoutFragment(metadata_url);
-    cache[url_without_fragment] = std::move(edmx);
+
+    // Sweeping on every lookup keeps the map from growing without bound in a
+    // long-lived process that attaches many services. See GitHub #106.
+    EvictExpired(now);
+
+    const auto url_without_fragment = UrlWithoutFragment(metadata_url);
+    const auto it = cache.find(url_without_fragment);
+    if (it == cache.end()) {
+        return nullptr;
+    }
+    // The shared_ptr copy leaves the lock with the caller; whatever happens to the map
+    // slot afterwards, the document the caller reads stays alive and unchanged.
+    return it->second.edmx;
+}
+
+std::shared_ptr<const Edmx> EdmCache::Set(const std::string& metadata_url, Edmx edmx) {
+    auto snapshot = std::make_shared<const Edmx>(std::move(edmx));
+    const auto now = std::chrono::steady_clock::now();
+
+    std::lock_guard<std::mutex> lock(cache_lock);
+    EvictExpired(now);
+    cache[UrlWithoutFragment(metadata_url)] = Entry{snapshot, now};
+    return snapshot;
+}
+
+void EdmCache::Invalidate(const std::string& metadata_url) {
+    std::lock_guard<std::mutex> lock(cache_lock);
+    cache.erase(UrlWithoutFragment(metadata_url));
+}
+
+void EdmCache::Clear() {
+    std::lock_guard<std::mutex> lock(cache_lock);
+    cache.clear();
+}
+
+size_t EdmCache::Size() const {
+    std::lock_guard<std::mutex> lock(cache_lock);
+    return cache.size();
+}
+
+void EdmCache::SetEntryLifetime(std::chrono::seconds lifetime) {
+    std::lock_guard<std::mutex> lock(cache_lock);
+    entry_lifetime = lifetime;
+}
+
+std::chrono::seconds EdmCache::GetEntryLifetime() const {
+    std::lock_guard<std::mutex> lock(cache_lock);
+    return entry_lifetime;
 }
 
 std::string EdmCache::UrlWithoutFragment(const std::string& url_str) const {

--- a/src/odata_edm.cpp
+++ b/src/odata_edm.cpp
@@ -84,6 +84,88 @@ std::string EdmCache::UrlWithoutFragment(const std::string& url_str) const {
     return ss.str();
 }
 
+// -----------------------------------------------------------------------------
+// The one EDM primitive type table
+// -----------------------------------------------------------------------------
+namespace {
+
+struct EdmPrimitiveMapping {
+    const char *edm_type_name;
+    duckdb::LogicalTypeId logical_type_id;
+    const char *duckdb_type_name;
+};
+
+// Edm.Byte is UNSIGNED (0..255); Edm.SByte is the signed one (-128..127). Mapping both
+// to TINYINT silently NULLed 128..255 (GitHub #68). Edm.Decimal appears here without
+// precision or scale; property-aware callers go through BuildDecimalLogicalType instead.
+const EdmPrimitiveMapping EDM_PRIMITIVE_MAPPINGS[] = {
+    {"Edm.Binary",         duckdb::LogicalTypeId::BLOB,      "BLOB"},
+    {"Edm.Boolean",        duckdb::LogicalTypeId::BOOLEAN,   "BOOLEAN"},
+    {"Edm.Byte",           duckdb::LogicalTypeId::UTINYINT,  "UTINYINT"},
+    {"Edm.SByte",          duckdb::LogicalTypeId::TINYINT,   "TINYINT"},
+    {"Edm.Date",           duckdb::LogicalTypeId::DATE,      "DATE"},
+    {"Edm.DateTime",       duckdb::LogicalTypeId::TIMESTAMP, "TIMESTAMP"},
+    {"Edm.DateTimeOffset", duckdb::LogicalTypeId::TIMESTAMP, "TIMESTAMP"},
+    {"Edm.Decimal",        duckdb::LogicalTypeId::DECIMAL,   "DECIMAL"},
+    {"Edm.Double",         duckdb::LogicalTypeId::DOUBLE,    "DOUBLE"},
+    {"Edm.Duration",       duckdb::LogicalTypeId::INTERVAL,  "INTERVAL"},
+    {"Edm.Guid",           duckdb::LogicalTypeId::VARCHAR,   "VARCHAR"},
+    {"Edm.Int16",          duckdb::LogicalTypeId::SMALLINT,  "SMALLINT"},
+    {"Edm.Int32",          duckdb::LogicalTypeId::INTEGER,   "INTEGER"},
+    {"Edm.Int64",          duckdb::LogicalTypeId::BIGINT,    "BIGINT"},
+    {"Edm.Single",         duckdb::LogicalTypeId::FLOAT,     "FLOAT"},
+    {"Edm.Stream",         duckdb::LogicalTypeId::BLOB,      "BLOB"},
+    {"Edm.String",         duckdb::LogicalTypeId::VARCHAR,   "VARCHAR"},
+    {"Edm.Time",           duckdb::LogicalTypeId::TIME,      "TIME"},
+    {"Edm.TimeOfDay",      duckdb::LogicalTypeId::TIME,      "TIME"},
+};
+
+const EdmPrimitiveMapping *FindEdmPrimitiveMapping(const std::string &type_name) {
+    for (const auto &mapping : EDM_PRIMITIVE_MAPPINGS) {
+        if (type_name == mapping.edm_type_name) {
+            return &mapping;
+        }
+    }
+    return nullptr;
+}
+
+// Geography/Geometry are surfaced as VARCHAR for now; the family is recognised by prefix
+// because CSDL spells out a dozen of them.
+bool IsEdmSpatialType(const std::string &type_name) {
+    return type_name.rfind("Edm.Geography", 0) == 0 || type_name.rfind("Edm.Geometry", 0) == 0;
+}
+
+} // namespace
+
+duckdb::LogicalType DuckTypeConverter::ConvertEdmPrimitiveStringToLogicalType(const std::string &type_name) {
+    if (const auto *mapping = FindEdmPrimitiveMapping(type_name)) {
+        return duckdb::LogicalType(mapping->logical_type_id);
+    }
+    // Unknown types, spatial ones included, fall back to VARCHAR.
+    return duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
+}
+
+std::string DuckTypeConverter::ConvertEdmTypeStringToDuckDbTypeString(const std::string &edm_type) {
+    if (const auto *mapping = FindEdmPrimitiveMapping(edm_type)) {
+        return mapping->duckdb_type_name;
+    }
+    return "VARCHAR";
+}
+
+duckdb::LogicalType DuckTypeConverter::operator()(PrimitiveType &type) const {
+    // Edm.GeographyPoint is the one spatial type this path models structurally, as a pair
+    // of doubles. The string-keyed mapping above still reports VARCHAR for it, which is a
+    // pre-existing inconsistency between the two entry points and not one this change
+    // introduces; unifying them would change catalog column types.
+    if (type == erpl_web::GeographyPoint) {
+        return duckdb::LogicalType::LIST(duckdb::LogicalType(duckdb::LogicalTypeId::DOUBLE));
+    }
+    if (IsEdmSpatialType(type.name)) {
+        return duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
+    }
+    return ConvertEdmPrimitiveStringToLogicalType(type.name);
+}
+
 // Version-specific parsing methods
 Edmx Edmx::FromXmlV2(const std::string& xml) {
     tinyxml2::XMLDocument doc;

--- a/src/odata_edm.cpp
+++ b/src/odata_edm.cpp
@@ -9,14 +9,14 @@ EdmCache& EdmCache::GetInstance() {
 }
 
 bool EdmCache::IsExpired(const Entry& entry, std::chrono::steady_clock::time_point now) const {
-    if (entry_lifetime <= std::chrono::seconds::zero()) {
+    if (entry_lifetime < std::chrono::seconds::zero()) {
         return false;
     }
     return (now - entry.stored_at) >= entry_lifetime;
 }
 
 void EdmCache::EvictExpired(std::chrono::steady_clock::time_point now) {
-    if (entry_lifetime <= std::chrono::seconds::zero()) {
+    if (entry_lifetime < std::chrono::seconds::zero()) {
         return;
     }
     for (auto it = cache.begin(); it != cache.end();) {

--- a/src/odata_url_helpers.cpp
+++ b/src/odata_url_helpers.cpp
@@ -1,7 +1,14 @@
 #include "odata_url_helpers.hpp"
+#include "yyjson.hpp"
 #include <sstream>
 
 namespace erpl_web {
+
+std::shared_ptr<HttpClient> CreateODataHttpClient() {
+    HttpParams http_params;
+    http_params.url_encode = false;
+    return std::make_shared<HttpClient>(http_params);
+}
 
 std::string ODataUrlResolver::resolveMetadataUrl(const HttpUrl &request_url,
                                                  const std::string &odata_context_if_any) const
@@ -103,6 +110,45 @@ std::string ODataUrlResolver::resolveMetadataUrl(const HttpUrl &request_url,
     return base.ToString();
 }
 
+namespace {
+
+// OData escapes a single quote inside a string literal by doubling it: O'Brien is written
+// 'O''Brien'. Emitting the raw quote closed the literal early, which either produced a
+// malformed key predicate the service rejected or - worse - let a parameter value inject
+// further OData syntax into the URL. See GitHub #104.
+std::string EscapeSingleQuotes(const std::string &value) {
+    std::string escaped;
+    escaped.reserve(value.size());
+    for (const char c : value) {
+        escaped += c;
+        if (c == '\'') {
+            escaped += '\'';
+        }
+    }
+    return escaped;
+}
+
+// Integers, decimals and ISO dates go into the key predicate unquoted; everything else is
+// a string literal. An empty value is a string literal, not a zero-length number: the old
+// find_first_not_of test answered npos for "" and emitted a bare "Key=".
+bool IsUnquotedParameterLiteral(const std::string &value) {
+    if (value.empty()) {
+        return false;
+    }
+    const bool only_digits_and_sign = (value.find_first_not_of("0123456789-") == std::string::npos);
+    const bool is_decimal = (value.find_first_not_of("0123456789.-") == std::string::npos &&
+                             value.find('.') != std::string::npos);
+    const bool is_date = (only_digits_and_sign && value.find('-') != std::string::npos && value.length() == 10);
+    const bool is_integer = (only_digits_and_sign && !is_date);
+    // "-", "--" and friends satisfy only_digits_and_sign but are not numbers.
+    if ((is_integer || is_decimal) && value.find_first_of("0123456789") == std::string::npos) {
+        return false;
+    }
+    return is_decimal || is_integer || is_date;
+}
+
+} // namespace
+
 HttpUrl InputParametersFormatter::addParams(const HttpUrl &url,
                                            const std::map<std::string, std::string> &params) const
 {
@@ -118,14 +164,10 @@ HttpUrl InputParametersFormatter::addParams(const HttpUrl &url,
         const auto &value = kv.second;
         if (!first) params_string += ",";
         first = false;
-        const bool only_digits_and_sign = (value.find_first_not_of("0123456789-") == std::string::npos);
-        const bool is_decimal = (value.find_first_not_of("0123456789.-") == std::string::npos && value.find('.') != std::string::npos);
-        const bool is_date = (only_digits_and_sign && value.find('-') != std::string::npos && value.length() == 10);
-        const bool is_integer = (only_digits_and_sign && !is_date);
-        if (is_decimal || is_integer || is_date) {
+        if (IsUnquotedParameterLiteral(value)) {
             params_string += key + "=" + value;
         } else {
-            params_string += key + "='" + value + "'";
+            params_string += key + "='" + EscapeSingleQuotes(value) + "'";
         }
     }
     params_string += ")";
@@ -146,6 +188,103 @@ HttpUrl InputParametersFormatter::addParams(const HttpUrl &url,
     }
     modified_url.Path(new_path);
     return modified_url;
+}
+
+// ----------------------- ODataDeltaLink -----------------------
+
+namespace {
+
+constexpr const char *V2_DELTA_SIGIL = "!deltatoken=";
+constexpr const char *V4_DELTA_SIGIL = "$deltatoken=";
+
+std::string ReadStringMember(duckdb_yyjson::yyjson_val *object, const char *key) {
+    if (object == nullptr) {
+        return std::string();
+    }
+    auto *value = duckdb_yyjson::yyjson_obj_get(object, key);
+    if (value == nullptr || !duckdb_yyjson::yyjson_is_str(value)) {
+        return std::string();
+    }
+    return std::string(duckdb_yyjson::yyjson_get_str(value));
+}
+
+// Reads the token that follows `sigil`, up to the next query separator.
+std::string TokenAfterSigil(const std::string &url, const char *sigil) {
+    const auto sigil_pos = url.find(sigil);
+    if (sigil_pos == std::string::npos) {
+        return std::string();
+    }
+    const auto start = sigil_pos + std::char_traits<char>::length(sigil);
+    const auto end = url.find_first_of("&#", start);
+    auto token = url.substr(start, end == std::string::npos ? std::string::npos : end - start);
+
+    // SAP Gateway quotes the token in some releases; the state store keeps it unquoted so
+    // that BuildDeltaUrl can requote it consistently.
+    if (token.size() >= 2 && (token.front() == '\'' || token.front() == '"') && token.back() == token.front()) {
+        token = token.substr(1, token.size() - 2);
+    }
+    return token;
+}
+
+} // namespace
+
+bool ODataDeltaLink::IsDeltaLink(const std::string &url) {
+    return url.find(V2_DELTA_SIGIL) != std::string::npos ||
+           url.find(V4_DELTA_SIGIL) != std::string::npos;
+}
+
+std::string ODataDeltaLink::ExtractToken(const std::string &delta_link) {
+    auto token = TokenAfterSigil(delta_link, V2_DELTA_SIGIL);
+    if (!token.empty()) {
+        return token;
+    }
+    return TokenAfterSigil(delta_link, V4_DELTA_SIGIL);
+}
+
+std::string ODataDeltaLink::ExtractDeltaLink(const std::string &json_body) {
+    if (json_body.empty()) {
+        return std::string();
+    }
+
+    auto *doc = duckdb_yyjson::yyjson_read(json_body.c_str(), json_body.size(), 0);
+    if (doc == nullptr) {
+        return std::string();
+    }
+
+    std::string delta_link;
+    auto *root = duckdb_yyjson::yyjson_doc_get_root(doc);
+    if (root != nullptr && duckdb_yyjson::yyjson_is_obj(root)) {
+        auto *d_wrapper = duckdb_yyjson::yyjson_obj_get(root, "d");
+        if (d_wrapper != nullptr && !duckdb_yyjson::yyjson_is_obj(d_wrapper)) {
+            d_wrapper = nullptr;
+        }
+
+        delta_link = ReadStringMember(root, "@odata.deltaLink");
+        if (delta_link.empty()) {
+            delta_link = ReadStringMember(d_wrapper, "__delta");
+        }
+        if (delta_link.empty()) {
+            delta_link = ReadStringMember(root, "__delta");
+        }
+        if (delta_link.empty()) {
+            // The form the older parser missed: the terminal page carries the token on its
+            // paging link rather than on a dedicated delta property. See GitHub #102.
+            auto next_link = ReadStringMember(d_wrapper, "__next");
+            if (next_link.empty()) {
+                next_link = ReadStringMember(root, "__next");
+            }
+            if (IsDeltaLink(next_link)) {
+                delta_link = next_link;
+            }
+        }
+    }
+
+    duckdb_yyjson::yyjson_doc_free(doc);
+    return delta_link;
+}
+
+std::string ODataDeltaLink::ExtractDeltaToken(const std::string &json_body) {
+    return ExtractToken(ExtractDeltaLink(json_body));
 }
 
 // ----------------------- ODataUrlCodec -----------------------

--- a/test/cpp/test_odata_protocol_core.cpp
+++ b/test/cpp/test_odata_protocol_core.cpp
@@ -1,0 +1,356 @@
+// Tests for the shared OData protocol core: delta-link extraction, key-predicate
+// formatting and the EdmCache. See GitHub #102, #104 and #106.
+
+#include "catch.hpp"
+#include "duckdb.hpp"
+
+#include "odata_client.hpp"
+#include "odata_edm.hpp"
+#include "odata_test_server.hpp"
+#include "odata_url_helpers.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <map>
+#include <string>
+#include <thread>
+#include <vector>
+
+using erpl_web::test_support::CannedResponse;
+using erpl_web::test_support::ODataTestServer;
+
+namespace {
+
+// The EdmCache is a process-global singleton, so every test that touches it has to
+// hand it back exactly as it found it or it will poison its neighbours.
+class EdmCacheGuard {
+public:
+    EdmCacheGuard() : saved_lifetime(erpl_web::EdmCache::GetInstance().GetEntryLifetime())
+    {
+        erpl_web::EdmCache::GetInstance().Clear();
+    }
+
+    ~EdmCacheGuard()
+    {
+        erpl_web::EdmCache::GetInstance().SetEntryLifetime(saved_lifetime);
+        erpl_web::EdmCache::GetInstance().Clear();
+    }
+
+    EdmCacheGuard(const EdmCacheGuard &) = delete;
+    EdmCacheGuard &operator=(const EdmCacheGuard &) = delete;
+
+private:
+    std::chrono::seconds saved_lifetime;
+};
+
+// A minimal but complete v4 EDMX: enough for FindEntitySets()/FindType() and small
+// enough that the tests below stay readable.
+std::string MinimalEdmx(const char *odata_version_attribute, const char *entity_set_name)
+{
+    return std::string(R"(<?xml version="1.0" encoding="utf-8"?>)") +
+           R"(<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version=")" +
+           odata_version_attribute + R"(">)" +
+           R"(<edmx:DataServices>)" +
+           R"(<Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Test">)" +
+           R"(<EntityType Name="Thing"><Key><PropertyRef Name="Id"/></Key>)" +
+           R"(<Property Name="Id" Type="Edm.String"/></EntityType>)" +
+           R"(<EntityContainer Name="Container"><EntitySet Name=")" + entity_set_name +
+           R"(" EntityType="Test.Thing"/></EntityContainer>)" +
+           R"(</Schema></edmx:DataServices></edmx:Edmx>)";
+}
+
+}  // namespace
+
+// ============================================================================
+// GitHub #102 -- one delta-link parser, and it understands the __next form
+// ============================================================================
+
+TEST_CASE("Delta link is read from every form a service uses", "[odata_delta_link]")
+{
+    using erpl_web::ODataDeltaLink;
+
+    SECTION("OData v4 @odata.deltaLink")
+    {
+        const std::string body =
+            R"({"@odata.context":"http://svc/$metadata#Things","value":[],)"
+            R"("@odata.deltaLink":"http://svc/Things?$deltatoken=v4token"})";
+
+        REQUIRE(ODataDeltaLink::ExtractDeltaLink(body) == "http://svc/Things?$deltatoken=v4token");
+        REQUIRE(ODataDeltaLink::ExtractDeltaToken(body) == "v4token");
+    }
+
+    SECTION("OData v2 __delta inside the d wrapper")
+    {
+        const std::string body =
+            R"({"d":{"results":[],"__delta":"http://svc/Things?$format=json&!deltatoken=D2024"}})";
+
+        REQUIRE(ODataDeltaLink::ExtractDeltaToken(body) == "D2024");
+    }
+
+    SECTION("SAP Gateway quotes the token")
+    {
+        const std::string body =
+            R"({"d":{"results":[],"__delta":"http://svc/Things?!deltatoken='D2024'"}})";
+
+        REQUIRE(ODataDeltaLink::ExtractDeltaToken(body) == "D2024");
+    }
+
+    // The regression this whole exercise is about. SAP ODP delivers the change-tracking
+    // token on the terminal page as a paging link carrying the "!deltatoken=" sigil, not
+    // as a "__delta" property. Both parsers that existed before #102 looked only at
+    // "__delta", returned no token, and so left the ODP scan in initial-load mode -- the
+    // next read then re-extracted the whole entity set instead of fetching deltas.
+    SECTION("__next carrying !deltatoken is a delta link")
+    {
+        const std::string body =
+            R"({"d":{"results":[{"Id":"1"}],)"
+            R"("__next":"http://svc/Things?$format=json&!deltatoken=D20240101120000"}})";
+
+        REQUIRE(ODataDeltaLink::ExtractDeltaLink(body) ==
+                "http://svc/Things?$format=json&!deltatoken=D20240101120000");
+        REQUIRE(ODataDeltaLink::ExtractDeltaToken(body) == "D20240101120000");
+    }
+
+    SECTION("the $deltatoken sigil identifies a link just as well")
+    {
+        REQUIRE(ODataDeltaLink::IsDeltaLink("http://svc/Things?$deltatoken=v4next"));
+        REQUIRE(ODataDeltaLink::IsDeltaLink("http://svc/Things?!deltatoken=D1"));
+        REQUIRE_FALSE(ODataDeltaLink::IsDeltaLink("http://svc/Things?$skiptoken=100"));
+    }
+
+    // ... but an ordinary paging link must NOT be mistaken for one, or every
+    // intermediate page would look like the end of a change-tracked extraction.
+    SECTION("an ordinary __next is not a delta link")
+    {
+        const std::string body =
+            R"({"d":{"results":[{"Id":"1"}],)"
+            R"("__next":"http://svc/Things?$format=json&$skiptoken=100"}})";
+
+        REQUIRE(ODataDeltaLink::ExtractDeltaLink(body).empty());
+        REQUIRE(ODataDeltaLink::ExtractDeltaToken(body).empty());
+    }
+
+    SECTION("no delta information at all")
+    {
+        REQUIRE(ODataDeltaLink::ExtractDeltaLink(R"({"d":{"results":[]}})").empty());
+        REQUIRE(ODataDeltaLink::ExtractDeltaLink("not json").empty());
+        REQUIRE(ODataDeltaLink::ExtractDeltaLink("").empty());
+    }
+
+    SECTION("token ends at the next query separator, not at the end of the URL")
+    {
+        REQUIRE(ODataDeltaLink::ExtractToken("http://svc/Set?!deltatoken=D1&$format=json") == "D1");
+        REQUIRE(ODataDeltaLink::ExtractToken("http://svc/Set?$deltatoken=D2#frag") == "D2");
+        REQUIRE(ODataDeltaLink::ExtractToken("http://svc/Set?$skiptoken=100").empty());
+    }
+}
+
+// ============================================================================
+// GitHub #104 -- key predicate formatting
+// ============================================================================
+
+TEST_CASE("Input parameters are escaped as OData string literals", "[odata_url_helpers]")
+{
+    erpl_web::InputParametersFormatter formatter;
+    const erpl_web::HttpUrl base("http://svc/Service/Report");
+
+    SECTION("a single quote in a value is doubled, not emitted raw")
+    {
+        // OData escapes ' inside a literal by doubling it. Emitting the raw quote closed
+        // the literal early and let the value inject further OData syntax into the URL.
+        const std::map<std::string, std::string> params{{"Customer", "O'Brien"}};
+        const auto result = formatter.addParams(base, params).ToString();
+
+        REQUIRE(result.find("(Customer='O''Brien')") != std::string::npos);
+        REQUIRE(result.find("(Customer='O'Brien')") == std::string::npos);
+    }
+
+    SECTION("an injected clause stays inside the literal")
+    {
+        const std::map<std::string, std::string> params{{"Customer", "x')/Other('y"}};
+        const auto result = formatter.addParams(base, params).ToString();
+
+        REQUIRE(result.find("(Customer='x'')/Other(''y')") != std::string::npos);
+    }
+
+    SECTION("an empty value is an empty string literal, not a bare key")
+    {
+        const std::map<std::string, std::string> params{{"Customer", ""}};
+        const auto result = formatter.addParams(base, params).ToString();
+
+        REQUIRE(result.find("(Customer='')") != std::string::npos);
+    }
+
+    SECTION("a lone sign is a string, not a number")
+    {
+        const std::map<std::string, std::string> params{{"Customer", "-"}};
+        const auto result = formatter.addParams(base, params).ToString();
+
+        REQUIRE(result.find("(Customer='-')") != std::string::npos);
+    }
+
+    SECTION("numbers and ISO dates stay unquoted")
+    {
+        REQUIRE(formatter.addParams(base, {{"Year", "2024"}}).ToString().find("(Year=2024)") !=
+                std::string::npos);
+        REQUIRE(formatter.addParams(base, {{"Rate", "1.25"}}).ToString().find("(Rate=1.25)") !=
+                std::string::npos);
+        REQUIRE(formatter.addParams(base, {{"Day", "2024-01-31"}}).ToString().find("(Day=2024-01-31)") !=
+                std::string::npos);
+    }
+}
+
+// ============================================================================
+// GitHub #104 -- EdmCache hands out snapshots, not pointers into its own map
+// ============================================================================
+
+TEST_CASE("EdmCache entries survive a concurrent overwrite", "[edm_cache]")
+{
+    EdmCacheGuard guard;
+    auto &cache = erpl_web::EdmCache::GetInstance();
+
+    const std::string url = "http://svc/Service/$metadata";
+    cache.Set(url, erpl_web::Edmx::FromXmlV2(MinimalEdmx("1.0", "Things")));
+
+    auto snapshot = cache.Get(url);
+    REQUIRE(snapshot != nullptr);
+    REQUIRE(snapshot->GetVersion() == erpl_web::ODataVersion::V2);
+
+    // Another connection re-reads $metadata for the same service and stores the result.
+    // The previous API handed out a pointer into the map slot this assignment overwrites,
+    // so the reader above silently started seeing the new document -- or, once the entry
+    // was erased rather than assigned, a destroyed one.
+    cache.Set(url, erpl_web::Edmx::FromXmlV4(MinimalEdmx("4.0", "Things")));
+
+    REQUIRE(snapshot->GetVersion() == erpl_web::ODataVersion::V2);
+    REQUIRE(snapshot->FindEntitySets().size() == 1);
+
+    auto fresh = cache.Get(url);
+    REQUIRE(fresh != nullptr);
+    REQUIRE(fresh->GetVersion() == erpl_web::ODataVersion::V4);
+}
+
+TEST_CASE("EdmCache entries survive invalidation while in use", "[edm_cache]")
+{
+    EdmCacheGuard guard;
+    auto &cache = erpl_web::EdmCache::GetInstance();
+
+    const std::string url = "http://svc/Service/$metadata";
+    cache.Set(url, erpl_web::Edmx::FromXmlV2(MinimalEdmx("1.0", "Things")));
+
+    auto snapshot = cache.Get(url);
+    REQUIRE(snapshot != nullptr);
+
+    cache.Invalidate(url);
+    REQUIRE(cache.Get(url) == nullptr);
+
+    // Erasing the map entry used to destroy the Edmx a scan was still reading.
+    REQUIRE(snapshot->FindEntitySets().size() == 1);
+    REQUIRE(snapshot->FindEntitySets()[0].name == "Things");
+}
+
+TEST_CASE("EdmCache expires entries", "[edm_cache]")
+{
+    EdmCacheGuard guard;
+    auto &cache = erpl_web::EdmCache::GetInstance();
+
+    const std::string url = "http://svc/Service/$metadata";
+
+    // A zero lifetime expires on the next lookup, which makes the sweep testable without
+    // sleeping. This is also what keeps the process-global map from growing without bound.
+    cache.SetEntryLifetime(std::chrono::seconds(0));
+    cache.Set(url, erpl_web::Edmx::FromXmlV4(MinimalEdmx("4.0", "Things")));
+    REQUIRE(cache.Get(url) == nullptr);
+    REQUIRE(cache.Size() == 0);
+
+    // A negative lifetime disables expiry entirely.
+    cache.SetEntryLifetime(std::chrono::seconds(-1));
+    cache.Set(url, erpl_web::Edmx::FromXmlV4(MinimalEdmx("4.0", "Things")));
+    REQUIRE(cache.Get(url) != nullptr);
+
+    // The shipped default is finite, so a redeployed service is eventually noticed.
+    REQUIRE(erpl_web::EdmCache::DEFAULT_ENTRY_LIFETIME_SECONDS > 0);
+}
+
+// Not a deterministic reproduction of the race -- it cannot be made one without a hook
+// inside the cache -- but under AddressSanitizer a reader holding a borrowed pointer
+// across a concurrent overwrite reports a use-after-free here with high probability,
+// and the test can never fail once entries are handed out as shared snapshots.
+TEST_CASE("EdmCache tolerates concurrent readers and writers", "[edm_cache]")
+{
+    EdmCacheGuard guard;
+    auto &cache = erpl_web::EdmCache::GetInstance();
+
+    const std::string url = "http://svc/Service/$metadata";
+    cache.Set(url, erpl_web::Edmx::FromXmlV2(MinimalEdmx("1.0", "Things")));
+
+    constexpr int ITERATIONS = 200;
+    std::atomic<bool> reader_saw_a_valid_document{true};
+    std::atomic<int> ready{0};
+
+    std::thread writer([&]() {
+        ready++;
+        while (ready.load() < 2) {
+        }
+        for (int i = 0; i < ITERATIONS; i++) {
+            cache.Set(url, erpl_web::Edmx::FromXmlV4(MinimalEdmx("4.0", "Things")));
+        }
+    });
+
+    std::thread reader([&]() {
+        ready++;
+        while (ready.load() < 2) {
+        }
+        for (int i = 0; i < ITERATIONS; i++) {
+            auto snapshot = cache.Get(url);
+            if (!snapshot) {
+                continue;
+            }
+            // Walking the document while the writer replaces the entry is the whole point.
+            if (snapshot->FindEntitySets().size() != 1) {
+                reader_saw_a_valid_document = false;
+            }
+        }
+    });
+
+    writer.join();
+    reader.join();
+
+    REQUIRE(reader_saw_a_valid_document.load());
+}
+
+// ============================================================================
+// GitHub #106 -- $metadata is fetched once per service, not once per consumer
+// ============================================================================
+
+TEST_CASE("Metadata is fetched once and shared across clients", "[edm_cache][odata_e2e]")
+{
+    EdmCacheGuard guard;
+
+    ODataTestServer server;
+    server.ServeMetadata("/svc/$metadata", MinimalEdmx("4.0", "Things"));
+    server.OnPath("/svc/", CannedResponse::Json(
+                               std::string(R"({"@odata.context":")") + server.Url("/svc/$metadata") +
+                               R"(","value":[{"name":"Things","kind":"EntitySet","url":"Things"}]})"));
+
+    const erpl_web::HttpUrl service_url(server.Url("/svc/"));
+
+    auto first = erpl_web::ODataServiceClient(erpl_web::CreateODataHttpClient(), service_url);
+    auto first_metadata = first.GetMetadata();
+    REQUIRE(first_metadata.FindEntitySets().size() == 1);
+
+    const auto after_first = server.RequestsFor("/svc/$metadata").size();
+    REQUIRE(after_first >= 1);
+
+    // A second consumer of the same service must reuse the cached document. Each attached
+    // catalog used to hold its own full copy and, worse, each client re-fetched it whenever
+    // the cache had been reset.
+    auto second = erpl_web::ODataServiceClient(erpl_web::CreateODataHttpClient(), service_url);
+    auto second_metadata = second.GetMetadata();
+    REQUIRE(second_metadata.FindEntitySets().size() == 1);
+
+    REQUIRE(server.RequestsFor("/svc/$metadata").size() == after_first);
+
+    // Exactly one document is held for the service, not one per consumer.
+    REQUIRE(erpl_web::EdmCache::GetInstance().Size() == 1);
+}

--- a/test/cpp/test_odata_protocol_core.cpp
+++ b/test/cpp/test_odata_protocol_core.cpp
@@ -354,3 +354,45 @@ TEST_CASE("Metadata is fetched once and shared across clients", "[edm_cache][oda
     // Exactly one document is held for the service, not one per consumer.
     REQUIRE(erpl_web::EdmCache::GetInstance().Size() == 1);
 }
+
+
+// ============================================================================
+// GitHub #104 -- the EDM primitive mapping exists once
+// ============================================================================
+
+TEST_CASE("EDM primitive mappings agree across entry points", "[odata_edm_mapping]")
+{
+    using erpl_web::DuckTypeConverter;
+
+    // The LogicalType-valued and the string-valued mapping used to be separate
+    // hand-written ladders, which is how Edm.Byte ended up wrong in several of them at
+    // once (GitHub #68). They now read the same table, so they cannot disagree.
+    const std::vector<std::string> edm_types{
+        "Edm.Binary", "Edm.Boolean", "Edm.Byte",  "Edm.SByte",  "Edm.Date",
+        "Edm.DateTime", "Edm.DateTimeOffset",     "Edm.Double", "Edm.Duration",
+        "Edm.Guid",   "Edm.Int16",   "Edm.Int32", "Edm.Int64",  "Edm.Single",
+        "Edm.Stream", "Edm.String",  "Edm.Time",  "Edm.TimeOfDay",
+        "Edm.SomethingNobodyHasHeardOf"};
+
+    for (const auto &edm_type : edm_types) {
+        const auto logical_type = DuckTypeConverter::ConvertEdmPrimitiveStringToLogicalType(edm_type);
+        const auto type_name = DuckTypeConverter::ConvertEdmTypeStringToDuckDbTypeString(edm_type);
+        INFO("EDM type: " << edm_type);
+        REQUIRE(logical_type.ToString() == type_name);
+    }
+
+    // The PrimitiveType-keyed visitor reads the same table.
+    erpl_web::Edmx empty_edmx;
+    DuckTypeConverter converter(empty_edmx);
+    auto byte_type = erpl_web::PrimitiveType("Edm.Byte");
+    REQUIRE(converter(byte_type).id() == duckdb::LogicalTypeId::UTINYINT);
+    auto sbyte_type = erpl_web::PrimitiveType("Edm.SByte");
+    REQUIRE(converter(sbyte_type).id() == duckdb::LogicalTypeId::TINYINT);
+
+    // ... apart from Edm.GeographyPoint, which this path models structurally. The
+    // divergence predates the collapse; it is asserted so that it stays deliberate.
+    auto geography_point = erpl_web::PrimitiveType("Edm.GeographyPoint");
+    REQUIRE(converter(geography_point).id() == duckdb::LogicalTypeId::LIST);
+    REQUIRE(DuckTypeConverter::ConvertEdmPrimitiveStringToLogicalType("Edm.GeographyPoint").id() ==
+            duckdb::LogicalTypeId::VARCHAR);
+}


### PR DESCRIPTION
## #104 — the `EdmCache` race (the one that mattered)

`Get` returned an `optional_ptr<Edmx>` aimed at a map slot and **released the lock before the caller dereferenced it**; `Set` on the same URL then assigned over that slot in place. Two connections reading the same service is the ordinary case, so a scan could silently start reading a different document mid-flight, or a destroyed one.

`Get` now returns `shared_ptr<const Edmx>`. Overwrite replaces the *slot*, never the object, so any holder keeps its snapshot alive and immutable for as long as it holds it.

**The change turned out to be source-compatible at every existing call site** — all of them use `if (ptr)`, `ptr->GetVersion()`, `return *ptr;`, which work unchanged on a `shared_ptr`. So the fix landed without touching files owned by concurrent work.

## #106 — verified the prior reasoning, then fixed what was actually wrong

Per-table lazy loading buys nothing: the cost is the single all-or-nothing `$metadata` GET, and lookups over in-memory EDMX are trivial. That thread should be closed rather than re-litigated. What *was* wrong:

- `ODataCatalog` held `std::optional<Edmx>` — a **second full EDMX copy per attached service** on top of the cache's. Now a `shared_ptr<const Edmx>` taken from the cache: N catalogs on one service cost one document, not N+1.
- `EdmCache` was a process-global map that was never evicted and never noticed a redeployed service. It now has an entry lifetime with a sweep on lookup, plus `Invalidate`/`Clear`/`Size`, and `ODataCatalog::InvalidateCachedMetadata()` as an explicit escape hatch.

## #102 items 2–3 — and a behavioural bug hiding in the duplication

Three copies of `CreateODataHttpClient` collapsed to one. **The Datasphere `direct_http_client` was not merely a duplicate** — it was `make_shared<HttpClient>()` with default params, i.e. it forgot `url_encode = false`, so that path **double-encoded the metadata URL**. That belongs on the fix list, not the tidiness list.

## #104 — `addParams` quote escaping

Values were wrapped in `'…'` with no escaping, so an embedded quote closed the literal early and let a parameter value inject further OData syntax into the URL: `(Customer='O'Brien')`, and `(Customer='x')/Other('y')` for a crafted value. Also fixed the classifier — `""` and `"-"` both passed the old numeric test and were emitted bare.

## #104 — type maps

Three hand-written ladders over the same EDM names collapsed onto one table — that triplication is how #68's `Edm.Byte` bug lived in all of them simultaneously. One divergence survives **deliberately and is now asserted** rather than implied: the `PrimitiveType` visitor maps `Edm.GeographyPoint` to `LIST(DOUBLE)` while the string path reports `VARCHAR`; unifying those would change catalog column types.

## #102 item 1 — parser landed, wiring still needed

The delta-link bug is real and its exact mechanism is now recorded: SAP ODP's terminal page returns the token as `d.__next = …?$format=json&!deltatoken=D2024…`. `NextUrl()` follows it, the following page has no `__delta`, extraction returns `""`, and the subscription stays in initial-load mode — so the next read re-extracts everything.

`ODataDeltaLink` handles `@odata.deltaLink`, `d.__delta`, root `__delta` and **`__next` carrying `!deltatoken`/`$deltatoken`**, while correctly *rejecting* a plain `__next` (a `$skiptoken` page must not look like the end of a change-tracked extraction). It also strips the quotes SAP Gateway sometimes adds and terminates at `&` or `#`.

**It is not yet wired in**, because both existing parsers and all their consumers live in `odp_*` files that were owned by concurrent work. Two steps remain, and the second is behavioural rather than a delegation: point `OdpRequestOrchestrator::ExtractDeltaToken`/`ExtractDeltaUrl` at it (removing ~110 lines and two per-call `std::regex` constructions), **and make `FetchAndLoadNextPage` check every page for a delta link, not only the terminal one** — on this form the token arrives on the page *before* the last. Tracked on #102; the parser is unit-tested, the ODP transition is not.

## Test honesty

One test — `EdmCache tolerates concurrent readers and writers` — is a bounded ASAN stress and **cannot be made deterministic** without a hook inside the cache. The deterministic overwrite test beside it already pins the contract, so this one can be dropped if you would rather not carry a probabilistic test.

## Verification

Full C++ suite **395 cases / 2049 assertions**. Live E2E: `odata_conformance_e2e` (22), `odata_v2`, `odata_v4`, `odata_expand` (46), both storage suites, `odata_describe` (32), `odata_scan_reexecution` (24), `web_core`, and `graph_excel` (21) against the real Graph tenant — all green.

Closes #104, closes #106. Advances #102.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791631629&installation_model_id=425457&pr_number=140&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F140&signature=02b5d8a86d93d21d9e82c7e32261a68971e4dfff00341f538d460e3c1672f8d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->