### PR TITLE
fix: recognise an ODP delta token delivered on __next (#102)

### DIFF
--- a/src/odp_odata_read_bind_data.cpp
+++ b/src/odp_odata_read_bind_data.cpp
@@ -1,4 +1,5 @@
 #include "odp_odata_read_bind_data.hpp"
+#include "odata_url_helpers.hpp"
 #include "secret_functions.hpp"
 #include "tracing.hpp"
 #include <algorithm>
@@ -6,6 +7,21 @@
 #include <regex>
 
 namespace erpl_web {
+
+namespace {
+
+// SAP ODP marks the END of a change-tracked extraction by returning the delta token on
+// "__next", not on "__delta". Following such a link as though it were another page walks
+// past the end of the extraction and loses the token, leaving the subscription in
+// initial-load mode so the next read re-extracts everything. A "__next" carrying a delta
+// sigil is therefore terminal, not a page. See GitHub #102.
+bool IsDeltaLink(const std::string &url)
+{
+    return !ODataDeltaLink::ExtractToken(url).empty();
+}
+
+} // namespace
+
 
 OdpODataReadBindData::OdpODataReadBindData(duckdb::ClientContext& context,
                                          const std::string& entity_set_url,
@@ -298,7 +314,7 @@ bool OdpODataReadBindData::HandleInitialLoad() {
         initial_load_preference_applied_ = result.preference_applied;
 
         auto first_next = result.response->NextUrl();
-        pending_next_url_ = (first_next.has_value() && !first_next->empty())
+        pending_next_url_ = (first_next.has_value() && !first_next->empty() && !IsDeltaLink(*first_next))
             ? first_next.value() : "";
 
         if (pending_next_url_.empty()) {
@@ -342,7 +358,7 @@ bool OdpODataReadBindData::HandleDeltaFetch() {
         }
 
         auto first_next = result.response->NextUrl();
-        pending_next_url_ = (first_next.has_value() && !first_next->empty())
+        pending_next_url_ = (first_next.has_value() && !first_next->empty() && !IsDeltaLink(*first_next))
             ? first_next.value() : "";
 
         if (pending_next_url_.empty()) {
@@ -633,7 +649,7 @@ void OdpODataReadBindData::FetchAndLoadNextPage() {
 
     // Determine whether there is yet another page after this one.
     auto further_next = next_result.response->NextUrl();
-    pending_next_url_ = (further_next.has_value() && !further_next->empty())
+    pending_next_url_ = (further_next.has_value() && !further_next->empty() && !IsDeltaLink(*further_next))
         ? further_next.value() : "";
 
     // When this is the last page, perform the state transition that was deferred

--- a/src/odp_request_orchestrator.cpp
+++ b/src/odp_request_orchestrator.cpp
@@ -1,4 +1,5 @@
 #include "odp_request_orchestrator.hpp"
+#include "odata_url_helpers.hpp"
 #include "odp_trace_redaction.hpp"
 #include "tracing.hpp"
 #include <iomanip>
@@ -192,23 +193,20 @@ bool OdpRequestOrchestrator::ValidatePreferenceApplied(const HttpResponse& respo
 
 std::string OdpRequestOrchestrator::ExtractDeltaToken(const ODataEntitySetResponse& response) {
     ERPL_TRACE_DEBUG("ODP_ORCHESTRATOR", "Extracting delta token from response");
-    
-    std::string response_content = response.RawContent();
-    ODataVersion version = response.GetODataVersion();
-    
-    std::string delta_token;
-    if (version == ODataVersion::V2) {
-        delta_token = ExtractDeltaTokenFromV2Response(response_content);
-    } else {
-        delta_token = ExtractDeltaTokenFromV4Response(response_content);
-    }
-    
+
+    // One implementation for every spelling, including the one this code used to miss:
+    // SAP ODP hands the token back on "__next" as "...&!deltatoken=...", not on "__delta".
+    // Reading only "__delta" left the subscription in initial-load mode, so the next read
+    // re-extracted the entire dataset. See GitHub #102.
+    const auto delta_link = ODataDeltaLink::ExtractDeltaLink(response.RawContent());
+    const auto delta_token = ODataDeltaLink::ExtractToken(delta_link);
+
     if (!delta_token.empty()) {
         ERPL_TRACE_INFO("ODP_ORCHESTRATOR", "Extracted delta token: " + delta_token.substr(0, 20) + "...");
     } else {
         ERPL_TRACE_WARN("ODP_ORCHESTRATOR", "No delta token found in response");
     }
-    
+
     return delta_token;
 }
 
@@ -614,30 +612,9 @@ std::string OdpRequestOrchestrator::ExtractTokenFromDeltaUrl(const std::string& 
 }
 
 std::string OdpRequestOrchestrator::ExtractDeltaUrl(const ODataEntitySetResponse& response) {
-    try {
-        auto content = response.RawContent();
-        auto doc = duckdb_yyjson::yyjson_read(content.c_str(), content.length(), 0);
-        if (!doc) {
-            return "";
-        }
-        auto root = duckdb_yyjson::yyjson_doc_get_root(doc);
-        if (!root) {
-            duckdb_yyjson::yyjson_doc_free(doc);
-            return "";
-        }
-        auto d_obj = duckdb_yyjson::yyjson_obj_get(root, "d");
-        if (d_obj) {
-            auto delta_val = duckdb_yyjson::yyjson_obj_get(d_obj, "__delta");
-            if (delta_val && duckdb_yyjson::yyjson_is_str(delta_val)) {
-                std::string delta_url = duckdb_yyjson::yyjson_get_str(delta_val);
-                duckdb_yyjson::yyjson_doc_free(doc);
-                return delta_url;
-            }
-        }
-        duckdb_yyjson::yyjson_doc_free(doc);
-    } catch (...) {
-    }
-    return "";
+    // Same single implementation, so the URL and the token can never disagree about
+    // which spellings count as a delta link. See GitHub #102.
+    return ODataDeltaLink::ExtractDeltaLink(response.RawContent());
 }
 
 std::string OdpRequestOrchestrator::NormalizeDeltaUrl(const std::string& delta_url) {

--- a/test/cpp/test_odp_parsing.cpp
+++ b/test/cpp/test_odp_parsing.cpp
@@ -1,4 +1,5 @@
 #include "catch.hpp"
+#include "odata_url_helpers.hpp"
 #include "odata_odp_functions.hpp"
 #include "datazoo/oauth2/http_client.hpp"
 #include "tracing.hpp"
@@ -130,4 +131,37 @@ TEST_CASE("ODP Entity Set Pattern Matching", "[odp]") {
         
         duckdb_yyjson::yyjson_doc_free(doc);
     }
+}
+
+// ---------------------------------------------------------------------------
+// GitHub #102 - the delta token arrives on __next, not on __delta
+// ---------------------------------------------------------------------------
+
+TEST_CASE("ODP recognises a delta token delivered on __next", "[odp_parsing]") {
+    // This is the shape SAP ODP actually returns to end a change-tracked extraction:
+    // the token rides on "__next" with a "!deltatoken=" sigil. The orchestrator used to
+    // read only "__delta", so extraction returned "", preference_applied went false, the
+    // subscription stayed in initial-load mode, and the NEXT read re-extracted the whole
+    // dataset instead of fetching deltas.
+    const std::string terminal_page = R"({"d":{"results":[],)"
+        R"("__next":"https://sap.example.com/sap/opu/odata/sap/X_SRV/EntityOfX?$format=json&!deltatoken=D20260910"}})";
+
+    const auto link = ODataDeltaLink::ExtractDeltaLink(terminal_page);
+    REQUIRE_FALSE(link.empty());
+    REQUIRE(ODataDeltaLink::ExtractToken(link) == "D20260910");
+}
+
+TEST_CASE("ODP does not mistake ordinary server-driven paging for a delta link", "[odp_parsing]") {
+    // The counterpart guard: a plain "__next" is a $skiptoken page and must keep paging.
+    // Treating it as terminal would truncate the extraction.
+    const std::string paging_page = R"({"d":{"results":[{"a":1}],)"
+        R"("__next":"https://sap.example.com/sap/opu/odata/sap/X_SRV/EntityOfX?$skiptoken=100"}})";
+
+    REQUIRE(ODataDeltaLink::ExtractDeltaLink(paging_page).empty());
+}
+
+TEST_CASE("A v2 __delta link still works", "[odp_parsing]") {
+    const std::string delta_page = R"({"d":{"results":[],)"
+        R"("__delta":"https://sap.example.com/sap/opu/odata/sap/X_SRV/EntityOfX?!deltatoken=D1"}})";
+    REQUIRE(ODataDeltaLink::ExtractToken(ODataDeltaLink::ExtractDeltaLink(delta_page)) == "D1");
 }


### PR DESCRIPTION
Completes #102. The parser landed in #140 but nothing called it, because both existing implementations and all their consumers were in files owned by concurrent work.

## The defect, precisely

SAP ODP ends a change-tracked extraction by returning the token on **`__next`**, not on `__delta`:

```json
{"d":{"results":[],"__next":"…/EntityOfX?$format=json&!deltatoken=D20260910"}}
```

Both extraction paths read only `__delta`. So:

1. `ExtractDeltaToken` returned `""`;
2. `preference_applied` went false;
3. `ProcessRequestResult` logged *"Initial load completed but change tracking not established"*;
4. the subscription stayed in **initial-load mode**;
5. the next read **re-extracted the entire dataset** instead of fetching deltas.

Silent, and expensive — repeatedly, on every subsequent read.

## Two halves, both needed

**Extraction** now goes through the single `ODataDeltaLink` implementation, which recognises `@odata.deltaLink`, `__delta` at either level, and `__next` carrying `!deltatoken`/`$deltatoken` — while still rejecting a plain `__next`, so ordinary `$skiptoken` paging keeps paging.

**Paging** needed the same knowledge, and this is the half that is easy to miss: `NextUrl()` returns that terminal `__next`, so the scan **followed it as though it were another page** — walking past the end of the extraction and losing the token even after extraction was fixed. A `__next` carrying a delta sigil is now treated as terminal at every site that asks whether another page exists (there were three).

Fixing only the extraction would have left the bug in place.

## Also removed

The second copy of the extraction logic, including **two `std::regex` objects constructed on every call**.

## Test honesty

Three unit tests cover the three shapes: the `__next`-borne token, the plain `__next` that must keep paging, and the classic `__delta`. They prove the parser and the paging predicate.

They do **not** prove the full ODP scan now transitions to delta mode end to end — that needs a live SAP ODP system, which is not available here. The state-transition half is verified by reading and by the surrounding unit tests. This is the same gap recorded on #62 and #121, and it is the single most valuable thing an SAP system would let me close.

## Verification

Full C++ suite **398 cases / 2053 assertions**. Live E2E: `odata_conformance_e2e` (22), `odata_v2`, `odata_v4`, `odata_expand` (46), `web_core` — all green.

Closes #102.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791632523&installation_model_id=425457&pr_number=141&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F141&signature=642b1e826ede305284aa6fc131c572de90249a15bf906fe49eacbc2a65445e66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->