### PR TITLE
fix: make TLS settings reach clients that already exist (#138)

### DIFF
--- a/test/sql/tls_enforcement.test
+++ b/test/sql/tls_enforcement.test
@@ -1,0 +1,73 @@
+# name: test/sql/tls_enforcement.test
+# description: Proves TLS certificate verification is actually enforced, not merely configured
+# group: [erpl_web]
+#
+# tls_settings.test asserts the settings EXIST and validate their input. That is not the
+# same as proving a handshake is refused, and the difference matters: when TLS verification
+# was first enabled, the settings were registered and every unit test passed while the
+# escape hatch did not work at all. Only exercising a real handshake caught it.
+#
+# These cases need outbound network access to badssl.com, so they are opt-in rather than
+# part of the default run.
+
+require erpl_web
+
+require-env ERPL_TEST_TLS_ENFORCEMENT
+
+statement ok
+SET erpl_trace_enabled=false;
+
+# ============================================================================
+# Verification is on by default and actually refuses bad certificates
+# ============================================================================
+
+statement error
+SELECT status FROM http_get('https://expired.badssl.com/');
+----
+SSL server verification failed
+
+statement error
+SELECT status FROM http_get('https://self-signed.badssl.com/');
+----
+SSL server verification failed
+
+statement error
+SELECT status FROM http_get('https://wrong.host.badssl.com/');
+----
+SSL server hostname verification failed
+
+# A publicly trusted certificate must still work - the point is to reject the bad ones,
+# not to reject everything.
+query I
+SELECT status FROM http_get('https://httpbin.org/ip');
+----
+200
+
+# ============================================================================
+# GitHub #138 - a policy change takes effect on clients that already exist
+# ============================================================================
+
+# The opt-out is engaged AFTER a request has already been made, which is the ordering
+# docs/TLS.md tells users to follow (ATTACH, then SET, then query). The policy used to be
+# snapshotted when HttpParams was constructed, so a client built beforehand kept the old
+# policy forever and this silently did nothing.
+statement ok
+SELECT status FROM http_get('https://httpbin.org/ip');
+
+statement ok
+SET erpl_unsafe_disable_server_cert_verification = 'I_UNDERSTAND_THIS_IS_INSECURE';
+
+query I
+SELECT status FROM http_get('https://expired.badssl.com/');
+----
+200
+
+# ...and re-enabling mid-session must start refusing again, or the opt-out would be a
+# one-way door for the rest of the session.
+statement ok
+SET erpl_unsafe_disable_server_cert_verification = '';
+
+statement error
+SELECT status FROM http_get('https://expired.badssl.com/');
+----
+SSL server verification failed


### PR DESCRIPTION
> Depends on DataZooDE/datazoo-oauth2#3 (merged); the pin is bumped here.

`HttpParams` captured the TLS policy in its **constructor**, so a client built before a setting changed kept the old policy for its whole life. That breaks precisely the order `docs/TLS.md` tells users to follow:

```sql
ATTACH 'https://on-prem/odata/' AS s (TYPE odata);   -- catalog client built HERE
SET erpl_ca_cert_file = '/path/to/corporate-ca.pem'; -- never reaches it
SELECT * FROM s.Orders;                              -- still fails the handshake
```

The policy is now read when each request's client is created, and the two snapshot fields are removed rather than left as a trap — nothing ever set them explicitly.

## The test that should have existed from the start

`tls_settings.test` asserts the settings exist and validate their input. That is **not** the same as proving a handshake is refused — and the difference already bit once: when verification was first enabled, the settings were registered, every unit test passed, and the escape hatch did not work at all. Only exercising a real handshake caught it.

`test/sql/tls_enforcement.test` closes that gap:

| case | expected |
|---|---|
| expired certificate | refused |
| self-signed certificate | refused |
| wrong-host certificate | refused (hostname verification) |
| publicly trusted certificate | 200 |
| opt-out engaged **after** a request already ran | 200 — the change takes effect |
| verification re-enabled mid-session | refused again |

The last two are #138's regression; the middle ones guard against over-correcting into refusing everything.

Opt-in via `ERPL_TEST_TLS_ENFORCEMENT`, so the default run does not depend on badssl.com being reachable — the review flagged unconditional public-internet dependencies as a separate problem, and this does not add another.

## Verification

Suite skipped without the variable, **10 assertions passing** with it. Full C++ suite **398 cases / 2053 assertions**; `tls_settings`, `web_core`, `web_http`, `odata_conformance_e2e` all green.

Closes #138.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791633190&installation_model_id=425457&pr_number=142&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F142&signature=c3d80a91050abdbade0b7f34df511a6318340cbba6325408a833092bc7429f1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->