### PR TITLE
perf: measure the page-memory question, and act only where the data points (#89)

### DIFF
--- a/test/perf/odata_page_memory.py
+++ b/test/perf/odata_page_memory.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Peak-RSS of an OData scan as a function of server page size (GitHub #89).
+
+WHY THIS EXISTS
+---------------
+Issue #89 proposed streaming rows out of `ODataEntitySetJsonContent::ToRows` and
+sending `Prefer: odata.maxpagesize`, on the theory that peak memory is dictated by
+the server's page size. The review asked for a page-size histogram before any
+optimisation. This is the instrument that produced it; re-run it before revisiting
+the issue rather than re-arguing from first principles.
+
+WHAT IT MEASURES
+----------------
+`total_rows` is held constant and only `rows_per_page` varies, so any difference in
+peak RSS is attributable to how much of a single page is live at once. Peak RSS is
+the kernel's own high-water mark (`/proc/<pid>/status` VmHWM), sampled by a poller.
+
+Pass `--query http_get` to measure the same body through `http_get()` instead. That
+is the control that separates what the HTTP layer costs from what OData parsing and
+`Value` boxing add on top.
+
+MEASURED 2026-09-10, release build, 500_000 rows total, ~271 wire bytes/row
+---------------------------------------------------------------------------
+    rows/page   page bytes   peak RSS   delta over the 200-row page
+          200       54_246     258 MB   -
+        2_000      547_180     279 MB   +21 MB
+       20_000    5_530_514     456 MB   +198 MB
+      100_000   27_803_848    1074 MB   +816 MB
+      500_000  140_203_780    3858 MB   +3600 MB
+
+Peak RSS is linear in the bytes of ONE page, at roughly 26x the page's wire size.
+The largest page any reachable real service returns is 308 KB (see
+odata_page_sizes.py), which buys about 8 MB - i.e. the effect is real but only
+above page sizes no measured service produces.
+
+The `--query http_get` control shows where that 26x is spent. On the same 208 MB
+body, debug build: baseline 1895 MB, `http_get` 7346 MB, `odata_read` 8298 MB. So
+~85% of peak on a large page is already committed by the HTTP layer before
+`ToRows` is ever called; OData parsing plus full-page `Value` boxing is the
+remaining ~15%. Streaming `ToRows` cannot change the order of magnitude.
+Projection makes no difference (`max(Id)` costs the same as `count(*)`), because
+`ToRows` always boxes the full schema.
+
+USAGE
+-----
+    # A debug binary has the extension linked in; a release binary needs LOAD.
+    test/perf/odata_page_memory.py ./build/debug/duckdb \\
+        --total-rows 500000 --payload 200 --pages 200 2000 20000 100000 500000
+
+    ERPL_LOAD=build/release/extension/erpl_web/erpl_web.duckdb_extension \\
+    test/perf/odata_page_memory.py ./build/release/duckdb --pages 200 20000
+
+NOTE ON THE DEBUG BINARY
+------------------------
+The debug build is AddressSanitizer-instrumented, so its absolute numbers carry a
+~1.9 GB fixed baseline and an inflated per-allocation cost. Compare deltas, or use a
+release build for absolute figures.
+"""
+import argparse
+import os
+import re
+import signal
+import subprocess
+import sys
+import threading
+import time
+import urllib.request
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SERVER = os.path.join(HERE, "odata_page_server.py")
+
+QUERIES = {
+    "odata_read": ("SELECT count(*) AS n, sum(Amount) AS s "
+                   "FROM odata_read('http://127.0.0.1:{port}/svc/Items')"),
+    # Control: same body over the wire, none of the OData parsing or Value boxing.
+    "http_get": "SELECT status FROM http_get('http://127.0.0.1:{port}/svc/Items')",
+    "noop": "SELECT 1",
+}
+
+
+def wait_ready(port, timeout=20.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/svc/", timeout=1).read()
+            return True
+        except Exception:  # noqa: BLE001
+            time.sleep(0.2)
+    return False
+
+
+def poll_peak(pid, stop, out):
+    """Track VmHWM, the kernel's peak-RSS counter, until the process exits."""
+    while not stop.is_set():
+        try:
+            with open(f"/proc/{pid}/status") as status:
+                for line in status:
+                    if line.startswith("VmHWM:"):
+                        out[0] = max(out[0], int(line.split()[1]))
+                        break
+        except OSError:
+            return
+        time.sleep(0.05)
+
+
+def run_one(binary, port, rows_per_page, total_rows, payload, query):
+    server = subprocess.Popen(
+        [sys.executable, SERVER, str(port), str(rows_per_page), str(total_rows), str(payload)],
+        stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True)
+    try:
+        if not wait_ready(port):
+            raise RuntimeError(f"synthetic OData server did not come up on port {port}")
+
+        argv = [binary]
+        load = os.environ.get("ERPL_LOAD")
+        if load:
+            argv += ["-unsigned", "-s", f"LOAD '{load}'"]
+        argv += ["-s", query.format(port=port)]
+
+        env = dict(os.environ, ASAN_OPTIONS="detect_odr_violation=0")
+        started = time.time()
+        proc = subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                text=True, env=env)
+        peak = [0]
+        stop = threading.Event()
+        poller = threading.Thread(target=poll_peak, args=(proc.pid, stop, peak), daemon=True)
+        poller.start()
+        output, _ = proc.communicate(timeout=3600)
+        stop.set()
+        poller.join(timeout=1)
+        wall = time.time() - started
+    finally:
+        server.send_signal(signal.SIGTERM)
+        try:
+            _, server_log = server.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            server.kill()
+            server_log = ""
+
+    served = re.findall(r"^PAGE .*bytes=(\d+)", server_log or "", re.M)
+    return {
+        "rows_per_page": rows_per_page,
+        "page_bytes": int(served[0]) if served else 0,
+        "pages_served": len(served),
+        "peak_rss_kb": peak[0],
+        "wall_s": round(wall, 1),
+        "output": " ".join(line.strip() for line in output.splitlines() if "│" in line),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("binary", help="path to a duckdb binary carrying erpl_web")
+    parser.add_argument("--total-rows", type=int, default=500000)
+    parser.add_argument("--payload", type=int, default=200,
+                        help="filler characters per row; 200 gives ~270 wire bytes/row, "
+                             "close to Northwind v4 Orders")
+    parser.add_argument("--pages", type=int, nargs="+",
+                        default=[200, 2000, 20000, 100000, 500000],
+                        help="rows per page to sweep")
+    parser.add_argument("--query", choices=sorted(QUERIES), default="odata_read")
+    parser.add_argument("--port-base", type=int, default=19300)
+    args = parser.parse_args()
+
+    query = QUERIES[args.query]
+    print(f"# query={args.query} total_rows={args.total_rows} payload={args.payload}")
+    print("rows_per_page\tpage_bytes\tpages\tpeak_rss_mb\twall_s")
+    for index, rows_per_page in enumerate(args.pages):
+        result = run_one(args.binary, args.port_base + index, rows_per_page,
+                         args.total_rows, args.payload, query)
+        print(f"{result['rows_per_page']}\t{result['page_bytes']}\t{result['pages_served']}\t"
+              f"{result['peak_rss_kb'] / 1024:.0f}\t{result['wall_s']}")
+        sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/perf/odata_page_server.py
+++ b/test/perf/odata_page_server.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Minimal OData v4 service serving synthetic pages of a configurable size.
+
+Usage: odata_server.py <port> <rows_per_page> <total_rows> [payload_chars]
+
+Isolates the memory relationship from network variance: the page size is
+whatever we say it is, and the row shape is fixed.
+Also records whether the client sent `Prefer: odata.maxpagesize` and honours it.
+"""
+import json
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+PORT = int(sys.argv[1])
+ROWS_PER_PAGE = int(sys.argv[2])
+TOTAL_ROWS = int(sys.argv[3])
+PAYLOAD = int(sys.argv[4]) if len(sys.argv) > 4 else 200
+
+BASE = f"http://127.0.0.1:{PORT}/svc/"
+
+METADATA = """<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+ <edmx:DataServices>
+  <Schema Namespace="Demo" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+   <EntityType Name="Item">
+    <Key><PropertyRef Name="Id"/></Key>
+    <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+    <Property Name="Name" Type="Edm.String"/>
+    <Property Name="Amount" Type="Edm.Double"/>
+    <Property Name="Payload" Type="Edm.String"/>
+   </EntityType>
+   <EntityContainer Name="Container">
+    <EntitySet Name="Items" EntityType="Demo.Item"/>
+   </EntityContainer>
+  </Schema>
+ </edmx:DataServices>
+</edmx:Edmx>"""
+
+FILLER = "x" * PAYLOAD
+
+PREFER_SEEN = []
+
+
+def make_row(i):
+    return {
+        "Id": i,
+        "Name": f"Item number {i}",
+        "Amount": i * 1.5,
+        "Payload": FILLER,
+    }
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *a):  # silence
+        pass
+
+    def _send(self, body, ctype):
+        data = body.encode() if isinstance(body, str) else body
+        self.send_response(200)
+        self.send_header("Content-Type", ctype)
+        self.send_header("OData-Version", "4.0")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_GET(self):
+        u = urlparse(self.path)
+        q = parse_qs(u.query)
+        prefer = self.headers.get("Prefer")
+        if prefer:
+            PREFER_SEEN.append(prefer)
+
+        if u.path.rstrip("/") == "/svc":
+            self._send(json.dumps({
+                "@odata.context": BASE + "$metadata",
+                "value": [{"name": "Items", "kind": "EntitySet", "url": "Items"}],
+            }), "application/json;odata.metadata=minimal")
+            return
+        if u.path == "/svc/$metadata":
+            self._send(METADATA, "application/xml")
+            return
+        if u.path == "/svc/Items":
+            skip = int(q.get("$skip", ["0"])[0])
+            page = ROWS_PER_PAGE
+            # Honour a client-sent maxpagesize, the behaviour a compliant service has.
+            if prefer and "odata.maxpagesize=" in prefer:
+                try:
+                    page = min(page, int(prefer.split("odata.maxpagesize=")[1].split(",")[0]))
+                except ValueError:
+                    pass
+            end = min(skip + page, TOTAL_ROWS)
+            doc = {
+                "@odata.context": BASE + "$metadata#Items",
+                "value": [make_row(i) for i in range(skip, end)],
+            }
+            if end < TOTAL_ROWS:
+                doc["@odata.nextLink"] = f"{BASE}Items?$skip={end}"
+            body = json.dumps(doc)
+            data = body.encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json;odata.metadata=minimal")
+            self.send_header("OData-Version", "4.0")
+            if prefer and "odata.maxpagesize=" in prefer:
+                self.send_header("Preference-Applied", f"odata.maxpagesize={page}")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+            sys.stderr.write(f"PAGE skip={skip} rows={end - skip} bytes={len(data)} prefer={prefer}\n")
+            sys.stderr.flush()
+            return
+        self.send_response(404)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+
+if __name__ == "__main__":
+    srv = ThreadingHTTPServer(("127.0.0.1", PORT), Handler)
+    sys.stderr.write(f"READY port={PORT} rows_per_page={ROWS_PER_PAGE} total={TOTAL_ROWS} payload={PAYLOAD}\n")
+    sys.stderr.flush()
+    srv.serve_forever()

--- a/test/perf/odata_page_sizes.py
+++ b/test/perf/odata_page_sizes.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Page-size histogram for the OData services we can actually reach (GitHub #89).
+
+Reports bytes per page, rows per page, whether a next link follows, and whether the
+service echoed `Preference-Applied` for a `Prefer: odata.maxpagesize` we sent.
+
+MEASURED 2026-09-10 - the histogram issue #89 asked for before optimising
+---------------------------------------------------------------------------
+    service / entity set              bytes/page   rows/page   bytes/row
+    services.odata.org V2 Orders         203_569         200        1018
+    services.odata.org V2 Customers       14_825          20         741
+    services.odata.org V2 Order_Details  307_745         500         615
+    services.odata.org V4 Orders          77_606         200         388
+    services.odata.org V4 Customers        5_565          20         278
+    services.odata.org V4 Order_Details   40_433         500          81
+    TripPin People                         7_101          20         355
+    TripPin Airports                       1_889           5         378
+    V2 Customers?$expand=Orders          196_465          20        9823
+    V4 Customers?$expand=Orders           75_227          20        3761
+
+Every one of those services caps the page itself and keeps capping it under
+`$top=800` / `$top=3000`. The largest page any reachable service produced is
+308 KB. `$expand` widens rows but the row cap still bounds the page.
+
+`Prefer: odata.maxpagesize` was sent to all of them and NONE honoured it: no
+`Preference-Applied` header came back and the page sizes were byte-identical to the
+unhinted requests. It is a hint, and the reference implementations ignore it.
+
+The Microsoft Graph tenant available to the tests is too small to exercise Graph's
+own caps (3 users, 7 groups, 2 messages, 2 list items - pages of 1-10 KB), so Graph
+contributes a lower bound here, not a cap measurement.
+
+USAGE
+-----
+    test/perf/odata_page_sizes.py                 # the public services above
+    test/perf/odata_page_sizes.py --prefer 50     # re-check maxpagesize honouring
+"""
+import argparse
+import json
+import sys
+import urllib.request
+
+PUBLIC_ENDPOINTS = [
+    ("nw-v2 Orders", "https://services.odata.org/V2/Northwind/Northwind.svc/Orders?$format=json"),
+    ("nw-v2 Customers", "https://services.odata.org/V2/Northwind/Northwind.svc/Customers?$format=json"),
+    ("nw-v2 Order_Details", "https://services.odata.org/V2/Northwind/Northwind.svc/Order_Details?$format=json"),
+    ("nw-v2 Customers+expand", "https://services.odata.org/V2/Northwind/Northwind.svc/Customers?$format=json&$expand=Orders"),
+    ("nw-v4 Orders", "https://services.odata.org/V4/Northwind/Northwind.svc/Orders"),
+    ("nw-v4 Customers", "https://services.odata.org/V4/Northwind/Northwind.svc/Customers"),
+    ("nw-v4 Order_Details", "https://services.odata.org/V4/Northwind/Northwind.svc/Order_Details"),
+    ("nw-v4 Customers+expand", "https://services.odata.org/V4/Northwind/Northwind.svc/Customers?$expand=Orders"),
+    ("nw-v4 Orders top=800", "https://services.odata.org/V4/Northwind/Northwind.svc/Orders?$top=800"),
+    ("trippin People", "https://services.odata.org/TripPinRESTierService/People"),
+    ("trippin Airports", "https://services.odata.org/TripPinRESTierService/Airports"),
+]
+
+
+def row_count(document):
+    """Row count for either shape: v4 `value`, v2 `d.results`, or a bare `d` array."""
+    if isinstance(document.get("value"), list):
+        return len(document["value"])
+    wrapper = document.get("d")
+    if isinstance(wrapper, dict) and isinstance(wrapper.get("results"), list):
+        return len(wrapper["results"])
+    if isinstance(wrapper, list):
+        return len(wrapper)
+    return None
+
+
+def next_link(document):
+    if "@odata.nextLink" in document:
+        return document["@odata.nextLink"]
+    wrapper = document.get("d")
+    if isinstance(wrapper, dict):
+        return wrapper.get("__next")
+    return None
+
+
+def probe(label, url, prefer=None, bearer=None):
+    request = urllib.request.Request(url)
+    request.add_header("Accept", "application/json")
+    if prefer is not None:
+        request.add_header("Prefer", f"odata.maxpagesize={prefer}")
+    if bearer:
+        request.add_header("Authorization", f"Bearer {bearer}")
+    try:
+        with urllib.request.urlopen(request, timeout=90) as response:
+            body = response.read()
+            applied = dict(response.headers).get("Preference-Applied", "-")
+    except Exception as error:  # noqa: BLE001
+        print(f"{label}\tERROR {error}")
+        return
+
+    try:
+        document = json.loads(body)
+    except ValueError:
+        print(f"{label}\tbytes={len(body)}\tNON-JSON")
+        return
+
+    rows = row_count(document)
+    per_row = (len(body) / rows) if rows else 0
+    print(f"{label}\tbytes={len(body)}\trows={rows}\tbytes/row={per_row:.0f}\t"
+          f"next={'yes' if next_link(document) else 'no'}\tPreference-Applied={applied}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--prefer", type=int, default=None,
+                        help="send Prefer: odata.maxpagesize=N and report what came back")
+    parser.add_argument("--url", action="append", default=[],
+                        help="probe an extra URL instead of relying on the built-in list")
+    parser.add_argument("--bearer", default=None, help="bearer token for authenticated services")
+    args = parser.parse_args()
+
+    endpoints = [(url, url) for url in args.url] or PUBLIC_ENDPOINTS
+    for label, url in endpoints:
+        probe(label, url, args.prefer, args.bearer)
+        sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The review said **measure before optimising**, and explicitly not to micro-optimise `Value` boxing before a page-size histogram existed. So this is evidence first, and the evidence says leave the read path alone.

## Page sizes from real services

| service / entity set | bytes/page | rows/page | server caps? |
|---|---|---|---|
| Northwind V2 `Order_Details` | 307,745 | 500 | yes |
| Northwind V2 `Orders` | 203,569 | 200 | yes |
| Northwind V2 `Customers?$expand=Orders` | 196,465 | 20 | yes |
| Northwind V4 `Orders` | 77,606 | 200 | yes |
| Northwind V4 `Customers` | 5,565 | 20 | yes |
| MS Graph (real tenant) | 956 – 9,728 | 1–7 | tenant too small |

**Largest page any reachable service produced: 308 KB.** `$top=800` and `$top=3000` did not raise any of them — the server cap holds.

**Every service ignored `Prefer: odata.maxpagesize`** — no `Preference-Applied`, byte-identical responses.

## Peak RSS versus page size

| rows/page | page bytes | peak RSS | Δ / page bytes |
|---|---|---|---|
| 200 | 54 KB | 258 MB | — |
| 20,000 | 5.5 MB | 456 MB | 36x |
| 500,000 | 140 MB | 3,858 MB | 26x |

Linear at ~26x. At the 308 KB real-world maximum, that is ~8 MB.

And end to end on real services, a 7 KB-page scan costs the same as a 308 KB-page scan: the delta is TLS, metadata and DuckDB machinery, not page buffering.

## Where the memory actually goes

| query | peak RSS | Δ over baseline |
|---|---|---|
| `SELECT 1` | 1,895 MB | — |
| `http_get` → `SELECT status` | 7,346 MB | +5,451 MB |
| `http_get` → `SELECT length(content)` | 7,356 MB | +5,461 MB |
| `odata_read` → `count(*)` | 8,298 MB | +6,403 MB |

**~85% of peak on a large page is committed by the HTTP layer before `ToRows` is ever called.** `SELECT status` costs the same as `SELECT length(content)`, so it is transport buffering, not output materialisation.

## Recommendation: do nothing to the OData read path

1. **Streaming `ToRows` is not worth it.** It addresses ~15% of a cost that does not arise at real page sizes, and cannot change the order of magnitude because the body is already amplified ~26x upstream. Against code that has had several correctness fixes land this week, that trade fails the project's stated priority order.
2. **Do not send `Prefer: odata.maxpagesize`.** Measured: nothing honours it. It is right where it already is — on the ODP path, where the SAP gateway does honour it.
3. **Releasing the raw page string early** is ~1x of a 26x cost.

The issue's premise is directionally true, but the constant is set upstream of the code it pointed at, and no reachable service picks a page big enough to matter.

## The one thing worth fixing, found by the attribution

`RedactBody` ran on **every** response body — a full copy plus several linear scans — and the result was then cut to 1000 characters and, with tracing off, discarded. On a 208 MB page: a 208 MB copy and ~1.6 GB of scanning, thrown away on the default path. Now guarded on tracing being enabled and applied only to the prefix that can be logged (DataZooDE/datazoo-oauth2#4, merged; pin bumped here).

## What could not be measured

- **Graph's own page caps** — the tenant has 3 users and 7 groups, so it never reached one.
- **SAP Gateway / Datasphere**, for want of credentials. SAP is the plausible source of an uncapped page; the harness is committed and sweeps page size directly if one ever turns up.

`test/perf/` carries the probe, a synthetic server with configurable page size, and the RSS sweep, with the numbers in the docstrings so this gets **re-measured rather than re-argued**.

## Verification

Full C++ suite **398 cases / 2053 assertions**. Tracing still emits a redacted, truncated body; a live 830-row read still returns 830.

Closes #89.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791634745&installation_model_id=425457&pr_number=144&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F144&signature=abea927cafdef880f0454a12f4500f7a4eb791bd2943ad71cdbc777386d030ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->