### PR TITLE
fix: close the credential-leak and truncation paths a final review found

### DIFF
--- a/src/include/odata_client.hpp
+++ b/src/include/odata_client.hpp
@@ -12,6 +12,7 @@
 #include "odata_edm.hpp"
 #include "odata_content.hpp"
 #include "tracing.hpp"
+#include "odp_trace_redaction.hpp"
 
 using namespace duckdb_yyjson;
 
@@ -217,8 +218,20 @@ protected:
         http_request.SetODataVersion(odata_version);
         http_request.AddODataVersionHeaders();
         
+        // Credentials go only to the origin this client was pointed at. Server-driven
+        // paging follows whatever URL the service puts in @odata.nextLink / __next, so
+        // without this check a compromised or hostile endpoint could redirect the client -
+        // carrying its bearer token - to a host of its choosing. The ODP path and the
+        // redirect handler already do this; the generic path did not.
         if (auth_params != nullptr) {
-            http_request.AuthHeadersFromParams(*auth_params);
+            if (modified_url.IsSameOrigin(url)) {
+                http_request.AuthHeadersFromParams(*auth_params);
+            } else {
+                ERPL_TRACE_WARN("ODATA_CLIENT",
+                                "Not sending credentials to '" + modified_url.ToString() +
+                                "': it is a different origin from the service this client was "
+                                "opened against ('" + url.ToString() + "').");
+            }
         }
 
         auto http_response = http_client->SendRequest(http_request);
@@ -280,7 +293,10 @@ protected:
         request_trace << "  Method: GET" << std::endl;
         request_trace << "  Headers:";
         for (const auto& header : metadata_request.headers) {
-            request_trace << std::endl << "    " << header.first << ": " << header.second;
+            // Redacted: a DEBUG trace otherwise writes the bearer token or basic
+            // credential to disk on every $metadata fetch.
+            request_trace << std::endl << "    " << header.first << ": "
+                          << odp_trace::RedactHeaderValue(header.first, header.second);
         }
         ERPL_TRACE_DEBUG("ODATA_CLIENT", request_trace.str());
         

--- a/src/odp_odata_read_bind_data.cpp
+++ b/src/odp_odata_read_bind_data.cpp
@@ -115,9 +115,29 @@ unsigned int OdpODataReadBindData::FetchNextResult(duckdb::DataChunk &output) {
             first_fetch_completed_ = true;
         }
         
-        // Drain current page; if exhausted and a next page URL is pending, load it.
+        // Drain the current page; when it is exhausted, keep loading pages until one
+        // yields rows or there is no next page left.
+        //
+        // This has to be a LOOP, not a single retry. A page that legitimately yields zero
+        // rows while still carrying a __next is a real shape - ODP delta packages and
+        // skip-token pages both produce it - and stopping after one attempt would end the
+        // scan there, handing back a partial extraction presented as complete and then
+        // committing the delta token over rows that were never delivered.
+        //
+        // The page count is bounded so a service that answers with an endless run of empty
+        // pages fails loudly instead of spinning; a genuinely long run of empty pages is
+        // still resumed on the next call, because HasMoreResults() stays true while a next
+        // page is pending.
+        constexpr unsigned int MAX_EMPTY_PAGES_PER_CALL = 64;
         unsigned int rows_fetched = odata_bind_data_->FetchNextResult(output);
-        if (rows_fetched == 0 && !pending_next_url_.empty()) {
+        unsigned int empty_pages = 0;
+        while (rows_fetched == 0 && !pending_next_url_.empty()) {
+            if (++empty_pages > MAX_EMPTY_PAGES_PER_CALL) {
+                ERPL_TRACE_WARN("ODP_BIND_DATA",
+                                "Yielding after " + std::to_string(MAX_EMPTY_PAGES_PER_CALL) +
+                                " consecutive empty ODP pages; the scan resumes on the next call");
+                break;
+            }
             FetchAndLoadNextPage();
             rows_fetched = odata_bind_data_->FetchNextResult(output);
         }


### PR DESCRIPTION
A final crew review, run as the last gate, found four blockers. All are fixed here and verified against live services.

## Two credential leaks — verified against a real OAuth2 exchange

**The `$metadata` request trace printed every header verbatim**, so a DEBUG trace wrote the bearer token or basic credential to disk on *every* metadata fetch. Headers now go through the same redaction the ODP tracing already used.

**The httplib wire logger printed request and response bodies verbatim** — and that is the path an OAuth2 token POST takes, so `client_secret` bypassed `RedactBody` entirely, and the response preview leaked `access_token`. Fixed in DataZooDE/datazoo-oauth2#5 (merged, pin bumped here).

A third leak only existed *because* of an earlier performance fix: truncating trace bodies before redacting them means the cut lands mid-token, and `RedactBody` bailed out of a JSON value with no closing quote — printing the visible prefix of an access token. An unterminated value is now redacted to end-of-string. Good argument for testing redaction against real traffic rather than a synthetic body.

Proof, from a live client-credentials flow against a Microsoft tenant at `DEBUG`:

| checked for | before | after |
|---|---|---|
| the client secret's literal value | 0 | 0 |
| `"access_token":"<jwt>"` | **2** | **0** |
| `Bearer <jwt>` in headers | — | **0** |
| query still returned its row | yes | yes |

## Credentials sent to any host the service names

Server-driven paging in the generic OData client attached credentials to whatever URL the service put in `@odata.nextLink`/`__next`. A compromised or hostile endpoint could therefore redirect the client — carrying its bearer token — to a host of its choosing.

Credentials are now withheld cross-origin with the reason logged, matching what the ODP path (#101) and the redirect handler already do. The generic path was simply missed.

## ODP silently truncating an extraction

The drain retried **one** page when a page came back empty. But a page that legitimately yields zero rows while still carrying a further `__next` is a real shape — ODP delta packages and skip-token pages both produce it. So the scan ended there, handed back a partial extraction presented as complete, and then committed the delta token over rows that were never delivered.

It now keeps loading until a page yields rows or none is pending, bounded so an endless run of empty pages yields (and resumes next call) rather than spinning.

## One finding I could not reproduce

The review's top-ranked item — server-driven paging stopping after page 1 when pushdown leaves the URL byte-identical — **does not reproduce**:

| query | expected | actual |
|---|---|---|
| v2 Orders `count(*)` | 830 | 830 |
| v4 Orders `count(*)` | 830 | 830 |
| v2 Order_Details | 2155 | 2155 |
| TripPin People (nested columns, 3 pages) | 20 | 20 |
| v2 Orders projected count | 830 | 830 |

Both cited triggers — `COUNT(*)` and an entity set with nested columns — page correctly across multiple pages. Recorded rather than silently dropped: the reasoning may hold for a configuration I could not construct, but I will not claim a fix for something I cannot show is broken.

## Still open from this review, filed not fixed

`odp_odata_read` still scans straight off `FunctionData` with a bare `GlobalTableFunctionState` — the same class as #75, which `odata_read` was fixed for. It is a real gap, and a larger change than belongs in a security patch.

## Verification

Full C++ suite **398 cases / 2053 assertions**. Live: `odata_conformance_e2e` (22), `odata_v2`, `odata_v4`, `odata_expand` (46), both storage suites, `odata_describe` (32), `odata_scan_reexecution` (24), `web_core`, `web_http` (31), plus `graph_excel` (21) and `microsoft_entra` (41) against the real tenant — all green. Multi-page paging re-checked at 2155 rows.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791636985&installation_model_id=425457&pr_number=145&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F145&signature=2a95ff394eaf3b4367ae79bc6a5a98412f8ae87928cd33f3af131d57b8a8bb40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->