### PR TITLE
fix: keep OData v4 operation advertisements out of columns (#147)

### DIFF
--- a/src/odata_read_bind_data.cpp
+++ b/src/odata_read_bind_data.cpp
@@ -56,6 +56,18 @@ static bool IsODataMetadataField(const std::string &field_name) {
     return true;
   }
 
+  // OData V4 advertises a bound action or function as a property whose name is
+  // "#namespace.name" - SAP Gateway emits one per bound operation, with an object
+  // value. A structural property name is a SimpleIdentifier and can never begin
+  // with '#', so these are control information too, not columns.
+  //
+  // Left unfiltered they became phantom VARCHAR columns that could never hold their
+  // object value: a real SAP travel service produced 7 such columns and 654 failed
+  // conversions in a single read. See GitHub #147.
+  if (!field_name.empty() && field_name.front() == '#') {
+    return true;
+  }
+
   // OData V4 (JSON Format, "Control Information") puts control information and
   // annotations in names containing '@' - "@odata.etag", "@odata.id",
   // "@odata.type", "@odata.editLink", and property-scoped forms such as

--- a/test/sql/sap/odata_sap_storage.test
+++ b/test/sql/sap/odata_sap_storage.test
@@ -32,3 +32,54 @@ query I
 SELECT AirlineID FROM travel.Airline ORDER BY AirlineID LIMIT 1;
 ----
 AA
+
+# ============================================================================
+# GitHub #147 - OData v4 bound-operation advertisements are not columns
+# ============================================================================
+
+# SAP advertises every bound action and function as a property named
+# "#namespace.ActionName" with an object value. Per the v4 JSON Format those
+# names are control information, like the "@"-prefixed ones, and a structural
+# property name can never begin with '#'. Treated as columns they became
+# phantom VARCHARs that could never hold their object value: this service
+# produced 7 such columns and 654 failed conversions in a single read.
+# Asserted as an exact column count: the 7 advertisements would push it to 32.
+query I
+SELECT COUNT(*) FROM (SELECT * FROM odata_read('${ERPL_SAP_BASE_URL}/sap/opu/odata4/dmo/ui_travel_d_d_o4/srvd/dmo/ui_travel_d_d/0001/Travel') LIMIT 0) t;
+----
+0
+
+query I
+SELECT COUNT(*) = 25 FROM (DESCRIBE SELECT * FROM odata_read('${ERPL_SAP_BASE_URL}/sap/opu/odata4/dmo/ui_travel_d_d_o4/srvd/dmo/ui_travel_d_d/0001/Travel'));
+----
+true
+
+# The real columns still arrive, and the rows with them.
+query I
+SELECT COUNT(*) > 4000 FROM odata_read('${ERPL_SAP_BASE_URL}/sap/opu/odata4/dmo/ui_travel_d_d_o4/srvd/dmo/ui_travel_d_d/0001/Travel');
+----
+true
+
+# ============================================================================
+# Filter literals against a strict SAP Gateway
+# ============================================================================
+
+# Date literals are emitted bare for v4. SAP rejects a quoted date, so this is
+# the case the review could not verify without a real Gateway.
+query I
+SELECT COUNT(*) > 0 FROM odata_read('${ERPL_SAP_BASE_URL}/sap/opu/odata4/dmo/ui_travel_d_d_o4/srvd/dmo/ui_travel_d_d/0001/Travel')
+WHERE BeginDate >= DATE '2026-01-01' AND BeginDate < DATE '2027-01-01';
+----
+true
+
+# An IN list becomes a parenthesised or-chain; SAP accepts the percent-encoded
+# grouping parentheses.
+query I
+SELECT COUNT(*) = (
+  SELECT COUNT(*) FROM odata_read('${ERPL_SAP_BASE_URL}/sap/opu/odata4/dmo/ui_travel_d_d_o4/srvd/dmo/ui_travel_d_d/0001/Travel')
+  WHERE AgencyID = '70017' OR AgencyID = '70020'
+)
+FROM odata_read('${ERPL_SAP_BASE_URL}/sap/opu/odata4/dmo/ui_travel_d_d_o4/srvd/dmo/ui_travel_d_d/0001/Travel')
+WHERE AgencyID IN ('70017', '70020');
+----
+true


### PR DESCRIPTION
First run against a **real SAP A4H system**, which the review flagged as its biggest verification gap. It found a bug immediately — and the conversion-failure reporting from #74 is what surfaced it:

```
erpl_web warning: 654 values in 7 columns could not be converted and were returned as NULL.
  column '#com.sap.gateway.srvd.dmo.ui_travel_d_d.v0001.acceptTravel': 77 failures;
    first offending value: {}; first error: Expected JSON type 'string', but got type: 'object'
```

## #147 — bound-operation advertisements were treated as columns

OData v4 advertises a bound action or function as a property named `#namespace.name` with an **object** value, and SAP Gateway emits one per bound operation on every entity. A structural property name is a `SimpleIdentifier` and can never begin with `#`, so these are control information exactly like the `@`-prefixed names fixed in #108 — the exclusion just didn't cover `#`.

Every one of those columns was a guaranteed NULL, because a VARCHAR column can never hold an object.

| | before | after |
|---|---|---|
| conversion warnings on a Travel read | 654 values in 7 columns | **0** |
| columns in the result | 32 | **25** |
| rows | 4136 | 4136 |

## Filter literals verified against a strict Gateway

The review said the v2/v4 literal formats could not be validated without a real SAP system, and deliberately withheld v2 type suffixes for that reason. Now checked against A4H:

| case | result |
|---|---|
| bare v4 date literals in a range predicate | accepted, 2018 rows |
| `IN` list → parenthesised or-chain | 204, matching the equivalent `OR` |
| string equality | 103, matching SAP's own `$count` |
| percent-encoded grouping parens `%28`/`%29` | accepted by SAP |

The SAP suite now runs live rather than skipping: `odata_sap_attach`, `odata_sap_storage`, `odata_sap_read_secret` all pass.

## Two things worth knowing, filed separately

**SAP applies conversion exits to filter values.** `AgencyID eq '070017'` matches rows whose stored value is `70017` — SAP's ALPHA conversion, not string equality. So a pushed-down filter can return rows that would *not* satisfy the same predicate evaluated locally. That is inherent to predicate pushdown against a server with its own matching semantics, and it is worth documenting rather than "fixing".

**SAP rejects a filter on a currency amount without its currency field**, with `/IWBEP/CM_V4S_RUN/031`. Not our defect — and thanks to #77 the service's own code and message now reach the user instead of a generic parse error.

## Verification

Full C++ suite **398 cases / 2053 assertions**. Live: the OData conformance suites, plus the SAP suite against A4H — 10 assertions in `odata_sap_storage` including the new regression checks.

Closes #147.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791646579&installation_model_id=425457&pr_number=148&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F148&signature=0dc330f2066fdc8f95d2d0af990ab20f6477d5bd91cbb961b90a65de72dadcea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->