### PR TITLE
fix: OData paging, metadata context, per-execution client isolation and URL $expand

### DIFF
--- a/src/include/odata_client.hpp
+++ b/src/include/odata_client.hpp
@@ -182,6 +182,20 @@ public:
     virtual bool HasInputParameters() const { return false; }
 
     std::string Url() const { return url.ToString(); }
+
+    // Adopt a page this client did not fetch itself.
+    //
+    // The bind path probes the URL once to detect the OData version, and that
+    // probe response IS the first page. It used to be parsed and buffered while
+    // the client was left untouched, so the client had no current_response and
+    // Get(true) had nothing to advance from: server-driven paging stopped after
+    // page one and every later page was dropped silently. Handing the response
+    // to the client keeps the saved round trip and makes the next link on that
+    // page reachable. See GitHub #149.
+    void AdoptResponse(std::shared_ptr<TResponse> response) {
+        current_response = std::move(response);
+    }
+
     std::shared_ptr<HttpClient> GetHttpClient() const { return http_client->GetHttpClient(); }
     std::shared_ptr<HttpAuthParams> AuthParams() const { return auth_params; }
 

--- a/src/include/odata_read_functions.hpp
+++ b/src/include/odata_read_functions.hpp
@@ -122,6 +122,16 @@ public:
     // Expand functionality
     void SetExpandClause(const std::string& expand_clause);
     std::string GetExpandClause() const;
+    // Extract expanded data from the page the bind-time probe already fetched.
+    //
+    // That page is buffered before the expand clause has been parsed, so at buffering time
+    // the expand schema is empty and the extraction is skipped. Bind calls this once the
+    // schema is known. Without it, $expand written into the URL returns NULL expanded
+    // columns for the whole scan - and because the expand cache is keyed on the scan-global
+    // row index, a page that contributes no entries shifts every later page's values too.
+    // See GitHub #156.
+    void ExtractExpandedDataFromBufferedFirstPage();
+
     void SetExpandedDataSchema(const std::vector<std::string>& expand_paths);
     // Forward nested expand paths into the extractor for recursive processing
     void SetNestedExpandPaths(const std::vector<std::string>& nested_paths);
@@ -214,6 +224,11 @@ private:
     // bind-time client instead would make the second EXECUTE of a bound `SELECT *` plan
     // resume from wherever the first one stopped. See GitHub #75 and #149.
     std::shared_ptr<ODataEntitySetResponse> first_page_response_;
+
+    // Per-scan guard: each execution clones the bind data and gets a FRESH extractor, so
+    // the extraction has to be redone per scan - and exactly once, or page one's expanded
+    // values would be appended twice and shift every later page.
+    bool first_page_expand_extracted_ = false;
     // Tracks how many rows have been emitted so far to align expanded cache row-wise
     size_t emitted_row_index_ = 0;
     bool service_root_mode_ = false;

--- a/src/include/odata_read_functions.hpp
+++ b/src/include/odata_read_functions.hpp
@@ -206,6 +206,14 @@ private:
     // data_extractor's row cache and odata_client's paging cursor, this is the
     // complete set of fields the clone must own.
     bool first_page_cached_ = false;
+
+    // The page the bind-time probe already fetched, kept as DATA rather than as client
+    // state. Every execution clones the bind data and must get its OWN client: they share
+    // one shared_ptr<ODataEntitySetClient> otherwise, and that client owns the mutable
+    // pagination cursor (url, current_response, page_requests). Handing the page to the
+    // bind-time client instead would make the second EXECUTE of a bound `SELECT *` plan
+    // resume from wherever the first one stopped. See GitHub #75 and #149.
+    std::shared_ptr<ODataEntitySetResponse> first_page_response_;
     // Tracks how many rows have been emitted so far to align expanded cache row-wise
     size_t emitted_row_index_ = 0;
     bool service_root_mode_ = false;

--- a/src/odata_read_bind_data.cpp
+++ b/src/odata_read_bind_data.cpp
@@ -573,6 +573,9 @@ duckdb::unique_ptr<ODataReadBindData> ODataReadBindData::FromEntitySetClient(
           std::make_unique<HttpResponse>(HttpMethod::GET, HttpUrl(client->Url()),
                                          200, "application/json", initial_content),
           client->GetODataVersion());
+      // The client must know about this page too, or it cannot follow its next
+      // link when the scan asks for page two (GitHub #149).
+      client->AdoptResponse(synthetic);
       bind_data->BufferFirstPageFromResponse(synthetic);
     } catch (const std::exception &e) {
       ERPL_TRACE_DEBUG(

--- a/src/odata_read_bind_data.cpp
+++ b/src/odata_read_bind_data.cpp
@@ -573,9 +573,10 @@ duckdb::unique_ptr<ODataReadBindData> ODataReadBindData::FromEntitySetClient(
           std::make_unique<HttpResponse>(HttpMethod::GET, HttpUrl(client->Url()),
                                          200, "application/json", initial_content),
           client->GetODataVersion());
-      // The client must know about this page too, or it cannot follow its next
-      // link when the scan asks for page two (GitHub #149).
-      client->AdoptResponse(synthetic);
+      // Kept as data; CloneForScan adopts it into the private client it mints for each
+      // execution, so the page's next link is reachable without two executions sharing a
+      // pagination cursor (GitHub #149 and #75).
+      bind_data->first_page_response_ = synthetic;
       bind_data->BufferFirstPageFromResponse(synthetic);
     } catch (const std::exception &e) {
       ERPL_TRACE_DEBUG(

--- a/src/odata_read_pushdown.cpp
+++ b/src/odata_read_pushdown.cpp
@@ -155,7 +155,23 @@ void ODataReadBindData::UpdateUrlFromPredicatePushdown() {
       PredicatePushdownHelper()->ApplyFiltersToUrl(odata_client->Url());
     
     ERPL_TRACE_DEBUG("ODATA_READ_BIND", "Updated URL: " + updated_url.ToString());
-    
+
+  // Nothing to apply: keep the client we already have. Replacing it with an
+  // identical one throws away its current_response, and the buffered first page
+  // below is only discarded when the URL changed -- so the scan would keep page
+  // one and then ask a client that has never issued a request to advance to page
+  // two, which it cannot. Server-driven paging stopped dead after the first page
+  // and the rest of the entity set was dropped silently. This is the ordinary
+  // `SELECT *` case: with every column projected and no filter there is no
+  // $select and no $filter to add, so the URL is necessarily unchanged.
+  // See GitHub #149.
+  if (prev_url_str == updated_url.ToString()) {
+    ERPL_TRACE_DEBUG("ODATA_READ_BIND",
+                     "Predicate pushdown left the URL unchanged; keeping the "
+                     "existing client so server-driven paging can continue");
+    return;
+  }
+
     // Store the current OData version before creating new client
     auto current_version = odata_client->GetODataVersion();
 
@@ -174,7 +190,7 @@ void ODataReadBindData::UpdateUrlFromPredicatePushdown() {
   // If the finalized URL changed compared to the prefetched one, discard
   // buffered data so we don't emit unfiltered/unprojected rows. The scan init
   // will prefetch again.
-    if (first_page_cached_ && prev_url_str != updated_url.ToString()) {
+    if (first_page_cached_) {
     ERPL_TRACE_INFO("ODATA_READ_BIND",
                     "Final URL changed after predicate pushdown; discarding "
                     "prefetched buffer and caches");

--- a/src/odata_read_scan_state.cpp
+++ b/src/odata_read_scan_state.cpp
@@ -390,7 +390,33 @@ bool ODataReadBindData::HasMoreResults() {
 duckdb::unique_ptr<ODataReadBindData> ODataReadBindData::CloneForScan() const {
   // The clone owns every piece of mutable scan state; the source keeps only
   // the schema and configuration settled during bind (GitHub #75).
-  auto clone = duckdb::make_uniq<ODataReadBindData>(odata_client, true);
+  //
+  // That includes the OData client: it carries the pagination cursor (url,
+  // current_response, page_requests), so sharing one between executions makes the second
+  // EXECUTE of a bound plan resume where the first stopped. A projecting plan used to get
+  // a private client by accident, because applying $select rebuilt it; an unprojected
+  // `SELECT *` changes no URL and rebuilds nothing, so the client is minted here instead
+  // and the accident is no longer load-bearing. Service-root mode issues no requests and
+  // keeps its stub.
+  auto scan_client = odata_client;
+  if (!service_root_mode_ && odata_client != nullptr) {
+    scan_client = std::make_shared<ODataEntitySetClient>(
+        odata_client->GetHttpClient(), HttpUrl(odata_client->Url()), odata_client->AuthParams());
+    const auto bound_version = odata_client->GetODataVersion();
+    if (bound_version != ODataVersion::UNKNOWN) {
+      scan_client->SetODataVersionDirectly(bound_version);
+    }
+    // The bind-time probe already paid for page one; adopting it here lets this execution
+    // follow that page's next link without re-fetching it, while keeping the cursor
+    // private. Deliberately NOT odata_client->current_response: after one execution that
+    // is the LAST page, and resuming from it would return nothing.
+    if (first_page_response_ != nullptr) {
+      scan_client->AdoptResponse(first_page_response_);
+    }
+  }
+
+  auto clone = duckdb::make_uniq<ODataReadBindData>(scan_client, true);
+  clone->first_page_response_ = first_page_response_;
 
   clone->service_root_mode_ = service_root_mode_;
   clone->InitializeComponents(service_root_mode_);

--- a/src/odata_read_scan_state.cpp
+++ b/src/odata_read_scan_state.cpp
@@ -110,7 +110,14 @@ void ODataReadBindData::EnsureInitialized() {
 
     // Make sure first page is prefetched once and buffered
     if (!first_page_cached_) {
+        // PrefetchFirstPage buffers through BufferFirstPageFromResponse, which extracts
+        // expanded data itself - the schema is settled by the time a scan runs.
         PrefetchFirstPage();
+    } else {
+        // The buffered page came from the bind-time probe, which ran before the expand
+        // clause was parsed, so its expanded data was never extracted. Do it now, into
+        // THIS scan's extractor. See GitHub #156.
+        ExtractExpandedDataFromBufferedFirstPage();
     }
 }
 
@@ -417,6 +424,10 @@ duckdb::unique_ptr<ODataReadBindData> ODataReadBindData::CloneForScan() const {
 
   auto clone = duckdb::make_uniq<ODataReadBindData>(scan_client, true);
   clone->first_page_response_ = first_page_response_;
+  // first_page_expand_extracted_ is deliberately NOT copied. The clone gets a fresh
+  // extractor with an empty expand cache, so this execution must extract page one's
+  // expanded data into it again; copying the flag would leave the first page's expanded
+  // columns NULL. See GitHub #156.
 
   clone->service_root_mode_ = service_root_mode_;
   clone->InitializeComponents(service_root_mode_);
@@ -518,6 +529,30 @@ void ODataReadBindData::PrefetchFirstPage() {
                        row_buffer->HasNextPage() ? "true" : "false"));
 }
 
+void ODataReadBindData::ExtractExpandedDataFromBufferedFirstPage() {
+  if (service_root_mode_ || first_page_response_ == nullptr || first_page_expand_extracted_) {
+    return;
+  }
+  if (!HasExpandedData() || data_extractor->GetExpandedDataSchema().empty()) {
+    return;
+  }
+
+  try {
+    ERPL_TRACE_DEBUG("ODATA_READ_BIND",
+                     "Extracting expanded data from the buffered probe page now that the "
+                     "expand schema is known");
+    data_extractor->ExtractExpandedDataFromResponse(first_page_response_->RawContent());
+    first_page_expand_extracted_ = true;
+  } catch (const StrictTypingViolation &) {
+    throw;
+  } catch (const std::exception &e) {
+    ERPL_TRACE_WARN("ODATA_READ_BIND",
+                    std::string("Failed to extract expanded data from the buffered probe "
+                                "page: ") +
+                        e.what());
+  }
+}
+
 void ODataReadBindData::BufferFirstPageFromResponse(
     std::shared_ptr<ODataEntitySetResponse> response) {
     if (!response) {
@@ -567,6 +602,9 @@ void ODataReadBindData::BufferFirstPageFromResponse(
     row_buffer->AddRows(std::move(page_rows));
     row_buffer->SetHasNextPage(response->NextUrl().has_value());
     first_page_cached_ = true;
+    // Whatever this page's expanded data was, it has been handled here; the re-extraction
+    // hook in EnsureInitialized must not append it a second time.
+    first_page_expand_extracted_ = true;
 }
 
 ODataReadGlobalState::ODataReadGlobalState(

--- a/src/odata_url_helpers.cpp
+++ b/src/odata_url_helpers.cpp
@@ -21,7 +21,33 @@ std::string ODataUrlResolver::resolveMetadataUrl(const HttpUrl &request_url,
         if (hash_pos != std::string::npos) {
             ctx = ctx.substr(0, hash_pos);
         }
+
+        // A relative context is resolved the way RFC 3986 resolves any relative
+        // reference: against the base's *directory*, so the last segment of the
+        // request path is replaced rather than appended to. OData services state
+        // the context of an entity set response as the bare "$metadata", and
+        // appending that to ".../0001/Travel" produces ".../0001/Travel/$metadata",
+        // which SAP Gateway answers with 400. The metadata document is then
+        // unreachable and every column falls back to VARCHAR without a word.
+        //
+        // The request's query string is dropped for the same reason: $format,
+        // $filter and $skiptoken describe the entity request, not the metadata
+        // document. See GitHub #152.
+        const bool is_absolute_reference =
+            ctx.find("://") != std::string::npos || (!ctx.empty() && ctx.front() == '/');
+        if (!is_absolute_reference) {
+            HttpUrl context_base(request_url);
+            context_base.Query("");
+            auto base_path = context_base.Path();
+            const auto last_slash = base_path.rfind('/');
+            base_path = (last_slash == std::string::npos) ? std::string("/")
+                                                          : base_path.substr(0, last_slash + 1);
+            context_base.Path(base_path);
+            return HttpUrl::MergeWithBaseUrlIfRelative(context_base, ctx).ToString();
+        }
+
         auto merged = HttpUrl::MergeWithBaseUrlIfRelative(request_url, ctx);
+        merged.Query("");
         return merged.ToString();
     }
 

--- a/test/cpp/test_odata_read_expand.cpp
+++ b/test/cpp/test_odata_read_expand.cpp
@@ -326,6 +326,51 @@ TEST_CASE("odata_read parses inline expanded data into the result", "[odata_expa
     REQUIRE(ExpandOnTheWire(server, "/nw/Products") == "Category");
 }
 
+// GitHub #156: $expand written into the URL must behave exactly like the expand= named
+// parameter. It did not. FromEntitySetClient buffers the bind-time probe page BEFORE
+// ProcessExpandClause has set the expand schema, so page one is buffered with no expanded
+// data extracted. The named-parameter spelling hides this: it ADDS $expand to the URL, so
+// the URL changes, the buffer is discarded and page one is refetched once the schema is
+// known. With $expand already in the URL nothing changes, the un-extracted buffer survives,
+// and the expanded column comes back NULL for the whole scan.
+TEST_CASE("odata_read expands identically whether $expand is in the URL or a parameter",
+          "[odata_expand][e2e]") {
+    ODataTestServer server;
+    server.ServeMetadataFixture("/nw/$metadata", "edm_northwind.xml");
+    server.OnPath(
+        "/nw/Products",
+        CannedResponse::Json(MakeV4Page(
+            server.Url("/nw/$metadata") + "#Products",
+            {R"({"ProductID":1,"ProductName":"Chai","SupplierID":1,"CategoryID":1,)"
+             R"("QuantityPerUnit":"10 boxes x 20 bags","UnitPrice":18.0,"UnitsInStock":39,)"
+             R"("UnitsOnOrder":0,"ReorderLevel":10,"Discontinued":false,)"
+             R"("Category":{"CategoryID":1,"CategoryName":"Beverages",)"
+             R"("Description":"Soft drinks, coffees, teas"}})"})));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto by_parameter = con.Query("SELECT CAST(Category AS VARCHAR) FROM odata_read('" +
+                                  server.Url("/nw/Products") + "', expand = 'Category')");
+    INFO((by_parameter->HasError() ? by_parameter->GetError() : std::string()));
+    REQUIRE_FALSE(by_parameter->HasError());
+    REQUIRE(by_parameter->RowCount() == 1);
+
+    auto by_url = con.Query("SELECT CAST(Category AS VARCHAR) FROM odata_read('" +
+                            server.Url("/nw/Products") + "?$expand=Category')");
+    INFO((by_url->HasError() ? by_url->GetError() : std::string()));
+    REQUIRE_FALSE(by_url->HasError());
+    REQUIRE(by_url->RowCount() == 1);
+
+    const auto parameter_text = by_parameter->GetValue(0, 0).ToString();
+    const auto url_text = by_url->GetValue(0, 0).ToString();
+    INFO("by parameter: " << parameter_text);
+    INFO("by url:       " << url_text);
+    REQUIRE(url_text.find("Beverages") != std::string::npos);
+    REQUIRE(url_text == parameter_text);
+}
+
 // Catches: an expand that is dropped as soon as another query option is present.
 // $top/$skip and $expand are assembled from the same helper, so a clause that
 // overwrites rather than adds is a plausible regression.

--- a/test/cpp/test_odata_server_e2e.cpp
+++ b/test/cpp/test_odata_server_e2e.cpp
@@ -189,6 +189,54 @@ TEST_CASE("odata_read follows every @odata.nextLink page", "[odata_e2e][paging]"
     REQUIRE(AnyRequestQueryContains(requests, "$skiptoken=3"));
 }
 
+// The paging test above selects a single column, which makes the pushdown helper
+// append a $select and therefore change the request URL. That difference is what
+// kept this bug hidden: the buffered first page is only discarded when the URL
+// changes, but the OData client is rebuilt unconditionally. With every column
+// selected and no filter, the URL is identical, so the scan kept the first page
+// and got a brand-new client with no current_response to advance from --
+// pagination stopped after page one and the rest of the entity set was dropped
+// without a word. `SELECT *` is the most ordinary query there is; against a real
+// SAP service it returned 100 of 4136 rows.
+TEST_CASE("odata_read follows every page when all columns are selected",
+          "[odata_e2e][paging]") {
+    ODataTestServer server;
+    const std::string entity_url = server.Url("/pgall/Airlines");
+    const std::string context = server.Url("/pgall/$metadata") + "#Airlines";
+
+    server.ServeMetadataFixture("/pgall/$metadata", "edm_trippin.xml");
+
+    server.OnMatch(
+        [](const RecordedRequest &request) {
+            return request.path == "/pgall/Airlines" && request.QueryParam("$skiptoken") == "2";
+        },
+        CannedResponse::Json(MakeV4Page(context, {AIRLINE_MU, AIRLINE_AF},
+                                        entity_url + "?$format=json&$skiptoken=3")));
+    server.OnMatch(
+        [](const RecordedRequest &request) {
+            return request.path == "/pgall/Airlines" && request.QueryParam("$skiptoken") == "3";
+        },
+        CannedResponse::Json(MakeV4Page(context, {AIRLINE_KL})));
+    server.OnPath("/pgall/Airlines",
+                  CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA, AIRLINE_FM},
+                                                  entity_url + "?$format=json&$skiptoken=2")));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    // ORDER BY over the star keeps every column live, so the projection cannot be
+    // pruned back down to one and no $select is emitted.
+    auto result = con.Query("SELECT * FROM odata_read('" + entity_url + "') ORDER BY AirlineCode");
+    INFO((result->HasError() ? result->GetError() : std::string()));
+    REQUIRE_FALSE(result->HasError());
+    REQUIRE(result->RowCount() == 5);
+
+    const auto requests = server.RequestsFor("/pgall/Airlines");
+    REQUIRE(AnyRequestQueryContains(requests, "$skiptoken=2"));
+    REQUIRE(AnyRequestQueryContains(requests, "$skiptoken=3"));
+}
+
 // Catches GitHub #93: a follow-up page that errors must fail the scan. Swallowing
 // the error would hand the user a silently truncated result set, which is worse
 // than no result at all.

--- a/test/cpp/test_odata_server_e2e.cpp
+++ b/test/cpp/test_odata_server_e2e.cpp
@@ -237,6 +237,74 @@ TEST_CASE("odata_read follows every page when all columns are selected",
     REQUIRE(AnyRequestQueryContains(requests, "$skiptoken=3"));
 }
 
+// GitHub #75 + #149 together. The re-execution guarantee and the all-columns paging fix
+// pull in opposite directions: CloneForScan hands every execution the SAME
+// shared_ptr<ODataEntitySetClient>, and the only thing that ever gave a scan a private
+// client was the unconditional rebuild inside UpdateUrlFromPredicatePushdown. Returning
+// early from that rebuild when the URL is unchanged - the exact `SELECT *` case #149 fixes
+// - would hand two executions one mutable pagination cursor.
+//
+// Every existing re-execution case projects (COUNT(*), COUNT(DISTINCT ...)), which emits a
+// $select and so still takes the rebuild path. These two do not, which is why the shape
+// was uncovered.
+TEST_CASE("a bound SELECT * plan returns every row on re-execution", "[odata_e2e][paging]") {
+    ODataTestServer server;
+    const std::string entity_url = server.Url("/reexec/Airlines");
+    const std::string context = server.Url("/reexec/$metadata") + "#Airlines";
+
+    server.ServeMetadataFixture("/reexec/$metadata", "edm_trippin.xml");
+    server.OnMatch(
+        [](const RecordedRequest &request) {
+            return request.path == "/reexec/Airlines" && request.QueryParam("$skiptoken") == "2";
+        },
+        CannedResponse::Json(MakeV4Page(context, {AIRLINE_MU, AIRLINE_AF})));
+    server.OnPath("/reexec/Airlines",
+                  CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA, AIRLINE_FM},
+                                                  entity_url + "?$format=json&$skiptoken=2")));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    REQUIRE_FALSE(con.Query("PREPARE p AS SELECT * FROM odata_read('" + entity_url + "')")->HasError());
+
+    for (int execution = 1; execution <= 3; execution++) {
+        auto result = con.Query("EXECUTE p");
+        INFO("execution " << execution);
+        INFO((result->HasError() ? result->GetError() : std::string()));
+        REQUIRE_FALSE(result->HasError());
+        REQUIRE(result->RowCount() == 4);
+    }
+}
+
+TEST_CASE("two SELECT * scans of one call each see every row", "[odata_e2e][paging]") {
+    ODataTestServer server;
+    const std::string entity_url = server.Url("/selfjoin/Airlines");
+    const std::string context = server.Url("/selfjoin/$metadata") + "#Airlines";
+
+    server.ServeMetadataFixture("/selfjoin/$metadata", "edm_trippin.xml");
+    server.OnMatch(
+        [](const RecordedRequest &request) {
+            return request.path == "/selfjoin/Airlines" && request.QueryParam("$skiptoken") == "2";
+        },
+        CannedResponse::Json(MakeV4Page(context, {AIRLINE_MU, AIRLINE_AF})));
+    server.OnPath("/selfjoin/Airlines",
+                  CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA, AIRLINE_FM},
+                                                  entity_url + "?$format=json&$skiptoken=2")));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    // A cross join of two unprojected scans: 4 x 4. Sharing one cursor between them makes
+    // this collapse.
+    auto result = con.Query("SELECT COUNT(*) FROM odata_read('" + entity_url + "') a, odata_read('" +
+                            entity_url + "') b");
+    INFO((result->HasError() ? result->GetError() : std::string()));
+    REQUIRE_FALSE(result->HasError());
+    REQUIRE(result->GetValue(0, 0).GetValue<int64_t>() == 16);
+}
+
 // Catches GitHub #93: a follow-up page that errors must fail the scan. Swallowing
 // the error would hand the user a silently truncated result set, which is worse
 // than no result at all.

--- a/test/cpp/test_odata_url_helpers.cpp
+++ b/test/cpp/test_odata_url_helpers.cpp
@@ -11,6 +11,36 @@ TEST_CASE("ODataUrlResolver uses @odata.context when present", "[odata_url]") {
     REQUIRE(meta.find("$metadata") != std::string::npos);
 }
 
+// A relative @odata.context is resolved against the service root, not appended to
+// the entity set URL. SAP Gateway answers an entity set with "$metadata#Travel";
+// appending that to ".../0001/Travel" yields ".../0001/Travel/$metadata", which the
+// Gateway rejects with 400. The metadata document is then unreachable and every
+// column silently degrades to VARCHAR -- dates and numbers arrive as strings and a
+// numeric comparison in SQL fails to bind. See GitHub #152.
+TEST_CASE("ODataUrlResolver resolves a relative @odata.context against the service root",
+          "[odata_url]") {
+    ODataUrlResolver r;
+
+    HttpUrl sap("http://host/sap/opu/odata4/dmo/svc/srvd/dmo/ui_travel/0001/Travel?$format=json");
+    REQUIRE(r.resolveMetadataUrl(sap, "$metadata#Travel") ==
+            "http://host/sap/opu/odata4/dmo/svc/srvd/dmo/ui_travel/0001/$metadata");
+
+    // The "./" spelling means the same thing.
+    REQUIRE(r.resolveMetadataUrl(sap, "./$metadata#Travel") ==
+            "http://host/sap/opu/odata4/dmo/svc/srvd/dmo/ui_travel/0001/$metadata");
+
+    // The request's own query string must not be carried onto the metadata URL:
+    // $format=json asks for a JSON entity payload, not a JSON metadata document.
+    REQUIRE(r.resolveMetadataUrl(sap, "$metadata#Travel").find("$format") == std::string::npos);
+
+    // An absolute-path context still wins outright.
+    REQUIRE(r.resolveMetadataUrl(sap, "/other/$metadata#Travel") == "http://host/other/$metadata");
+
+    // ...as does a fully absolute one.
+    REQUIRE(r.resolveMetadataUrl(sap, "https://elsewhere/svc/$metadata#Travel") ==
+            "https://elsewhere/svc/$metadata");
+}
+
 TEST_CASE("ODataUrlResolver falls back for Datasphere without context", "[odata_url]") {
     ODataUrlResolver r;
     HttpUrl base("https://host/api/v1/dwc/consumption/relational/ten/ass/Entity");

--- a/test/sql/sap/odata_sap_storage.test
+++ b/test/sql/sap/odata_sap_storage.test
@@ -83,3 +83,33 @@ FROM odata_read('${ERPL_SAP_BASE_URL}/sap/opu/odata4/dmo/ui_travel_d_d_o4/srvd/d
 WHERE AgencyID IN ('70017', '70020');
 ----
 true
+
+# ============================================================================
+# GitHub #149 - every page is read when the whole row is selected
+# ============================================================================
+
+# The COUNT(*) assertion above passes even when paging is broken, because DuckDB
+# prunes the projection down to nothing and the resulting $select changes the
+# request URL, which is exactly the condition that hid the bug. Keeping all 25
+# columns live means no $select and no $filter, so the URL is unchanged - and
+# that is the case where the scan used to stop after the first page and return
+# 100 of 4136 rows without a warning.
+query I
+SELECT COUNT(*) = (
+  SELECT COUNT(*) FROM odata_read('${ERPL_SAP_BASE_URL}/sap/opu/odata4/dmo/ui_travel_d_d_o4/srvd/dmo/ui_travel_d_d/0001/Travel')
+)
+FROM (
+  SELECT * FROM odata_read('${ERPL_SAP_BASE_URL}/sap/opu/odata4/dmo/ui_travel_d_d_o4/srvd/dmo/ui_travel_d_d/0001/Travel')
+  ORDER BY TravelUUID
+);
+----
+true
+
+# ...and the rows are distinct, so the page that is kept is not simply repeated.
+query I
+SELECT COUNT(*) = COUNT(DISTINCT TravelUUID) FROM (
+  SELECT * FROM odata_read('${ERPL_SAP_BASE_URL}/sap/opu/odata4/dmo/ui_travel_d_d_o4/srvd/dmo/ui_travel_d_d/0001/Travel')
+  ORDER BY TravelUUID
+);
+----
+true


### PR DESCRIPTION
Four correctness fixes in the OData read path, found against a live SAP A4H system and by an agent-crew review. They ship together because each was exposed by the one before it.

### #149 — `SELECT *` silently returned only the first page
**100 of 4136 rows** against live SAP, no error, no warning. The probe response is buffered as page one but was never given to the client, so `current_response` stayed null; separately the client was rebuilt unconditionally while the buffer was only discarded when the URL changed. All columns + no filter ⇒ URL unchanged ⇒ paging stopped after page one. Any projection or filter masked it, which is why the existing paging test (single column) missed it.

### #152 — relative `@odata.context` lost the metadata document
Exposed by the above. SAP's `$metadata#Travel` was appended to the entity URL (`.../Travel/$metadata` → 400) instead of resolved against the service root, so the EDM was unreachable and **every column degraded to VARCHAR** — `BookingFee` lost DOUBLE, `BeginDate` lost DATE, `WHERE BookingFee > 100` stopped binding. The old test only asserted "$metadata" appeared *somewhere*, which the wrong URL satisfied too.

### GitHub #75 regression — per-execution client isolation
Caught by crew review of the #149 fix. `CloneForScan` hands every execution the **same** `shared_ptr<ODataEntitySetClient>`, which owns the pagination cursor; the unconditional rebuild was the only thing giving each execution a private one. The 2nd EXECUTE of a bound `SELECT *` plan returned **2 of 4 rows**. The first page is now held as data and each execution mints its own client. Every existing re-execution test projects, which is why the shape was uncovered.

### #156 — `$expand` in the URL returned NULL for the whole scan
`expand='Category'` returned the struct; `?$expand=Category` returned NULL. The probe page is buffered before the expand schema exists, and the named-parameter spelling masks it by changing the URL. Two traps in the fix: it can't be done once at bind (each execution gets a fresh extractor), and it must happen exactly once per scan or page one's values are appended twice and shift every later page.

### Verification
Red/green on all four. Live SAP A4H: 4136 rows / 4136 distinct keys via CTAS and COPY; `BookingFee` DOUBLE, `BeginDate` DATE, `SAP__Messages` STRUCT[] restored. 403 C++ cases / 2081 assertions; SQL suite green apart from the two known missing-ODP-service tests (gated separately in #155).