### PR TITLE
fix: never drop a pushdown filter, and stop routing reads through the shared response cache

### DIFF
--- a/src/include/odata_client.hpp
+++ b/src/include/odata_client.hpp
@@ -126,7 +126,7 @@ private:
 template <typename TResponse>
 class ODataClient {
 public:    
-    ODataClient(std::shared_ptr<CachingHttpClient> http_client, const HttpUrl& url, std::shared_ptr<HttpAuthParams> auth_params)
+    ODataClient(std::shared_ptr<HttpClient> http_client, const HttpUrl& url, std::shared_ptr<HttpAuthParams> auth_params)
         : http_client(http_client)
         , url(url) 
         , auth_params(auth_params)
@@ -196,7 +196,7 @@ public:
         current_response = std::move(response);
     }
 
-    std::shared_ptr<HttpClient> GetHttpClient() const { return http_client->GetHttpClient(); }
+    std::shared_ptr<HttpClient> GetHttpClient() const { return http_client; }
     std::shared_ptr<HttpAuthParams> AuthParams() const { return auth_params; }
 
     // Server-driven paging follows whatever @odata.nextLink / __next the service
@@ -207,7 +207,15 @@ public:
     static constexpr idx_t MAX_PAGE_REQUESTS = 10000;
 
 protected:
-    std::shared_ptr<CachingHttpClient> http_client;
+    // Deliberately the bare client, not CachingHttpClient. That wrapper is a process-wide
+    // 30s response cache keyed on method + URL + body hash, with credentials excluded from
+    // the key. Nothing that repeats ever reached it - DoMetadataHttpGet bypasses it because
+    // the EDM is cached separately, and ProbeUrl builds its own client - so its only traffic
+    // was nextLink pages, each fetched exactly once. That is a 0% hit rate with 100%
+    // retention: every page body of every scan held for 30s, unbounded. The one case where
+    // the key did match was the same page URL under two different credentials, which served
+    // one caller's rows to another.
+    std::shared_ptr<HttpClient> http_client;
     HttpUrl url;
     std::shared_ptr<HttpAuthParams> auth_params;
     std::shared_ptr<TResponse> current_response;
@@ -316,7 +324,7 @@ protected:
         
         // Use the injected client (bypassing the response cache, as metadata is cached separately
         // in the EdmCache) instead of building a throw-away client per attempt.
-        auto metadata_http_client = (http_client != nullptr) ? http_client->GetHttpClient() : nullptr;
+        auto metadata_http_client = http_client;
         if (metadata_http_client == nullptr) {
             throw std::runtime_error("No HTTP client available to fetch OData metadata from "
                                      + HttpUrl::MergeWithBaseUrlIfRelative(url, sanitized_raw).ToString());

--- a/src/odata_client.cpp
+++ b/src/odata_client.cpp
@@ -96,19 +96,19 @@ void ODataClient<TResponse>::DetectODataVersion()
 // ----------------------------------------------------------------------
 
 ODataEntitySetClient::ODataEntitySetClient(std::shared_ptr<HttpClient> http_client, const HttpUrl& url, const Edmx& edmx)
-    : ODataClient(std::make_shared<CachingHttpClient>(http_client), url, nullptr)
+    : ODataClient(http_client, url, nullptr)
 { }
 
 ODataEntitySetClient::ODataEntitySetClient(std::shared_ptr<HttpClient> http_client, const HttpUrl& url)
-    : ODataClient(std::make_shared<CachingHttpClient>(http_client), url, nullptr)
+    : ODataClient(http_client, url, nullptr)
 { }
 
 ODataEntitySetClient::ODataEntitySetClient(std::shared_ptr<HttpClient> http_client, const HttpUrl& url, const Edmx& edmx, std::shared_ptr<HttpAuthParams> auth_params)
-    : ODataClient(std::make_shared<CachingHttpClient>(http_client), url, auth_params)
+    : ODataClient(http_client, url, auth_params)
 { }
 
 ODataEntitySetClient::ODataEntitySetClient(std::shared_ptr<HttpClient> http_client, const HttpUrl& url, std::shared_ptr<HttpAuthParams> auth_params)
-    : ODataClient(std::make_shared<CachingHttpClient>(http_client), url, auth_params)
+    : ODataClient(http_client, url, auth_params)
 { }
 
 std::string ODataEntitySetClient::GetMetadataContextUrl()
@@ -603,11 +603,11 @@ std::vector<ODataEntitySetReference> ODataServiceResponse::EntitySets()
 // ----------------------------------------------------------------------
 
 ODataServiceClient::ODataServiceClient(std::shared_ptr<HttpClient> http_client, const HttpUrl& url)
-    : ODataClient(std::make_shared<CachingHttpClient>(http_client), url, nullptr)
+    : ODataClient(http_client, url, nullptr)
 { }
 
 ODataServiceClient::ODataServiceClient(std::shared_ptr<HttpClient> http_client, const HttpUrl& url, std::shared_ptr<HttpAuthParams> auth_params)
-    : ODataClient(std::make_shared<CachingHttpClient>(http_client), url, auth_params)
+    : ODataClient(http_client, url, auth_params)
 { }
 
 std::shared_ptr<ODataServiceResponse> ODataServiceClient::Get(bool get_next)

--- a/src/odata_predicate_pushdown_helper.cpp
+++ b/src/odata_predicate_pushdown_helper.cpp
@@ -885,18 +885,13 @@ std::string ODataPredicatePushdownHelper::TranslateConstantComparison(const duck
     std::string constant_value = filter.constant.ToString();
     ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN", "Constant value: '" + constant_value + "' (type: " + filter.constant.type().ToString() + ")");
     
-    // Skip invalid filters that would generate malformed OData
-    if (constant_value.empty() || constant_value == "''" || constant_value == "\"\"") {
-        // Empty string comparisons often don't make sense and can cause OData errors
-        ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN", "Skipping empty string comparison for column: " + column_name);
-        return "";
-    }
-    
-    // Skip filters with very long values that might cause OData URL issues
-    if (constant_value.length() > 1000) {
-        ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN", "Skipping filter with very long value (length: " + std::to_string(constant_value.length()) + ") for column: " + column_name);
-        return "";
-    }
+    // Nothing is skipped here on the grounds of the value alone. DuckDB removes a
+    // predicate from the plan once it becomes a TableFilter and the function advertises
+    // filter_pushdown, so no residual filter re-applies what we drop: skipping means
+    // returning rows that do not satisfy the query's WHERE clause. An empty string is a
+    // perfectly good OData literal ("Col eq ''", which SAP Gateway answers correctly),
+    // and an over-long literal is the service's business - a rejection from the server is
+    // loud, unlike a silently wrong answer. See GitHub #153.
     
     std::stringstream result;
     result << column_name << " ";
@@ -922,23 +917,29 @@ std::string ODataPredicatePushdownHelper::TranslateConstantComparison(const duck
             comparison_operator = "ge";
             break;
         default:
-            // Unsupported comparison type - skip this filter
-            ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN", "Unsupported comparison type for column: " + column_name);
-            return "";
+            // Skipping would silently widen the result set (see above), so fail instead.
+            ERPL_TRACE_ERROR("PREDICATE_PUSHDOWN", "Unsupported comparison type for column: " + column_name);
+            throw duckdb::NotImplementedException(
+                "OData pushdown cannot express the comparison used on column '" + column_name +
+                "'. Please open an issue at https://github.com/DataZooDE/erpl-web/issues");
     }
     
     result << comparison_operator;
     ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN", "Using comparison operator: " + comparison_operator);
 
-    // Render the constant as a version-appropriate OData literal. A type with no
-    // safe literal form drops the whole comparison rather than emitting a
-    // wrongly-typed one; DuckDB still applies it as a residual filter.
+    // Render the constant as a version-appropriate OData literal. A type with no safe
+    // literal form cannot be pushed and cannot be left to DuckDB either, because the
+    // predicate is no longer in the plan - so the query fails rather than answering with
+    // rows that do not match it.
     const auto literal = FormatODataLiteral(filter.constant, odata_version);
     if (!literal.has_value()) {
-        ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN",
+        ERPL_TRACE_ERROR("PREDICATE_PUSHDOWN",
                          "No OData literal form for type " + filter.constant.type().ToString() +
-                         " on column " + column_name + "; leaving the filter to DuckDB");
-        return "";
+                         " on column " + column_name);
+        throw duckdb::NotImplementedException(
+            "OData pushdown has no literal form for type " + filter.constant.type().ToString() +
+            " used in a comparison on column '" + column_name +
+            "'. Cast the value to a type the service understands, or filter after reading.");
     }
     result << " " << *literal;
     ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN", "Added literal: " + *literal);
@@ -986,9 +987,10 @@ std::string ODataPredicatePushdownHelper::TranslateInFilter(const duckdb::InFilt
 }
 
 std::string ODataPredicatePushdownHelper::TranslateConjunction(const duckdb::ConjunctionAndFilter &filter, const std::string &column_name) const {
-    // Children that cannot be translated are dropped. That widens the result
-    // set, and DuckDB's residual filter removes the surplus rows, so the answer
-    // stays correct.
+    // A child that cannot be translated throws, and the exception propagates: dropping
+    // it would widen the result set with nothing downstream to narrow it again. An empty
+    // translation now means only "advisory filter" (optional, bloom, or an uninitialised
+    // dynamic filter), which is safe to leave out. See GitHub #153.
     std::vector<std::string> translated;
     translated.reserve(filter.child_filters.size());
     for (const auto &child : filter.child_filters) {

--- a/src/odata_predicate_pushdown_helper.cpp
+++ b/src/odata_predicate_pushdown_helper.cpp
@@ -27,11 +27,14 @@ std::string EscapeODataStringLiteral(const std::string &value)
 // Renders a DuckDB constant as an OData literal for the given protocol version,
 // or nullopt when the type has no literal form we can emit safely.
 //
-// Returning nullopt drops the filter rather than guessing. That is safe for a
-// ConstantFilter: DuckDB keeps it as a residual filter above the scan, so the
-// rows are still filtered locally - we merely transfer more of them. Emitting a
-// wrongly-typed literal is not safe, because a lenient server silently returns a
-// different row set that no residual filter can repair.
+// Returning nullopt means "this value has no OData spelling", not "drop the filter".
+// DuckDB does NOT keep a pushed filter as a residual above the scan - once a predicate
+// becomes a TableFilter and the function advertises filter_pushdown, the optimizer removes
+// it from the plan (optimizer/pushdown/pushdown_get.cpp). So every caller must either fail
+// the query or be advisory by construction (optional, bloom, dynamic filters); dropping
+// the comparison returns rows that do not satisfy the WHERE clause. See GitHub #153.
+// Emitting a wrongly-typed literal is not safe either, because a lenient server silently
+// returns a different row set.
 std::optional<std::string> FormatODataLiteral(const duckdb::Value &value, ODataVersion version)
 {
     if (value.IsNull()) {
@@ -674,8 +677,15 @@ std::string ODataPredicatePushdownHelper::BuildFilterClause(duckdb::optional_ptr
         if (column_name_resolver) {
             column_name = column_name_resolver(filter_entry.first);
             if (column_name.empty()) {
+                // Skipping loses the predicate entirely: DuckDB pushed it here and removed
+                // it from the plan, so nothing re-applies it and the scan returns rows that
+                // do not satisfy the WHERE clause. See GitHub #153.
                 ERPL_TRACE_ERROR("PREDICATE_PUSHDOWN", "Column name resolver returned empty string for index " + std::to_string(filter_entry.first));
-                continue;
+                throw duckdb::InternalException(
+                    "OData pushdown could not resolve a column name for filter index " +
+                    std::to_string(filter_entry.first) +
+                    "; refusing to drop the filter, which would return rows that do not match "
+                    "the query");
             }
             ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN", "Column name resolver mapped index " + std::to_string(filter_entry.first) + " to: " + column_name);
         } else {
@@ -684,8 +694,13 @@ std::string ODataPredicatePushdownHelper::BuildFilterClause(duckdb::optional_ptr
             ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN", "No column name resolver, using direct index: " + std::to_string(column_index));
             
             if (column_index >= all_column_names.size()) {
+                // As above: dropping the filter silently widens the result.
                 ERPL_TRACE_ERROR("PREDICATE_PUSHDOWN", "Column index " + std::to_string(column_index) + " is out of bounds for column names array");
-                continue;
+                throw duckdb::InternalException(
+                    "OData pushdown got a filter for column index " + std::to_string(column_index) +
+                    ", but the scan has only " + std::to_string(all_column_names.size()) +
+                    " columns; refusing to drop the filter, which would return rows that do not "
+                    "match the query");
             }
             
             column_name = all_column_names[column_index];
@@ -795,6 +810,13 @@ namespace {
 // and unused on 1.4, which makes this case label simply unreachable on the LTS build.
 constexpr auto BLOOM_FILTER_TABLE_FILTER_TYPE = static_cast<duckdb::TableFilterType>(10);
 
+// Where the 1.5 header exists, hold the numeric value to the real enumerator: a future
+// renumbering would otherwise silently point this case label at a different filter kind.
+#if __has_include("duckdb/planner/filter/bloom_filter.hpp")
+static_assert(BLOOM_FILTER_TABLE_FILTER_TYPE == duckdb::TableFilterType::BLOOM_FILTER,
+              "TableFilterType::BLOOM_FILTER is no longer 10; update the LTS fallback value");
+#endif
+
 }  // namespace
 
 std::string ODataPredicatePushdownHelper::TranslateFilter(const duckdb::TableFilter &filter, const std::string &column_name) const {
@@ -855,7 +877,19 @@ std::string ODataPredicatePushdownHelper::TranslateFilter(const duckdb::TableFil
                 result = "";
                 break;
             }
-            result = TranslateConstantComparison(*filter_data.filter, column_name);
+            try {
+                result = TranslateConstantComparison(*filter_data.filter, column_name);
+            } catch (const duckdb::NotImplementedException &) {
+                // A dynamic filter is advisory by construction: the Top-N operator that
+                // produced it enforces the bound again above the scan. Failing here would
+                // abort a query that works today - ORDER BY <timestamptz col> LIMIT n - for
+                // a filter we are never required to push.
+                ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN",
+                                 "Dynamic filter on column '" + column_name +
+                                 "' has no OData translation; skipping it (it is not required "
+                                 "for correctness)");
+                result = "";
+            }
             break;
         }
         case duckdb::TableFilterType::IN_FILTER:
@@ -958,23 +992,24 @@ std::string ODataPredicatePushdownHelper::TranslateInFilter(const duckdb::InFilt
         return "";
     }
 
-    constexpr idx_t MAX_IN_LIST_SIZE = 100;
-    if (filter.values.size() > MAX_IN_LIST_SIZE) {
-        ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN",
-                         "IN list on column '" + column_name + "' has " +
-                         std::to_string(filter.values.size()) + " values; too long for a URL, filtering locally");
-        return "";
-    }
+    // There is no local fallback to fall back TO: DuckDB removed this filter from the plan
+    // when it pushed it here, so returning "" hands back the whole entity set. The old
+    // 100-value ceiling did exactly that. A long URL is the service's business - a 414 is
+    // loud, where a dropped filter is silently wrong. See GitHub #153.
 
     std::stringstream result;
     result << "(";
     for (idx_t i = 0; i < filter.values.size(); ++i) {
         const auto literal = FormatODataLiteral(filter.values[i], odata_version);
         if (!literal.has_value()) {
-            ERPL_TRACE_DEBUG("PREDICATE_PUSHDOWN",
+            ERPL_TRACE_ERROR("PREDICATE_PUSHDOWN",
                              "IN list on column '" + column_name +
-                             "' holds a value with no OData literal form; filtering locally");
-            return "";
+                             "' holds a value with no OData literal form");
+            throw duckdb::NotImplementedException(
+                "OData pushdown has no literal form for type " + filter.values[i].type().ToString() +
+                " used in an IN list on column '" + column_name +
+                "'. Materialise the read first, for example: CREATE TEMP TABLE t AS SELECT * FROM "
+                "odata_read(...); SELECT * FROM t WHERE ...");
         }
         if (i > 0) {
             result << " or ";
@@ -1017,9 +1052,11 @@ std::string ODataPredicatePushdownHelper::TranslateConjunction(const duckdb::Con
 }
 
 std::string ODataPredicatePushdownHelper::TranslateConjunction(const duckdb::ConjunctionOrFilter &filter, const std::string &column_name) const {
-    // An OR is all-or-nothing: dropping a branch would NARROW the disjunction
-    // and withhold rows the server would otherwise return, which no residual
-    // filter can recover. So if any child fails to translate, push nothing.
+    // An OR is all-or-nothing. A branch that cannot be translated throws from the child
+    // translation, like everywhere else (GitHub #153). A branch that translates to "" is
+    // merely advisory and carries no predicate of its own, so pushing a partial form would
+    // wrongly NARROW the disjunction; that case abandons the whole thing, which is safe
+    // because whatever produced the advisory filter re-applies it above the scan.
     std::vector<std::string> translated;
     translated.reserve(filter.child_filters.size());
     for (const auto &child : filter.child_filters) {

--- a/test/cpp/test_odata_content.cpp
+++ b/test/cpp/test_odata_content.cpp
@@ -789,13 +789,10 @@ TEST_CASE("Test OData v4 error payload is surfaced with code and message", "[oda
         content.ToRows(column_names, column_types);
         FAIL("expected the service error to be raised");
     } catch (const std::exception &e) {
-        // MSVC does not resolve Catch's INFO in this translation unit, so the message is
-        // carried into the failure through FAIL, which the same file already uses.
         const std::string message = e.what();
-        if (message.find("Request_ResourceNotFound") == std::string::npos ||
-            message.find("Resource 'Foo' does not exist.") == std::string::npos) {
-            FAIL("service error was not surfaced; got: " + message);
-        }
+        INFO(message);
+        REQUIRE(message.find("Request_ResourceNotFound") != std::string::npos);
+        REQUIRE(message.find("Resource 'Foo' does not exist.") != std::string::npos);
     }
 }
 
@@ -817,10 +814,9 @@ TEST_CASE("Test OData v2 error payload is surfaced with code and message", "[oda
         FAIL("expected the service error to be raised");
     } catch (const std::exception &e) {
         const std::string message = e.what();
-        if (message.find("SY/530") == std::string::npos ||
-            message.find("Invalid filter on property Foo") == std::string::npos) {
-            FAIL("service error was not surfaced; got: " + message);
-        }
+        INFO(message);
+        REQUIRE(message.find("SY/530") != std::string::npos);
+        REQUIRE(message.find("Invalid filter on property Foo") != std::string::npos);
     }
 }
 

--- a/test/cpp/test_odata_content.cpp
+++ b/test/cpp/test_odata_content.cpp
@@ -789,10 +789,13 @@ TEST_CASE("Test OData v4 error payload is surfaced with code and message", "[oda
         content.ToRows(column_names, column_types);
         FAIL("expected the service error to be raised");
     } catch (const std::exception &e) {
+        // MSVC does not resolve Catch's INFO in this translation unit, so the message is
+        // carried into the failure through FAIL, which the same file already uses.
         const std::string message = e.what();
-        INFO(message);
-        REQUIRE(message.find("Request_ResourceNotFound") != std::string::npos);
-        REQUIRE(message.find("Resource 'Foo' does not exist.") != std::string::npos);
+        if (message.find("Request_ResourceNotFound") == std::string::npos ||
+            message.find("Resource 'Foo' does not exist.") == std::string::npos) {
+            FAIL("service error was not surfaced; got: " + message);
+        }
     }
 }
 
@@ -814,9 +817,10 @@ TEST_CASE("Test OData v2 error payload is surfaced with code and message", "[oda
         FAIL("expected the service error to be raised");
     } catch (const std::exception &e) {
         const std::string message = e.what();
-        INFO(message);
-        REQUIRE(message.find("SY/530") != std::string::npos);
-        REQUIRE(message.find("Invalid filter on property Foo") != std::string::npos);
+        if (message.find("SY/530") == std::string::npos ||
+            message.find("Invalid filter on property Foo") == std::string::npos) {
+            FAIL("service error was not surfaced; got: " + message);
+        }
     }
 }
 

--- a/test/cpp/test_odata_filter_translation.cpp
+++ b/test/cpp/test_odata_filter_translation.cpp
@@ -177,10 +177,11 @@ TEST_CASE("An AND conjunction drops advisory children", "[odata_filter]") {
 	REQUIRE(TranslateOne(std::move(conjunction), ODataVersion::V4) == "(Col eq 1)");
 }
 
-TEST_CASE("An OR conjunction is abandoned when any child is untranslatable", "[odata_filter]") {
-	// Dropping a child of an OR would NARROW the result set and silently lose
-	// rows that no residual filter can bring back, so the whole disjunction
-	// must be abandoned instead.
+TEST_CASE("An OR conjunction is abandoned when a branch is merely advisory", "[odata_filter]") {
+	// An advisory branch carries no predicate of its own, so the disjunction it appears in
+	// constrains nothing and pushing a partial form would NARROW the result. Abandoning it
+	// is safe here precisely because the branch was advisory; a branch that genuinely
+	// cannot be translated throws instead (see the case above).
 	auto conjunction = duckdb::make_uniq<duckdb::ConjunctionOrFilter>();
 	conjunction->child_filters.push_back(MakeEq(Value::INTEGER(1)));
 
@@ -251,6 +252,70 @@ TEST_CASE("An AND conjunction fails loudly when a child cannot be translated", "
 
 	REQUIRE_THROWS_AS(TranslateOne(std::move(conjunction), ODataVersion::V4),
 	                  duckdb::NotImplementedException);
+}
+
+TEST_CASE("An initialised dynamic filter of an untranslatable type is skipped, not thrown",
+          "[odata_filter]") {
+	// A dynamic filter comes from the Top-N optimiser and is always enforced again above
+	// the scan, so it is advisory whatever it holds. Once initialised it reaches
+	// TranslateConstantComparison, which now throws for a type with no literal form -- that
+	// would abort "ORDER BY <timestamptz col> LIMIT n", a query that works today.
+	auto filter_data = duckdb::make_shared_ptr<duckdb::DynamicFilterData>();
+	filter_data->filter = duckdb::make_uniq<duckdb::ConstantFilter>(
+	    duckdb::ExpressionType::COMPARE_LESSTHAN, Value::TIMESTAMPTZ(duckdb::timestamp_tz_t(0)));
+	filter_data->initialized = true;
+
+	REQUIRE(TranslateOne(duckdb::make_uniq<duckdb::DynamicFilter>(filter_data),
+	                     ODataVersion::V4) == "");
+}
+
+TEST_CASE("An IN filter fails loudly when a value cannot be translated", "[odata_filter]") {
+	// Same reasoning as the constant comparison: dropping the filter returns rows that do
+	// not satisfy the WHERE clause, and nothing downstream filters them out.
+	duckdb::vector<Value> values;
+	values.push_back(Value::TIMESTAMPTZ(duckdb::timestamp_tz_t(0)));
+	REQUIRE_THROWS_AS(TranslateOne(duckdb::make_uniq<duckdb::InFilter>(std::move(values)),
+	                               ODataVersion::V4),
+	                  duckdb::NotImplementedException);
+}
+
+TEST_CASE("A very long IN list is still translated", "[odata_filter]") {
+	// The old 100-value ceiling silently dropped the filter and returned the whole entity
+	// set. A long URL is the service's business; a 414 is loud.
+	duckdb::vector<Value> values;
+	for (int i = 0; i < 101; i++) {
+		values.push_back(Value::INTEGER(i));
+	}
+	const auto translated = TranslateOne(duckdb::make_uniq<duckdb::InFilter>(std::move(values)),
+	                                     ODataVersion::V4);
+	REQUIRE(translated.find("Col eq 0") != std::string::npos);
+	REQUIRE(translated.find("Col eq 100") != std::string::npos);
+}
+
+TEST_CASE("An OR conjunction fails loudly when a branch cannot be translated", "[odata_filter]") {
+	// Pushing nothing means the server returns everything and DuckDB re-applies nothing,
+	// so the query silently widens -- the same defect as dropping an AND child.
+	auto conjunction = duckdb::make_uniq<duckdb::ConjunctionOrFilter>();
+	conjunction->child_filters.push_back(MakeEq(Value::INTEGER(1)));
+	conjunction->child_filters.push_back(duckdb::make_uniq<duckdb::ConstantFilter>(
+	    duckdb::ExpressionType::COMPARE_EQUAL, Value::TIMESTAMPTZ(duckdb::timestamp_tz_t(0))));
+
+	REQUIRE_THROWS_AS(TranslateOne(std::move(conjunction), ODataVersion::V4),
+	                  duckdb::NotImplementedException);
+}
+
+TEST_CASE("A filter on a column that cannot be resolved fails loudly", "[odata_filter]") {
+	// The filter is neither pushed nor re-applied, so continuing past it returns rows that
+	// do not satisfy the WHERE clause. Unlike the other cases this one fires on an ordinary
+	// projection/expand mapping bug rather than on an exotic type, which makes silently
+	// widening worse, not better.
+	ODataPredicatePushdownHelper helper({"Col"});
+	helper.SetODataVersion(ODataVersion::V4);
+
+	duckdb::TableFilterSet filter_set;
+	filter_set.filters[7] = MakeEq(Value::INTEGER(1));  // no column at index 7
+
+	REQUIRE_THROWS(helper.ConsumeFilters(&filter_set));
 }
 
 TEST_CASE("Advisory filters are still skipped rather than failing", "[odata_filter]") {

--- a/test/cpp/test_odata_filter_translation.cpp
+++ b/test/cpp/test_odata_filter_translation.cpp
@@ -161,9 +161,10 @@ TEST_CASE("An IN filter becomes an or-chain instead of throwing", "[odata_filter
 // GitHub #85 - empty child translations must not corrupt a conjunction
 // ---------------------------------------------------------------------------
 
-TEST_CASE("An AND conjunction drops untranslatable children", "[odata_filter]") {
-	// Dropping a child of an AND widens the result set; DuckDB's residual
-	// filter removes the extra rows, so this is safe.
+TEST_CASE("An AND conjunction drops advisory children", "[odata_filter]") {
+	// An uninitialised dynamic filter is advisory - the Top-N optimiser fills it in
+	// later and the query is correct without it - so dropping it is safe. Children
+	// that are NOT advisory must not be dropped; see the case below.
 	auto conjunction = duckdb::make_uniq<duckdb::ConjunctionAndFilter>();
 	conjunction->child_filters.push_back(MakeEq(Value::INTEGER(1)));
 
@@ -202,6 +203,70 @@ TEST_CASE("A conjunction with no translatable children produces no $filter", "[o
 	conjunction->child_filters.push_back(duckdb::make_uniq<duckdb::DynamicFilter>(sentinel_data));
 
 	REQUIRE(TranslateOne(std::move(conjunction), ODataVersion::V4) == "");
+}
+
+
+// ---------------------------------------------------------------------------
+// GitHub #153 - a filter we cannot translate must never be dropped silently
+// ---------------------------------------------------------------------------
+//
+// DuckDB removes a predicate from the plan once it becomes a TableFilter and the
+// function advertises filter_pushdown (see optimizer/pushdown/pushdown_get.cpp), so
+// nothing re-applies it above the scan. Dropping one therefore returns rows that do
+// not satisfy the query's own WHERE clause. Against live SAP this made
+// "WHERE CurrencyCode = ''" answer 4136 rows where the correct answer is 0.
+
+TEST_CASE("An empty string comparison is translated, not skipped", "[odata_filter]") {
+	// "Col eq ''" is valid OData and SAP Gateway answers it correctly; there was
+	// never a reason to drop it.
+	REQUIRE(TranslateOne(MakeEq(Value("")), ODataVersion::V4) == "Col eq ''");
+	REQUIRE(TranslateOne(MakeEq(Value("")), ODataVersion::V2) == "Col eq ''");
+}
+
+TEST_CASE("A long string literal is translated, not skipped", "[odata_filter]") {
+	// A long literal is the service's business: a rejection from the server is loud,
+	// whereas dropping the filter is silently wrong.
+	const std::string long_value(1001, 'x');
+	const auto translated = TranslateOne(MakeEq(Value(long_value)), ODataVersion::V4);
+	REQUIRE(translated == "Col eq '" + long_value + "'");
+}
+
+TEST_CASE("A constant with no OData literal form fails loudly", "[odata_filter]") {
+	// TIMESTAMP_TZ has no safe literal form. Failing is the only correct answer left,
+	// because DuckDB will not filter the rows for us.
+	REQUIRE_THROWS_AS(TranslateOne(duckdb::make_uniq<duckdb::ConstantFilter>(
+	                                   duckdb::ExpressionType::COMPARE_EQUAL,
+	                                   Value::TIMESTAMPTZ(duckdb::timestamp_tz_t(0))),
+	                               ODataVersion::V4),
+	                  duckdb::NotImplementedException);
+}
+
+TEST_CASE("An AND conjunction fails loudly when a child cannot be translated", "[odata_filter]") {
+	// Dropping the child would widen the result set with nothing downstream to narrow
+	// it again.
+	auto conjunction = duckdb::make_uniq<duckdb::ConjunctionAndFilter>();
+	conjunction->child_filters.push_back(MakeEq(Value::INTEGER(1)));
+	conjunction->child_filters.push_back(duckdb::make_uniq<duckdb::ConstantFilter>(
+	    duckdb::ExpressionType::COMPARE_EQUAL, Value::TIMESTAMPTZ(duckdb::timestamp_tz_t(0))));
+
+	REQUIRE_THROWS_AS(TranslateOne(std::move(conjunction), ODataVersion::V4),
+	                  duckdb::NotImplementedException);
+}
+
+TEST_CASE("Advisory filters are still skipped rather than failing", "[odata_filter]") {
+	// The contrast: these three are documented as not required for correctness, so
+	// ignoring them stays legitimate and must not become an error.
+	auto sentinel_data = duckdb::make_shared_ptr<duckdb::DynamicFilterData>();
+	sentinel_data->filter = duckdb::make_uniq<duckdb::ConstantFilter>(
+	    duckdb::ExpressionType::COMPARE_LESSTHAN, Value::INTEGER(7));
+	sentinel_data->initialized = false;
+	REQUIRE(TranslateOne(duckdb::make_uniq<duckdb::DynamicFilter>(sentinel_data),
+	                     ODataVersion::V4) == "");
+
+	auto child = duckdb::make_uniq<duckdb::ConstantFilter>(duckdb::ExpressionType::COMPARE_EQUAL,
+	                                                       Value::TIMESTAMPTZ(duckdb::timestamp_tz_t(0)));
+	auto optional_filter = duckdb::make_uniq<duckdb::OptionalFilter>(std::move(child));
+	REQUIRE(TranslateOne(std::move(optional_filter), ODataVersion::V4) == "");
 }
 
 // ---------------------------------------------------------------------------
@@ -299,10 +364,13 @@ TEST_CASE("$top is withheld when a filter could not be translated", "[odata_filt
 	helper.ConsumeLimit(10);
 
 	duckdb::TableFilterSet filter_set;
-	// A TIMESTAMP_TZ constant has no safe OData literal form, so it stays local.
-	filter_set.filters[0] = duckdb::make_uniq<duckdb::ConstantFilter>(
-	    duckdb::ExpressionType::COMPARE_EQUAL,
-	    Value::TIMESTAMPTZ(duckdb::timestamp_tz_t(0)));
+	// An advisory filter is the only kind that still reaches the server untranslated:
+	// everything else now fails the query rather than being dropped (GitHub #153).
+	auto sentinel_data = duckdb::make_shared_ptr<duckdb::DynamicFilterData>();
+	sentinel_data->filter = duckdb::make_uniq<duckdb::ConstantFilter>(
+	    duckdb::ExpressionType::COMPARE_LESSTHAN, Value::INTEGER(7));
+	sentinel_data->initialized = false;
+	filter_set.filters[0] = duckdb::make_uniq<duckdb::DynamicFilter>(sentinel_data);
 	helper.ConsumeFilters(&filter_set);
 
 	HttpUrl url("https://host/svc/Entity");

--- a/test/cpp/test_odata_server_e2e.cpp
+++ b/test/cpp/test_odata_server_e2e.cpp
@@ -259,6 +259,27 @@ TEST_CASE("a bound SELECT * plan returns every row on re-execution", "[odata_e2e
         },
         CannedResponse::Json(MakeV4Page(context, {AIRLINE_MU, AIRLINE_AF})));
     server.OnPath("/reexec/Airlines",
+
+// The OData clients wrapped their HTTP client in CachingHttpClient, a process-wide 30s
+// response cache keyed on method + URL + body hash - credentials are NOT part of the key.
+// Nothing that repeats ever reached it (DoMetadataHttpGet bypasses it because the EDM is
+// cached separately, and ProbeUrl builds its own bare client), so its only traffic was
+// nextLink pages, each fetched once: a 0% hit rate with 100% retention. The one time the
+// key did match was the dangerous one - the same page URL fetched under two different
+// credentials, where the second caller was served the first caller's rows.
+TEST_CASE("a page fetched under different credentials is not served from cache",
+          "[odata_e2e][security]") {
+    ODataTestServer server;
+    const std::string entity_url = server.Url("/creds/Airlines");
+    const std::string context = server.Url("/creds/$metadata") + "#Airlines";
+
+    server.ServeMetadataFixture("/creds/$metadata", "edm_trippin.xml");
+    server.OnMatch(
+        [](const RecordedRequest &request) {
+            return request.path == "/creds/Airlines" && request.QueryParam("$skiptoken") == "2";
+        },
+        CannedResponse::Json(MakeV4Page(context, {AIRLINE_MU, AIRLINE_AF})));
+    server.OnPath("/creds/Airlines",
                   CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA, AIRLINE_FM},
                                                   entity_url + "?$format=json&$skiptoken=2")));
 
@@ -303,6 +324,31 @@ TEST_CASE("two SELECT * scans of one call each see every row", "[odata_e2e][pagi
     INFO((result->HasError() ? result->GetError() : std::string()));
     REQUIRE_FALSE(result->HasError());
     REQUIRE(result->GetValue(0, 0).GetValue<int64_t>() == 16);
+
+    const std::string scope = server.BaseUrl();
+    for (const std::string &user : {std::string("alice"), std::string("bob")}) {
+        REQUIRE_FALSE(con.Query("DROP SECRET IF EXISTS s")->HasError());
+        auto created = con.Query("CREATE SECRET s (TYPE http_basic, USERNAME '" + user +
+                                 "', PASSWORD '" + user + "-pw', SCOPE '" + scope + "')");
+        INFO((created->HasError() ? created->GetError() : std::string()));
+        REQUIRE_FALSE(created->HasError());
+
+        auto result = con.Query("SELECT COUNT(*) FROM odata_read('" + entity_url + "')");
+        INFO((result->HasError() ? result->GetError() : std::string()));
+        REQUIRE_FALSE(result->HasError());
+        REQUIRE(result->GetValue(0, 0).GetValue<int64_t>() == 4);
+    }
+
+    // The second page is the one that goes through the client under test. Both reads must
+    // have fetched it themselves, under their own Authorization header.
+    std::vector<std::string> page_two_authorizations;
+    for (const auto &request : server.RequestsFor("/creds/Airlines")) {
+        if (request.QueryParam("$skiptoken") == "2") {
+            page_two_authorizations.push_back(request.Header("Authorization"));
+        }
+    }
+    REQUIRE(page_two_authorizations.size() == 2);
+    REQUIRE(page_two_authorizations[0] != page_two_authorizations[1]);
 }
 
 // Catches GitHub #93: a follow-up page that errors must fail the scan. Swallowing

--- a/test/cpp/test_odata_server_e2e.cpp
+++ b/test/cpp/test_odata_server_e2e.cpp
@@ -259,27 +259,6 @@ TEST_CASE("a bound SELECT * plan returns every row on re-execution", "[odata_e2e
         },
         CannedResponse::Json(MakeV4Page(context, {AIRLINE_MU, AIRLINE_AF})));
     server.OnPath("/reexec/Airlines",
-
-// The OData clients wrapped their HTTP client in CachingHttpClient, a process-wide 30s
-// response cache keyed on method + URL + body hash - credentials are NOT part of the key.
-// Nothing that repeats ever reached it (DoMetadataHttpGet bypasses it because the EDM is
-// cached separately, and ProbeUrl builds its own bare client), so its only traffic was
-// nextLink pages, each fetched once: a 0% hit rate with 100% retention. The one time the
-// key did match was the dangerous one - the same page URL fetched under two different
-// credentials, where the second caller was served the first caller's rows.
-TEST_CASE("a page fetched under different credentials is not served from cache",
-          "[odata_e2e][security]") {
-    ODataTestServer server;
-    const std::string entity_url = server.Url("/creds/Airlines");
-    const std::string context = server.Url("/creds/$metadata") + "#Airlines";
-
-    server.ServeMetadataFixture("/creds/$metadata", "edm_trippin.xml");
-    server.OnMatch(
-        [](const RecordedRequest &request) {
-            return request.path == "/creds/Airlines" && request.QueryParam("$skiptoken") == "2";
-        },
-        CannedResponse::Json(MakeV4Page(context, {AIRLINE_MU, AIRLINE_AF})));
-    server.OnPath("/creds/Airlines",
                   CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA, AIRLINE_FM},
                                                   entity_url + "?$format=json&$skiptoken=2")));
 
@@ -324,6 +303,34 @@ TEST_CASE("two SELECT * scans of one call each see every row", "[odata_e2e][pagi
     INFO((result->HasError() ? result->GetError() : std::string()));
     REQUIRE_FALSE(result->HasError());
     REQUIRE(result->GetValue(0, 0).GetValue<int64_t>() == 16);
+}
+
+// The OData clients wrapped their HTTP client in CachingHttpClient, a process-wide 30s
+// response cache keyed on method + URL + body hash - credentials are NOT part of the key.
+// Nothing that repeats ever reached it (DoMetadataHttpGet bypasses it because the EDM is
+// cached separately, and ProbeUrl builds its own bare client), so its only traffic was
+// nextLink pages, each fetched once: a 0% hit rate with 100% retention. The one time the
+// key did match was the dangerous one - the same page URL fetched under two different
+// credentials, where the second caller was served the first caller's rows.
+TEST_CASE("a page fetched under different credentials is not served from cache",
+          "[odata_e2e][security]") {
+    ODataTestServer server;
+    const std::string entity_url = server.Url("/creds/Airlines");
+    const std::string context = server.Url("/creds/$metadata") + "#Airlines";
+
+    server.ServeMetadataFixture("/creds/$metadata", "edm_trippin.xml");
+    server.OnMatch(
+        [](const RecordedRequest &request) {
+            return request.path == "/creds/Airlines" && request.QueryParam("$skiptoken") == "2";
+        },
+        CannedResponse::Json(MakeV4Page(context, {AIRLINE_MU, AIRLINE_AF})));
+    server.OnPath("/creds/Airlines",
+                  CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA, AIRLINE_FM},
+                                                  entity_url + "?$format=json&$skiptoken=2")));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
 
     const std::string scope = server.BaseUrl();
     for (const std::string &user : {std::string("alice"), std::string("bob")}) {


### PR DESCRIPTION
Fixes #153, plus the security and memory defect an agent-crew performance review found in the same path.

### #153 — untranslatable filters were dropped, not re-applied
DuckDB removes a predicate from the plan once it becomes a `TableFilter` and the function advertises `filter_pushdown` (`optimizer/pushdown/pushdown_get.cpp`), so nothing re-applies what we drop. Live SAP: `WHERE CurrencyCode = ''` returned **4136 rows where the answer is 0**; so did a comparison against a >1000-char literal.

Fixed across **every** path, not just the one that surfaced it (the crew found the first pass was half-applied):
- the empty-string guard and the arbitrary 1000-char ceiling are deleted — both were translatable (`Col eq ''` is valid OData and SAP answers it correctly)
- `IN` past 100 values, and `IN` with an untranslatable member, now throw instead of returning the whole entity set
- an `OR` branch that cannot be translated throws; an unresolved/out-of-bounds filter column throws instead of `continue`
- an *initialised* `DYNAMIC_FILTER` is caught and skipped — it is advisory by construction, and failing it would abort `ORDER BY <timestamptz> LIMIT n`, which works today

An empty translation now means exactly one thing: an advisory filter (optional, bloom, uninitialised dynamic).

### Credential-blind response cache
The OData clients wrapped their HTTP client in a process-wide 30s cache keyed on method + URL + body hash — **credentials excluded**. A test against the local server proves the consequence: two reads with different `Authorization` headers produced a **single** page-two request, so the second caller was served the first caller's rows.

The wrapper also never functioned as a cache: `DoMetadataHttpGet` bypasses it (EdmCache handles metadata) and `ProbeUrl` builds its own client, so its only traffic was nextLink pages — each fetched exactly once. 0% hit rate, 100% retention, every page body pinned for 30s. The crew named it the strongest candidate for the unattributed 85% of peak RSS in #89.

### Verification
410 C++ cases / 2082 assertions. Live SAP: `= ''` → 0, `= 'USD'` → 1205, `IN(...)` → 204, `<> 'USD'` → 2931.