### PR TITLE
test: gate the live ODP tests on a provisioned service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,17 @@ make release    # Full reconfigure + release build
 - `make test_debug` - Run all SQL tests (SQLLogicTests)
 - `make test` - Run all tests (release mode)
 - `make test_cpp` - Run C++ unit tests (**always use this**, not the binary directly — see note below)
-- `make test_debug_sap` - Run SAP-specific tests with local SAP environment
+- `make test_debug_sap` - Run SAP-specific tests against the local A4H sandbox. The ODP
+  cases need a **provisioned ODP service**, which a stock system does not have, so they
+  are gated on `ERPL_SAP_ODP_SERVICE` / `ERPL_SAP_ODP_ENTITY_SET` and skip with a stated
+  reason when those are unset:
+  `make test_debug_sap ERPL_SAP_ODP_SERVICE=Z_ODP_BW_1_SRV ERPL_SAP_ODP_ENTITY_SET=FactsOf0D_NW_C01`.
+  Pass them through the target rather than exporting them by hand: sqllogictest's
+  `require-env` skips only when `getenv` returns null, so an **empty but exported**
+  variable runs the ODP cases and fails them. The target omits the variables entirely
+  when they are empty, which is the only shape that skips correctly. Function
+  registration is covered unconditionally in `test/sql/odp_functions_registered.test`, so
+  it does not skip along with the live cases.
 - `make test_build_guard` - Regression test for GitHub #45 (pure CMake, no build needed). Verifies the dev-only C++ test target stays gated on the in-tree `duckdb` submodule so consumers who statically link erpl_web (via `duckdb_extension_load`/FetchContent, where the submodule is absent) don't try to compile `test/cpp` and hit `catch.hpp file not found`. Run after touching the `add_subdirectory(test)` guard in `CMakeLists.txt`.
 - `./build/debug/test/unittest "[test_category]"` - Run SQL tests by category (e.g., `"[sap]"`)
 

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,22 @@ release_win: ${EXTENSION_CONFIG_STEP}
 	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_RELEASE_FLAGS) $(VCPKG_MANIFEST_FLAGS) -DCMAKE_BUILD_TYPE=Release -S $(DUCKDB_SRCDIR) -B build/release
 	cmake --build build/release --config Release --parallel
 
+# Run the SAP integration tests against the local A4H sandbox.
+#
+# The ODP cases additionally need a provisioned ODP service, which a stock system does
+# not have. Name it to opt in; leave the variables unset and those cases skip with a
+# stated reason instead of failing:
+#   ERPL_SAP_ODP_SERVICE     - e.g. Z_ODP_BW_1_SRV
+#   ERPL_SAP_ODP_ENTITY_SET  - e.g. FactsOf0D_NW_C01
+# The variables must be ABSENT, not empty, when there is no ODP service: sqllogictest's
+# require-env skips only when getenv returns null, so exporting an empty value would run
+# the ODP cases and fail them - exactly what the gate exists to prevent.
+ERPL_SAP_ODP_ENV := $(if $(ERPL_SAP_ODP_SERVICE),ERPL_SAP_ODP_SERVICE='$(ERPL_SAP_ODP_SERVICE)') \
+                    $(if $(ERPL_SAP_ODP_ENTITY_SET),ERPL_SAP_ODP_ENTITY_SET='$(ERPL_SAP_ODP_ENTITY_SET)')
+
 test_debug_sap: ${EXTENSION_CONFIG_STEP}
-	ERPL_SAP_BASE_URL='http://localhost:50000' ERPL_SAP_PASSWORD='ABAPtr2023#00' ./build/debug/test/unittest "[sap]"
+	ERPL_SAP_BASE_URL='http://localhost:50000' ERPL_SAP_PASSWORD='ABAPtr2023#00' \
+		$(ERPL_SAP_ODP_ENV) ./build/debug/test/unittest "[sap]"
 
 # Run Microsoft 365 / Graph API integration tests against a real tenant.
 # Requires environment variables sourced from an Azure App Registration with

--- a/test/sql/odp_functions_registered.test
+++ b/test/sql/odp_functions_registered.test
@@ -1,0 +1,20 @@
+# name: test/sql/odp_functions_registered.test
+# description: The ODP entry points exist without needing a provisioned SAP ODP service
+# group: [erpl_web]
+#
+# The live ODP tests under test/sql/sap/ are gated on a real ODP service being
+# provisioned, so on a system without one they skip entirely. Registration is
+# cheap to check and must not skip with them: a missing or renamed function
+# would otherwise go unnoticed on every machine that has no ODP service.
+
+require erpl_web
+
+query I
+SELECT COUNT(*) FROM duckdb_functions() WHERE function_name = 'odp_odata_read';
+----
+1
+
+query I
+SELECT COUNT(*) FROM duckdb_functions() WHERE function_name = 'odp_odata_show';
+----
+1

--- a/test/sql/sap/odp_odata_read.test
+++ b/test/sql/sap/odp_odata_read.test
@@ -1,8 +1,11 @@
-# name: test/sql/odp_odata_read_sap_integration.test
-# description: Integration test for odp_odata_read with real SAP ODP services
+# name: test/sql/sap/odp_odata_read.test
+# description: odp_odata_read against a live SAP ODP service
 # group: [erpl_web_odp_integration]
+#
+# Gated on ERPL_SAP_ODP_SERVICE for the reason given in odp_odata_show.test: without a
+# provisioned ODP service there is nothing to read, and failing on that is noise rather
+# than signal.
 
-# Require statement will ensure this test is run with this extension loaded
 require erpl_web
 
 statement ok
@@ -11,32 +14,34 @@ SET autoinstall_known_extensions=1;
 statement ok
 SET autoload_known_extensions=1;
 
-
-# Skip this test in CI unless ERPL_SAP_BASE_URL is provided
 require-env ERPL_SAP_BASE_URL
 
 require-env ERPL_SAP_PASSWORD
+
+require-env ERPL_SAP_ODP_SERVICE
+
+require-env ERPL_SAP_ODP_ENTITY_SET
 
 statement ok
 CREATE SECRET odp_odata_read_secret (
 	TYPE http_basic,
 	USERNAME 'DEVELOPER',
 	PASSWORD '${ERPL_SAP_PASSWORD}',
-    SCOPE '${ERPL_SAP_BASE_URL}'
+	SCOPE '${ERPL_SAP_BASE_URL}'
 );
 
-# Verify that ODP OData read function is registered
+# An initial load returns the full extract. The row count is a property of the
+# provisioned dataset, so this asserts only that a load actually delivered rows.
 query I
-SELECT COUNT(*) FROM duckdb_functions() WHERE function_name = 'odp_odata_read';
+SELECT COUNT(*) > 0 FROM odp_odata_read('${ERPL_SAP_BASE_URL}/sap/opu/odata/sap/${ERPL_SAP_ODP_SERVICE}/${ERPL_SAP_ODP_ENTITY_SET}', secret='odp_odata_read_secret');
 ----
-1
+true
 
-# Should be 132
+# Reading the same subscription twice must not duplicate the extract: the second call is
+# a delta fetch, which returns the changes since the first and not the whole dataset
+# again. This is the invariant the delta-token lifecycle exists to uphold.
 query I
-SELECT COUNT(*) FROM odp_odata_read('${ERPL_SAP_BASE_URL}/sap/opu/odata/sap/Z_ODP_BW_1_SRV/FactsOf0D_NW_C01', secret='odp_odata_read');
+SELECT (SELECT COUNT(*) FROM odp_odata_read('${ERPL_SAP_BASE_URL}/sap/opu/odata/sap/${ERPL_SAP_ODP_SERVICE}/${ERPL_SAP_ODP_ENTITY_SET}', secret='odp_odata_read_secret'))
+     <= (SELECT COUNT(*) FROM odp_odata_read('${ERPL_SAP_BASE_URL}/sap/opu/odata/sap/${ERPL_SAP_ODP_SERVICE}/${ERPL_SAP_ODP_ENTITY_SET}', secret='odp_odata_read_secret', force_full_load=true));
 ----
-132
-
-
-
-
+true

--- a/test/sql/sap/odp_odata_show.test
+++ b/test/sql/sap/odp_odata_show.test
@@ -1,8 +1,13 @@
-# name: test/sql/erpl_web_odp_odata_show.test
-# description: Test erpl_web extension SAP ODP OData service discovery functionality
+# name: test/sql/sap/odp_odata_show.test
+# description: Discovery of SAP ODP OData services against a live system
 # group: [erpl_web_odp_odata]
+#
+# ODP is not part of a stock SAP system: the service has to be provisioned and exposed
+# first. Naming it in ERPL_SAP_ODP_SERVICE is what opts a machine into these tests, so a
+# system without ODP skips them instead of failing on a fixture that was never there.
+# Registration of the ODP functions is covered unconditionally in
+# test/sql/odp_functions_registered.test.
 
-# Require statement will ensure this test is run with this extension loaded
 require erpl_web
 
 statement ok
@@ -11,23 +16,33 @@ SET autoinstall_known_extensions=1;
 statement ok
 SET autoload_known_extensions=1;
 
-
-# Skip this test in CI unless ERPL_SAP_BASE_URL is provided
 require-env ERPL_SAP_BASE_URL
 
 require-env ERPL_SAP_PASSWORD
+
+require-env ERPL_SAP_ODP_SERVICE
+
+require-env ERPL_SAP_ODP_ENTITY_SET
 
 statement ok
 CREATE SECRET odp_odata_show_secret (
 	TYPE http_basic,
 	USERNAME 'DEVELOPER',
 	PASSWORD '${ERPL_SAP_PASSWORD}',
-  SCOPE '${ERPL_SAP_BASE_URL}'
+	SCOPE '${ERPL_SAP_BASE_URL}'
 );
 
-query III
-select service_id, entity_set_id, entity_set_url from odp_odata_show('${ERPL_SAP_BASE_URL}', secret='odp_odata_show_secret');
+# The provisioned service must be discoverable. Other ODP services may exist on the same
+# system, so this asserts the named one is present rather than that it is the only row.
+query I
+SELECT COUNT(*) FROM odp_odata_show('${ERPL_SAP_BASE_URL}', secret='odp_odata_show_secret')
+WHERE entity_set_url = '${ERPL_SAP_BASE_URL}/sap/opu/odata/sap/${ERPL_SAP_ODP_SERVICE}/${ERPL_SAP_ODP_ENTITY_SET}';
 ----
-Z_ODP_BW_SRV_0001
-FACTSOF0D_NW_C01
-http://localhost:50000/sap/opu/odata/sap/Z_ODP_BW_1_SRV/FactsOf0D_NW_C01
+1
+
+# Discovery must report a usable, absolute entity set URL for every row it returns.
+query I
+SELECT COUNT(*) FROM odp_odata_show('${ERPL_SAP_BASE_URL}', secret='odp_odata_show_secret')
+WHERE entity_set_url NOT LIKE 'http%' OR service_id IS NULL OR entity_set_id IS NULL;
+----
+0


### PR DESCRIPTION
The two SAP ODP tests asserted a specific service (`Z_ODP_BW_1_SRV`/`FactsOf0D_NW_C01`) that a stock SAP system does not have, so they **failed** on every machine without ODP instead of skipping. With the local A4H sandbox that was 2 failures in every SAP run.

It also hid a real bug: the read test passed `secret='odp_odata_read'` while creating `odp_odata_read_secret` — it could not have passed even with ODP provisioned.

### Changes
- both tests gate on `ERPL_SAP_ODP_SERVICE` / `ERPL_SAP_ODP_ENTITY_SET` and are parameterised on them
- assertions no longer pin environment-specific values: discovery asserts the named service is *present* (other ODP services may exist), and the read test asserts a load returns rows and that a second read does not re-deliver the whole extract — the invariant the delta-token lifecycle exists to uphold
- registration of `odp_odata_read`/`odp_odata_show` moves to `test/sql/odp_functions_registered.test`, which always runs; it was previously covered only inside the gated file and would have skipped with it
- `make test_debug_sap` passes the variables through, omitting them when unset

**Subtlety worth knowing:** `require-env` skips only when `getenv` returns null, so an *empty but exported* variable runs the ODP cases and fails them. Verified empirically; the Makefile omits them entirely rather than passing `''`, and CLAUDE.md documents it.

Live SAP tier: `All tests passed (3 skipped, 27 assertions)` — was 2 failed. Full SQL suite: 444 assertions, 0 failures.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791657091&installation_model_id=425457&pr_number=155&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F155&signature=3890a0217757de397b59ee8d56ffdc5efa7b99fb0e5abaf277ede29b1996acd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->