### PR TITLE
test: run the ODP tests against a real, provisioned ODP service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1515,3 +1515,56 @@ Consultation: .ai/codex_context/20250130_091500_oauth_thread_safety.md"
 - **DuckDB CONTRIBUTING.md** - https://github.com/duckdb/duckdb/blob/main/CONTRIBUTING.md
 - **Community Extensions List** - https://duckdb.org/community_extensions/list_of_extensions (reference implementations)
 - **OpenAI Codex** - https://github.com/openai/codex (consult when stuck on complex problems)
+
+## Provisioning an ODP OData service on the A4H sandbox
+
+The ODP tests need a real ODP OData service. A stock ABAP system has none, and SAP ships
+**no non-UI way** to create one: `CL_RSODP_ODATA_GENERATOR` only generates the MPC/DPC
+classes; the model registration and hub activation live in `CL_RSODP_ODATA_ODP_OUT_GA`,
+which is driven by the SEGW guided-activity UI.
+
+`scripts/sap/zcl_odp_provision.abap` does the same three steps headlessly:
+
+1. `CL_RSODP_ODATA_GENERATOR->GENERATE_CLASSES` — generate MPC/DPC
+2. `/IWBEP/IF_REGISTER_MDL_SERVICE->REGISTER_SERVICE` — register model + service (backend)
+3. `/IWFND/CL_MGW_ACTIVATION_API->ACTIVATE_SERVICE` — add to the Gateway hub and activate the ICF node
+
+Run it with [erpl-adt](https://github.com/DataZooDE/erpl-adt):
+
+```bash
+export SAP_PASSWORD=...
+erpl-adt object create --type CLAS/OC --name ZCL_ODP_PROVISION --package '$TMP' \
+    --description 'ODP provisioning'
+erpl-adt source write ZCL_ODP_PROVISION --type CLAS --file scripts/sap/zcl_odp_provision.abap
+erpl-adt activate ZCL_ODP_PROVISION
+erpl-adt object run ZCL_ODP_PROVISION      # -> generate rc=0 / register OK / activate OK
+```
+
+Then point the tests at it:
+
+```bash
+make test_debug_sap ERPL_SAP_ODP_SERVICE=Z_ODP_FCT_SRV \
+                    ERPL_SAP_ODP_ENTITY_SET=FactsOfZJRODPVSQL
+```
+
+**Things that cost time the first time:**
+
+- The ODP name comes from the CDS view's **SQL view name**, not the CDS name, plus a
+  category suffix: `$F` for `@Analytics.dataCategory: #CUBE`, `$P` for `#DIMENSION`,
+  `$T` for `#TEXT`. List them with
+  `SELECT viewname, odpname FROM rsodpabapcdsextb( p_langu = @sy-langu )` — note that view
+  takes a **parameter**, and forgetting it fails activation with the unhelpful
+  *"The parameter P_LANGU was not bound"*.
+- Everything must live in `$TMP`. The `@Analytics.dataExtraction.*` annotations and the
+  classic ODP APIs are not released for ABAP Cloud, so a HOME-tier package rejects them
+  on an ABAP Cloud developer trial.
+- A source CDS view is provided as `scripts/sap/zjr_odp_v.ddls.abap` over the table in
+  `scripts/sap/zjr_odp_data.tabl.abap`, for a fixture whose contents you control.
+- **Delta is a separate matter.** `RODPS_REPL_ODP_GET_DETAIL` reports
+  `supports_delta = ' '` for ABAP-CDS sources on this system even with
+  `@Analytics.dataExtraction.delta.byElement`, so SAP returns no `__delta` link and no
+  `DeltaLinksOf*` entity set is generated (`CL_RSODP_ODATA_ODP_OUT_MPC` guards it with
+  `CHECK i_supports_delta = ...`). The reader correctly stays in initial-load mode and
+  logs *"change tracking not established"*. Testing the delta lifecycle end to end needs a
+  genuinely delta-capable ODP (CDC-based extraction, or a BW/SAPI source).
+

--- a/scripts/sap/zcl_odp_provision.abap
+++ b/scripts/sap/zcl_odp_provision.abap
@@ -1,0 +1,109 @@
+* Provision an ODP OData service on an SAP system, headlessly.
+*
+* SAP ships no non-UI entry point for this: CL_RSODP_ODATA_GENERATOR only generates the
+* MPC/DPC classes, and everything around it (model, service registration, hub activation)
+* lives in CL_RSODP_ODATA_ODP_OUT_GA, which is driven by the SEGW guided-activity UI.
+* This class performs the same three steps directly:
+*
+*   1. CL_RSODP_ODATA_GENERATOR->GENERATE_CLASSES      - generate MPC/DPC
+*   2. /IWBEP/IF_REGISTER_MDL_SERVICE->REGISTER_SERVICE - register model + service (backend)
+*   3. /IWFND/CL_MGW_ACTIVATION_API->ACTIVATE_SERVICE   - add to the Gateway hub + ICF node
+*
+* Run it with erpl-adt:
+*   erpl-adt object create --type CLAS/OC --name ZCL_ODP_PROVISION --package '$TMP' \
+*       --description 'ODP provisioning'
+*   erpl-adt source write ZCL_ODP_PROVISION --type CLAS --file zcl_odp_provision.abap
+*   erpl-adt activate ZCL_ODP_PROVISION
+*   erpl-adt object run ZCL_ODP_PROVISION
+*
+* Adjust the constants and the ODP name below. The ODP name is derived from the CDS view's
+* SQL VIEW name (not the CDS name) plus a category suffix: $F for @Analytics.dataCategory
+* #CUBE, $P for #DIMENSION, $T for #TEXT. Query the available ones with
+*   SELECT viewname, odpname FROM rsodpabapcdsextb( p_langu = @sy-langu ).
+*
+* $TMP is deliberate: the extraction annotations and the classic ODP APIs are not released
+* for ABAP Cloud, so a HOME-tier package rejects them on an ABAP Cloud developer trial.
+
+CLASS zcl_odp_provision DEFINITION PUBLIC FINAL CREATE PUBLIC.
+  PUBLIC SECTION.
+    INTERFACES if_oo_adt_classrun.
+ENDCLASS.
+
+CLASS zcl_odp_provision IMPLEMENTATION.
+  METHOD if_oo_adt_classrun~main.
+
+    CONSTANTS lc_model   TYPE /iwbep/med_mdl_technical_name VALUE 'Z_ODP_FCT_MDL'.
+    CONSTANTS lc_service TYPE /iwbep/med_grp_technical_name VALUE 'Z_ODP_FCT_SRV'.
+    CONSTANTS lc_mpc     TYPE seoclsname VALUE 'ZCL_Z_ODP_FCT_MPC'.
+    CONSTANTS lc_dpc     TYPE seoclsname VALUE 'ZCL_Z_ODP_FCT_DPC'.
+
+    DATA lt_odp TYPE cl_rsodp_odata_odp_out_mpc=>tt_odp.
+    DATA ls_odp TYPE cl_rsodp_odata_odp_out_mpc=>ts_odp.
+    DATA lv_rc  TYPE sysubrc.
+
+    ls_odp-odpname = 'ZJRODPVSQL$F'.              APPEND ls_odp TO lt_odp.
+
+    NEW cl_rsodp_odata_generator( )->generate_classes(
+      EXPORTING
+        i_corrnr          = ''
+        i_devclass        = '$TMP'
+        i_model_name      = lc_model
+        i_model_version   = '0001'
+        i_service_name    = lc_service
+        i_service_version = '0001'
+        i_mpc_name        = lc_mpc
+        i_dpc_name        = lc_dpc
+        i_context         = 'ABAP_CDS'
+        i_t_odp           = lt_odp
+      IMPORTING
+        e_rc              = lv_rc ).
+    out->write( |generate_classes rc = { lv_rc }| ).
+    IF lv_rc <> 0.
+      RETURN.
+    ENDIF.
+
+    DATA lv_transport TYPE trkorr.
+    DATA lv_package   TYPE devclass VALUE '$TMP'.
+    TRY.
+        CAST /iwbep/if_register_mdl_service( NEW /iwbep/cl_register_mdl_service( ) )->register_service(
+          EXPORTING
+            iv_service_technical_name = lc_service
+            iv_service_version        = '0001'
+            iv_service_external_name  = 'Z_ODP_FCT_SRV'
+            iv_model_technical_name   = lc_model
+            iv_model_version          = '0001'
+            iv_model_provider_class   = lc_mpc
+            iv_data_provider_class    = lc_dpc
+            iv_model_description      = 'ODP jr model'
+            iv_service_description    = 'ODP jr service'
+          CHANGING
+            cv_transport              = lv_transport
+            cv_package                = lv_package ).
+        out->write( 'register_service: OK' ).
+      CATCH /iwbep/cx_mgw_med_exception INTO DATA(lx_reg).
+        out->write( |register_service failed: { lx_reg->get_text( ) }| ).
+        RETURN.
+    ENDTRY.
+
+    DATA lv_srg  TYPE /iwfnd/med_mdl_srg_identifier.
+    DATA lv_tech TYPE /iwfnd/med_mdl_srg_name.
+    TRY.
+        /iwfnd/cl_mgw_activation_api=>get_instance( )->activate_service(
+          EXPORTING
+            iv_service_name         = lc_service
+            iv_service_version      = '0001'
+            iv_system_alias         = 'LOCAL'
+            iv_package              = '$TMP'
+            iv_default_client       = abap_true
+            iv_do_activate_icf_node = abap_true
+            iv_suppress_dialog      = abap_true
+          IMPORTING
+            ev_srg_identifier       = lv_srg
+            ev_tech_service_name    = lv_tech ).
+        out->write( |activate_service OK; srg={ lv_srg }| ).
+      CATCH /iwfnd/cx_med_remote INTO DATA(lx_act).
+        out->write( |activate_service failed: { lx_act->get_text( ) }| ).
+    ENDTRY.
+
+  ENDMETHOD.
+ENDCLASS.

--- a/scripts/sap/zjr_odp_data.tabl.abap
+++ b/scripts/sap/zjr_odp_data.tabl.abap
@@ -1,0 +1,12 @@
+@EndUserText.label : 'ODP delta test data'
+@AbapCatalog.enhancement.category : #NOT_EXTENSIBLE
+@AbapCatalog.tableCategory : #TRANSPARENT
+@AbapCatalog.deliveryClass : #A
+@AbapCatalog.dataMaintenance : #RESTRICTED
+define table zjr_odp_data {
+  key client   : abap.clnt not null;
+  key item_id  : abap.char(10) not null;
+  item_name    : abap.char(40);
+  item_value   : abap.int4;
+  changed_at   : timestampl;
+}

--- a/scripts/sap/zjr_odp_v.ddls.abap
+++ b/scripts/sap/zjr_odp_v.ddls.abap
@@ -1,0 +1,14 @@
+@AbapCatalog.sqlViewName: 'ZJRODPVSQL'
+@AbapCatalog.compiler.compareFilter: true
+@AccessControl.authorizationCheck: #NOT_REQUIRED
+@EndUserText.label: 'ODP delta test view'
+@Analytics.dataCategory: #CUBE
+@Analytics.dataExtraction.enabled: true
+@Analytics.dataExtraction.delta.byElement.name: 'changed_at'
+@Analytics.dataExtraction.delta.byElement.maxDelayInSeconds: 1800
+define view ZJR_ODP_V as select from zjr_odp_data {
+  key item_id    as ItemId,
+      item_name  as ItemName,
+      item_value as ItemValue,
+      changed_at as ChangedAt
+}

--- a/test/sql/sap/odp_odata_read.test
+++ b/test/sql/sap/odp_odata_read.test
@@ -22,6 +22,15 @@ require-env ERPL_SAP_ODP_SERVICE
 
 require-env ERPL_SAP_ODP_ENTITY_SET
 
+# ODP delta tokens are refused an in-memory catalog on purpose (GitHub #92): they would
+# vanish at session end and turn every later read into a silent full extraction. A
+# sqllogictest session is in-memory, so the state has to live in a real file.
+statement ok
+ATTACH '__TEST_DIR__/odp_state.db' AS odp_state;
+
+statement ok
+USE odp_state;
+
 statement ok
 CREATE SECRET odp_odata_read_secret (
 	TYPE http_basic,


### PR DESCRIPTION
The ODP tests were gated on `ERPL_SAP_ODP_SERVICE` because no ODP service existed to run them against. **One now exists**, provisioned headlessly on the A4H sandbox, and the tests pass against it.

### The read test could never have passed
It asked for ODP data from an in-memory catalog, which `odp_odata_read` refuses on purpose (#92) — delta tokens stored there vanish at session end and silently turn every later read into a full extraction. A sqllogictest session is in-memory, so the test failed with the guard's own error rather than exercising anything. It now attaches a database file under `__TEST_DIR__`.

### Provisioning
SAP ships **no non-UI entry point** for creating an ODP OData service: `CL_RSODP_ODATA_GENERATOR` only generates the MPC/DPC classes; model registration and hub activation live in `CL_RSODP_ODATA_ODP_OUT_GA`, driven by the SEGW guided-activity UI.

`scripts/sap/zcl_odp_provision.abap` performs the same three steps directly, run via [erpl-adt](https://github.com/DataZooDE/erpl-adt):

1. `CL_RSODP_ODATA_GENERATOR->GENERATE_CLASSES`
2. `/IWBEP/IF_REGISTER_MDL_SERVICE->REGISTER_SERVICE`
3. `/IWFND/CL_MGW_ACTIVATION_API->ACTIVATE_SERVICE`

A CDS view and table are included so the fixture's contents are ours to control.

### Verified live
```
odp_odata_show  -> Z_ODP_FCT_SRV_0001 | FACTSOFZJRODPVSQL | .../FactsOfZJRODPVSQL
odp_odata_read  -> rows returned from a real ODP initial load
SAP tier        -> 37 assertions, 1 skipped, 0 failed
full SQL suite  -> 454 assertions, 0 failed
```

### Honest limitation, documented
Delta is **not** covered end to end. `RODPS_REPL_ODP_GET_DETAIL` reports `supports_delta = ' '` for ABAP-CDS sources on this system even with `@Analytics.dataExtraction.delta.byElement`, so SAP returns no `__delta` link and no `DeltaLinksOf*` entity set is generated (`CL_RSODP_ODATA_ODP_OUT_MPC` guards it with `CHECK i_supports_delta`). The reader correctly stays in initial-load mode and warns "change tracking not established" — verified as correct behaviour, not a bug. Closing the delta gap needs a CDC-based or BW/SAPI source.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791691620&installation_model_id=425457&pr_number=162&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F162&signature=1e878559de3ac95d953c589a0aab92c5ec1d0009677eb9b7212d7a0fcb639854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->