### PR TITLE
fix: paging ceiling and progress accounting

### DIFF
--- a/src/include/odata_client.hpp
+++ b/src/include/odata_client.hpp
@@ -203,7 +203,14 @@ public:
     // hands back, so the number of requests is bounded by the service and not by
     // us. A service that repeats a link (SAP ODP is known to echo the same
     // $skiptoken on a "!deltatoken" response) would otherwise spin forever.
-    // This is the hard stop on how many pages one client will ever fetch.
+    // This is the hard stop on how many pages one client will ever fetch, and it
+    // is the ONLY definition: ODataEntitySetClient used to redeclare it as
+    // 100000, and because the guard lives in that subclass the enforced ceiling
+    // was ten times the documented one. See GitHub #161.
+    //
+    // The repeated-next-link check above catches the common runaway far earlier;
+    // this is the backstop for a service that keeps advertising *different*
+    // links forever.
     static constexpr idx_t MAX_PAGE_REQUESTS = 10000;
 
 protected:
@@ -480,13 +487,6 @@ public:
 
 private:
     EntitySet GetCurrentEntitySetType();
-
-    // Server-driven paging guard. A service that echoes back a next link
-    // identical to the request that produced it (SAP ODP repeating a
-    // "!deltatoken"/"$skiptoken", or a legal empty page that still carries a
-    // next link) would otherwise spin forever issuing HTTP requests.
-    static constexpr idx_t MAX_PAGE_REQUESTS = 100000;
-    idx_t page_request_count = 0;
 
     // For Datasphere input parameters: storage for input parameters
     std::map<std::string, std::string> input_parameters;

--- a/src/odata_client.cpp
+++ b/src/odata_client.cpp
@@ -209,9 +209,15 @@ std::shared_ptr<ODataEntitySetResponse> ODataEntitySetClient::Get(bool get_next)
         }
 
         if (page_requests >= MAX_PAGE_REQUESTS) {
+            // Say what to do about it. A caller who hits this on a legitimately huge
+            // extraction has no way to guess that a narrower query or a larger server page
+            // size is the answer, and a bare "limit exceeded" reads like a bug in us.
             throw std::runtime_error(
                 "OData server-driven paging exceeded the limit of " + std::to_string(MAX_PAGE_REQUESTS) +
-                " pages; the service keeps advertising a next link. Last URL: " + resolved_next_url.ToString());
+                " pages; the service keeps advertising a next link. Either the service is "
+                "looping, or this extraction genuinely needs more pages than the limit "
+                "allows - in which case narrow the read with a filter, or ask the service "
+                "for larger pages. Last URL: " + resolved_next_url.ToString());
         }
         page_requests++;
 

--- a/src/odata_read_scan_state.cpp
+++ b/src/odata_read_scan_state.cpp
@@ -39,6 +39,11 @@ void ODataProgressTracker::IncrementRowsFetched(uint64_t count) {
     rows_fetched_ += count;
 }
 
+// Despite the name, the value is a PERCENTAGE (0-100), not a fraction. That is what
+// DuckDB's table-function contract wants: PhysicalTableScan::GetProgress assigns the
+// returned value to ProgressData::done and sets ProgressData::total = 100.0
+// (duckdb/src/execution/operator/scan/physical_table_scan.cpp). A negative value means
+// "unknown" and makes DuckDB hide the progress bar.
 double ODataProgressTracker::GetProgressFraction() const {
     if (!has_total_ || total_count_ == 0) {
         return -1.0; // unknown -> DuckDB will not show progress
@@ -217,7 +222,13 @@ void ODataReadBindData::ProcessPageResponse(
     const auto row_count = page_rows.size();
     row_buffer->AddRows(std::move(page_rows));
     row_buffer->SetHasNextPage(response->NextUrl().has_value());
-    progress_tracker->IncrementRowsFetched(row_count);
+    // Deliberately no IncrementRowsFetched here. Progress counts rows HANDED TO DuckDB,
+    // and UpdateProgressTracking already counts them as they are emitted. Counting them
+    // again on arrival double-counted every page after the first - the first page is
+    // buffered by BufferFirstPageFromResponse, which never incremented - so progress
+    // saturated at a clamped 100% while barely two thirds of the rows had been delivered.
+    // See GitHub #160.
+    (void)row_count;
 }
 
 idx_t ODataReadBindData::EmitRowsToOutput(duckdb::DataChunk &output, const SchemaInfo& schema_info) {

--- a/test/cpp/test_odata_client.cpp
+++ b/test/cpp/test_odata_client.cpp
@@ -183,3 +183,13 @@ TEST_CASE("Test ThrowIfNoResponse guards the null response path", "[odata_client
     HttpResponse error_response(HttpMethod::GET, HttpUrl("https://mock.odata.service/test"), 401);
     REQUIRE_NOTHROW(ThrowIfNoResponse(&error_response, "https://mock.odata.service/test"));
 }
+
+// GitHub #161: ODataEntitySetClient redeclared MAX_PAGE_REQUESTS as 100000 while the base
+// class documented 10000, and the guard lives in the derived class - so the enforced
+// ceiling was ten times the documented one, with a dead unused counter beside it. The
+// constant is now single-sourced; this pins the value the guard actually uses.
+TEST_CASE("the server-driven paging ceiling is single-sourced", "[odata_client][paging]") {
+    REQUIRE(ODataEntitySetClient::MAX_PAGE_REQUESTS == 10000);
+    REQUIRE(ODataEntitySetClient::MAX_PAGE_REQUESTS ==
+            ODataClient<ODataEntitySetResponse>::MAX_PAGE_REQUESTS);
+}

--- a/test/cpp/test_odata_progress.cpp
+++ b/test/cpp/test_odata_progress.cpp
@@ -1,0 +1,117 @@
+// GitHub #160: rows were counted twice - once when a page was buffered
+// (ProcessPageResponse) and again when the rows were emitted
+// (UpdateProgressTracking). Progress therefore over-reported by up to 2x and
+// saturated early. GetProgressFraction clamps to 100, so the only way to observe
+// it is to sample progress mid-scan, which needs a service large enough to emit
+// more than one vector.
+
+#include "catch.hpp"
+#include "duckdb.hpp"
+
+#include "odata_client.hpp"
+#include "odata_read_functions.hpp"
+#include "odata_test_server.hpp"
+
+#include <memory>
+#include <sstream>
+#include <string>
+
+using erpl_web::HttpClient;
+using erpl_web::HttpParams;
+using erpl_web::HttpUrl;
+using erpl_web::ODataEntitySetClient;
+using erpl_web::ODataReadBindData;
+using erpl_web::ODataVersion;
+using erpl_web::test_support::CannedResponse;
+using erpl_web::test_support::ODataTestServer;
+
+namespace {
+
+const char *const PROGRESS_EDMX = R"(<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Test" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Row">
+        <Key><PropertyRef Name="id"/></Key>
+        <Property Name="id" Type="Edm.String" Nullable="false"/>
+      </EntityType>
+      <EntityContainer Name="Container">
+        <EntitySet Name="Rows" EntityType="Test.Row"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>)";
+
+// A page carrying @odata.count, which is what gives the tracker a denominator.
+std::string MakeCountedPage(const std::string &context, idx_t first_id, idx_t row_count,
+                            idx_t total_count, const std::string &next_link)
+{
+    std::ostringstream out;
+    out << R"({"@odata.context":")" << context << R"(","@odata.count":)" << total_count
+        << R"(,"value":[)";
+    for (idx_t i = 0; i < row_count; i++) {
+        if (i > 0) {
+            out << ",";
+        }
+        out << R"({"id":"row-)" << (first_id + i) << R"("})";
+    }
+    out << "]";
+    if (!next_link.empty()) {
+        out << R"(,"@odata.nextLink":")" << next_link << R"(")";
+    }
+    out << "}";
+    return out.str();
+}
+
+}  // namespace
+
+TEST_CASE("progress reflects rows emitted, not rows counted twice", "[odata_progress]") {
+    // The first page must be SMALLER than a vector, so the scan pulls page two before it
+    // emits anything. That second page is the one that goes through ProcessPageResponse,
+    // which is where the duplicate increment lived; a first page big enough to fill a
+    // vector on its own never exercises it.
+    constexpr idx_t FIRST_PAGE_ROWS = 1500;
+    constexpr idx_t SECOND_PAGE_ROWS = 1600;
+    constexpr idx_t TOTAL_ROWS = FIRST_PAGE_ROWS + SECOND_PAGE_ROWS;
+
+    ODataTestServer server;
+    const std::string entity_url = server.Url("/prog/Rows");
+    const std::string context = server.Url("/prog/$metadata") + "#Rows";
+
+    server.ServeMetadata("/prog/$metadata", PROGRESS_EDMX);
+    server.OnMatch(
+        [](const erpl_web::test_support::RecordedRequest &request) {
+            return request.path == "/prog/Rows" && request.QueryParam("$skiptoken") == "2";
+        },
+        CannedResponse::Json(MakeCountedPage(context, FIRST_PAGE_ROWS, SECOND_PAGE_ROWS,
+                                             TOTAL_ROWS, "")));
+    server.OnPath("/prog/Rows",
+                  CannedResponse::Json(MakeCountedPage(context, 0, FIRST_PAGE_ROWS, TOTAL_ROWS,
+                                                       entity_url + "?$format=json&$skiptoken=2")));
+
+    HttpParams params;
+    auto http_client = std::make_shared<HttpClient>(params);
+    auto client = std::make_shared<ODataEntitySetClient>(http_client, HttpUrl(entity_url), nullptr);
+    client->SetODataVersionDirectly(ODataVersion::V4);
+
+    auto bind_data = ODataReadBindData::FromEntitySetClient(client, "");
+    auto types = bind_data->GetResultTypes();
+    REQUIRE_FALSE(types.empty());
+
+    duckdb::vector<duckdb::LogicalType> chunk_types(types.begin(), types.end());
+    duckdb::DataChunk chunk;
+    chunk.Initialize(duckdb::Allocator::DefaultAllocator(), chunk_types);
+
+    chunk.Reset();
+    const auto emitted = bind_data->FetchNextResult(chunk);
+    REQUIRE(emitted > 0);
+    REQUIRE(emitted <= STANDARD_VECTOR_SIZE);
+
+    // Whatever share of the rows has actually been emitted, progress must be about that
+    // share. Counting each row twice drove this past 100 (clamped) while barely two thirds
+    // of the rows had been handed over.
+    const double expected = 100.0 * static_cast<double>(emitted) / static_cast<double>(TOTAL_ROWS);
+    const double reported = bind_data->GetProgressFraction();
+    INFO("emitted=" << emitted << " reported=" << reported << " expected=~" << expected);
+    REQUIRE(reported == Approx(expected).margin(1.0));
+}


### PR DESCRIPTION
Two correctness cleanups from the crew review, both with the decisions you settled.

### #161 — the enforced paging ceiling was 10x the documented one
`ODataEntitySetClient` redeclared `MAX_PAGE_REQUESTS` as **100000** while the base class documented **10000**. The guard lives in the subclass, so the name resolved to the subclass constant. A dead `page_request_count` sat beside it, never read or written.

Now single-sourced at the documented **10000**. That is a real behaviour change — an extraction genuinely needing more than 10000 pages (100-row pages over a 10M-row set) now fails where it ran before. Per your call, the contract wins; the error now says what to do about it instead of just stopping:

> *…Either the service is looping, or this extraction genuinely needs more pages than the limit allows — in which case narrow the read with a filter, or ask the service for larger pages.*

The test asserts the value the guard actually uses. **Before this change it did not compile**, because the shadowing constant was private — which is itself the defect.

### #160 — progress counted every row twice
Counted once on arrival (`ProcessPageResponse`) and again on emit (`UpdateProgressTracking`). Every page after the first was double-counted, so progress hit a clamped 100% while ~66% of rows had been delivered.

Observing it needs a first page **smaller** than a vector, so the scan pulls page two before emitting — a first page that fills a vector alone never reaches the duplicated call. The new test serves 1500 then 1600 rows with `@odata.count`:

```
before: emitted=2048 reported=100   expected=~66.06
after:  emitted=2048 reported=66.06
```

The open scale question is answered from DuckDB's source rather than guessed: `PhysicalTableScan::GetProgress` assigns the value to `ProgressData::done` with `total = 100.0`, so **0–100 is correct** and only the method name was misleading. Documented rather than renamed.

421 C++ cases / 2127 assertions green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791724060&installation_model_id=425457&pr_number=163&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F163&signature=b698bd789fdb1d261fa26e13d62f4f3ebf06e59131c79bd4bbd319914fdbbd8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->