### PR TITLE
fix: pick up the credential-aware HTTP response cache

### DIFF
--- a/test/cpp/test_http_cache_credentials.cpp
+++ b/test/cpp/test_http_cache_credentials.cpp
@@ -1,0 +1,101 @@
+// The process-wide HTTP response cache keys on method + URL + body hash. Credentials are
+// not part of that key, so two callers holding different secrets for the same URL collided
+// inside one process and the second was served the first one's rows. The OData readers no
+// longer route through this cache, but every other caller still does.
+
+#include "catch.hpp"
+#include "duckdb.hpp"
+
+#include "datazoo/oauth2/http_client.hpp"
+#include "odata_test_server.hpp"
+
+#include <string>
+
+using erpl_web::CachingHttpClient;
+using erpl_web::HttpClient;
+using erpl_web::HttpMethod;
+using erpl_web::HttpParams;
+using erpl_web::HttpRequest;
+using erpl_web::HttpUrl;
+using erpl_web::test_support::CannedResponse;
+using erpl_web::test_support::ODataTestServer;
+
+namespace {
+
+HttpRequest MakeGet(const std::string &url, const std::string &authorization)
+{
+    HttpRequest request(HttpMethod::GET, HttpUrl(url));
+    if (!authorization.empty()) {
+        request.headers["Authorization"] = authorization;
+    }
+    return request;
+}
+
+}  // namespace
+
+TEST_CASE("the cache key distinguishes requests made under different credentials",
+          "[http_cache][security]") {
+    const std::string url = "https://example.invalid/service/Entity";
+
+    auto alice = MakeGet(url, "Basic YWxpY2U6cHc=");
+    auto bob = MakeGet(url, "Basic Ym9iOnB3");
+
+    REQUIRE(alice.ToCacheKey() != bob.ToCacheKey());
+}
+
+TEST_CASE("two callers with different credentials each reach the server",
+          "[http_cache][security]") {
+    ODataTestServer server;
+    server.OnPath("/svc/Entity", CannedResponse::Json(R"({"value":[]})"));
+
+    HttpParams params;
+    auto caching_client = std::make_shared<CachingHttpClient>(std::make_shared<HttpClient>(params));
+
+    auto alice = MakeGet(server.Url("/svc/Entity"), "Basic YWxpY2U6cHc=");
+    auto bob = MakeGet(server.Url("/svc/Entity"), "Basic Ym9iOnB3");
+
+    auto first = caching_client->SendRequest(alice);
+    REQUIRE(first != nullptr);
+    auto second = caching_client->SendRequest(bob);
+    REQUIRE(second != nullptr);
+
+    // Before the fix the second call was answered out of the cache and never left the
+    // process, handing Bob whatever Alice's credentials had fetched.
+    REQUIRE(server.RequestsFor("/svc/Entity").size() == 2);
+}
+
+TEST_CASE("a credentialed response is not retained in the cache at all",
+          "[http_cache][security]") {
+    ODataTestServer server;
+    server.OnPath("/svc/Secret", CannedResponse::Json(R"({"value":[1]})"));
+
+    HttpParams params;
+    auto caching_client = std::make_shared<CachingHttpClient>(std::make_shared<HttpClient>(params));
+
+    auto request = MakeGet(server.Url("/svc/Secret"), "Bearer sometoken");
+    auto response = caching_client->SendRequest(request);
+    REQUIRE(response != nullptr);
+
+    // Not merely keyed apart - a response fetched with credentials is never stored, so it
+    // cannot be served to anyone, whatever their key happens to hash to.
+    REQUIRE_FALSE(caching_client->IsInCache(request));
+
+    auto repeated = caching_client->SendRequest(request);
+    REQUIRE(repeated != nullptr);
+    REQUIRE(server.RequestsFor("/svc/Secret").size() == 2);
+}
+
+TEST_CASE("an uncredentialed response is still cached", "[http_cache]") {
+    // The fix must not quietly turn the cache off for everyone.
+    ODataTestServer server;
+    server.OnPath("/svc/Public", CannedResponse::Json(R"({"value":[2]})"));
+
+    HttpParams params;
+    auto caching_client = std::make_shared<CachingHttpClient>(std::make_shared<HttpClient>(params));
+
+    auto request = MakeGet(server.Url("/svc/Public"), "");
+    REQUIRE(caching_client->SendRequest(request) != nullptr);
+    REQUIRE(caching_client->SendRequest(request) != nullptr);
+
+    REQUIRE(server.RequestsFor("/svc/Public").size() == 1);
+}


### PR DESCRIPTION
Bumps `datazoo-oauth2` to [the merged fix](https://github.com/DataZooDE/datazoo-oauth2/pull/6) and adds the tests that prove it.

`HttpRequest::ToCacheKey()` hashed method, URL and body — **not credentials** — and `HttpCache` is a process-wide singleton with a 30s TTL. Two callers holding secrets for different tenants of the same service URL collided, and the second was served the first one's rows.

The OData readers stopped routing through that cache in #154, but every other caller — `http_get`, the Graph and Datasphere clients — still does, so the defect stayed live for them.

### Tests live here, not in the submodule
`http_client.cpp` needs DuckDB's vendored httplib, so it sits outside datazoo-oauth2's standalone Catch2 target. Against the previous submodule commit, three of these four fail:

| case | before | after |
|---|---|---|
| cache key differs per credential | fail | pass |
| two credentialed callers each reach the server | fail | pass |
| credentialed response not retained | fail | pass |
| uncredentialed response still cached | pass | pass |

That last one is the guard against over-correcting: the fix scopes the cache rather than disabling it.

419 C++ cases / 2121 assertions green against the merged submodule.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791733105&installation_model_id=425457&pr_number=164&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F164&signature=d360ce8fa2a4542a7fc81a5522aab724e56b9292d0229bc648239a42cb81ebbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->