### PR TITLE
perf: bound the expand cache, and record ODP audit totals once

### DIFF
--- a/src/include/odata_read_functions.hpp
+++ b/src/include/odata_read_functions.hpp
@@ -311,7 +311,18 @@ public:
     
     // Core extraction methods
     void ExtractExpandedDataFromResponse(const std::string& response_content);
-    duckdb::Value ExtractExpandedDataForRow(const std::string& row_id, const std::string& expand_path);
+    // row_index is the scan-global index of the row being emitted. It used to be passed as
+    // a string and parsed back per cell; it is an index, so it is typed as one.
+    duckdb::Value ExtractExpandedDataForRow(duckdb::idx_t row_index, const std::string& expand_path);
+
+    // Release the expanded values for every row before row_index.
+    //
+    // Rows are emitted strictly in order, so once the scan has moved past a row its
+    // expanded values can never be asked for again. Without this the cache held one
+    // duckdb::Value per row per expand path for the WHOLE scan - memory grew with total
+    // rows rather than with the rows still in flight, which over a large $expand read is
+    // the entire expanded column. See GitHub #159.
+    void ReleaseExpandedDataBefore(duckdb::idx_t row_index);
     
     // Schema management
     void SetExpandedDataSchema(const std::vector<std::string>& expand_paths);
@@ -356,6 +367,10 @@ private:
     std::vector<std::string> expanded_data_schema;
     std::vector<duckdb::LogicalType> expanded_data_types;
     std::map<std::string, std::vector<duckdb::Value>> expanded_data_cache;
+
+    // Scan-global index of the row held at element 0 of each cache vector. Released rows
+    // are erased from the front, so the vectors are indexed relative to this.
+    duckdb::idx_t expanded_data_base_row_ = 0;
     // Top-level expanded column names (iterate columns)
     std::vector<std::string> expand_paths;
     // Full nested expand paths for recursive inference

--- a/src/include/odp_odata_read_bind_data.hpp
+++ b/src/include/odp_odata_read_bind_data.hpp
@@ -174,6 +174,11 @@ public:
     void FinalizeScan();
 
 private:
+    void WriteAuditTotals();
+
+public:
+
+private:
     // ========================================================================
     // Core Components (Composition Pattern)
     // ========================================================================
@@ -198,6 +203,14 @@ private:
     bool initialized_;
     bool first_fetch_completed_;
     int64_t current_audit_id_;
+
+    // Totals for the audit row, accumulated across the whole extraction and written once.
+    // The audit UPDATE assigns rather than adds, so writing per chunk left the row holding
+    // the LAST chunk's count instead of the total - useless for the one thing the audit
+    // table exists for: checking that a package was fully delivered. See GitHub #158.
+    int64_t audit_rows_fetched_ = 0;
+    int64_t audit_package_size_bytes_ = 0;
+    bool audit_written_ = false;
 
     // Incremental pagination state
     // When a multi-page response is being consumed, pending_next_url_ holds the

--- a/src/odata_data_extractor.cpp
+++ b/src/odata_data_extractor.cpp
@@ -286,18 +286,21 @@ void ODataDataExtractor::ExtractExpandedDataFromResponse(
 }
 
 duckdb::Value
-ODataDataExtractor::ExtractExpandedDataForRow(const std::string &row_id,
+ODataDataExtractor::ExtractExpandedDataForRow(duckdb::idx_t row_index,
                                               const std::string &expand_path) {
     auto it = expanded_data_cache.find(expand_path);
     if (it != expanded_data_cache.end()) {
-        // Return value for this row index if available
-        try {
-            size_t row_index = static_cast<size_t>(std::stoull(row_id));
-            if (row_index < it->second.size()) {
-                return it->second[row_index];
+        // The vectors are indexed relative to the oldest row still held: anything before
+        // that has been released and must read as NULL rather than as whatever value now
+        // occupies that offset.
+        if (row_index >= expanded_data_base_row_) {
+            const auto local_index = static_cast<size_t>(row_index - expanded_data_base_row_);
+            if (local_index < it->second.size()) {
+                return it->second[local_index];
             }
-        } catch (...) {
-            // ignore parse errors, fall through to NULL
+        }
+        {
+            // fall through to NULL
         }
     }
     return duckdb::Value();
@@ -1094,8 +1097,22 @@ void ODataDataExtractor::EnableCompression(bool enable) {
                        std::string(enable ? "enabled" : "disabled"));
 }
 
+void ODataDataExtractor::ReleaseExpandedDataBefore(duckdb::idx_t row_index) {
+    if (row_index <= expanded_data_base_row_) {
+        return;
+    }
+    const auto to_release = static_cast<size_t>(row_index - expanded_data_base_row_);
+
+    for (auto &[path, values] : expanded_data_cache) {
+        const auto erase_count = std::min(to_release, values.size());
+        values.erase(values.begin(), values.begin() + static_cast<std::ptrdiff_t>(erase_count));
+    }
+    expanded_data_base_row_ = row_index;
+}
+
 void ODataDataExtractor::ClearCache() {
     expanded_data_cache.clear();
+    expanded_data_base_row_ = 0;
     ERPL_TRACE_DEBUG("DATA_EXTRACTOR", "Cleared expanded data cache");
 }
 

--- a/src/odata_read_scan_state.cpp
+++ b/src/odata_read_scan_state.cpp
@@ -231,6 +231,14 @@ idx_t ODataReadBindData::EmitRowsToOutput(duckdb::DataChunk &output, const Schem
     }
     
     output.SetCardinality(to_emit);
+
+    // Rows are emitted strictly in order, so everything before the current position can
+    // never be read again. Releasing here bounds the expand cache to the rows still in
+    // flight instead of the whole scan (GitHub #159).
+    if (data_extractor && HasExpandedData()) {
+        data_extractor->ReleaseExpandedDataBefore(static_cast<duckdb::idx_t>(emitted_row_index_));
+    }
+
     return to_emit;
 }
 
@@ -306,9 +314,9 @@ duckdb::Value ODataReadBindData::GetExpandedColumnValue(
     if (expand_index < data_extractor->GetExpandedDataSchema().size()) {
         std::string expand_path = data_extractor->GetExpandedDataSchema()[expand_index];
         
-        // Use global emitted_row_index_ to align with how cache was filled (per input row)
+        // The cache is filled per input row, so the scan-global emitted index is the key.
         auto expand_data = data_extractor->ExtractExpandedDataForRow(
-            std::to_string(emitted_row_index_), expand_path);
+            static_cast<duckdb::idx_t>(emitted_row_index_), expand_path);
         
         if (!expand_data.IsNull()) {
             ERPL_TRACE_DEBUG("ODATA_SCAN", duckdb::StringUtil::Format("Setting expanded data for path '%s'", expand_path.c_str()));

--- a/src/odp_odata_read_bind_data.cpp
+++ b/src/odp_odata_read_bind_data.cpp
@@ -150,10 +150,14 @@ unsigned int OdpODataReadBindData::FetchNextResult(duckdb::DataChunk &output) {
 
         ERPL_TRACE_DEBUG("ODP_BIND_DATA", duckdb::StringUtil::Format("Fetched %u rows", rows_fetched));
 
-        if (current_audit_id_ > 0 && rows_fetched > 0) {
-            state_manager_->UpdateAuditEntry(current_audit_id_, 200, rows_fetched,
-                                           output.size() * output.GetTypes().size() * 8);
-        }
+        // Accumulate; the audit row is written once, when the scan finishes. Writing here
+        // meant one UPDATE per 2048 rows - each on a freshly constructed duckdb::Connection
+        // that takes the connection-manager lock - on the row-emission hot path, and
+        // because the UPDATE assigns rather than adds, the row ended up holding the last
+        // chunk's count rather than the total. See GitHub #158.
+        audit_rows_fetched_ += static_cast<int64_t>(rows_fetched);
+        audit_package_size_bytes_ +=
+            static_cast<int64_t>(output.size() * output.GetTypes().size() * 8);
 
         return rows_fetched;
         
@@ -463,6 +467,23 @@ void OdpODataReadBindData::ProcessRequestResult(const OdpRequestOrchestrator::Od
 
 void OdpODataReadBindData::FinalizeScan() {
     CommitStagedDeltaToken();
+    WriteAuditTotals();
+}
+
+void OdpODataReadBindData::WriteAuditTotals() {
+    if (current_audit_id_ <= 0 || audit_written_) {
+        return;
+    }
+    // Written once per extraction, with the totals the scan actually delivered. Guarded so
+    // a scan finalised more than once does not overwrite a complete row with a second,
+    // emptier one.
+    audit_written_ = true;
+    state_manager_->UpdateAuditEntry(current_audit_id_, 200, audit_rows_fetched_,
+                                     audit_package_size_bytes_);
+    ERPL_TRACE_DEBUG("ODP_BIND_DATA",
+                     duckdb::StringUtil::Format("Wrote audit totals: %lld rows, %lld bytes",
+                                                (long long)audit_rows_fetched_,
+                                                (long long)audit_package_size_bytes_));
 }
 
 void OdpODataReadBindData::CommitStagedDeltaToken() {

--- a/test/cpp/edm_sap_odp_bw_fact.xml
+++ b/test/cpp/edm_sap_odp_bw_fact.xml
@@ -1,18 +1,3 @@
-[jr@bigfox ~]$ http -a 'DEVELOPER:ABAPtr2023#00' 'http://localhost:50000/sap/opu/odata/sap/Z_ODP_BW_1_SRV/$metadata'
-HTTP/1.1 200 OK
-cache-control: max-age=0
-content-encoding: gzip
-content-length: 1695
-content-type: application/xml
-dataserviceversion: 2.0
-last-modified: Sun, 31 Aug 2025 06:05:40 GMT
-sap-perf-fesrec: 73959.000000
-sap-processing-info: ODataBEP=,crp=,RAL=,st=,MedCacheHub=Table,codeployed=X,softstate=
-sap-server: true
-set-cookie: sap-usercontext=sap-client=001; path=/
-set-cookie: MYSAPSSO2=AjQxMDMBABhEAEUAVgBFAEwATwBQAEUAUgAgACAAIAACAAYwADAAMQADABBBADQASAAgACAAIAAgACAABAAYMgAwADIANQAwADgAMwAxADAANgAzADMABQAEAAAACAYAAlgACQACRQD%2fAPswgfgGCSqGSIb3DQEHAqCB6jCB5wIBATELMAkGBSsOAwIaBQAwCwYJKoZIhvcNAQcBMYHHMIHEAgEBMBowDjEMMAoGA1UEAxMDQTRIAggKIBcCAhUJATAJBgUrDgMCGgUAoF0wGAYJKoZIhvcNAQkDMQsGCSqGSIb3DQEHATAcBgkqhkiG9w0BCQUxDxcNMjUwODMxMDYzMzI5WjAjBgkqhkiG9w0BCQQxFgQUqRkZLpehSuZ%21q5wsdubMXSPK%21QQwCQYHKoZIzjgEAwQuMCwCFHqcvCK0kNbqagCuwbbI%2frpRDP0bAhQgWHe%21poiQYLso3rGkAKBNkCwOTg%3d%3d; path=/; domain=localhost
-set-cookie: SAP_SESSIONID_A4H_001=uhiX_u6HoCQdBqptazGGQWhacS-GNBHwuKICQqwRAAI%3d; path=/
-
 <?xml version="1.0" encoding="utf-8"?>
 <edmx:Edmx xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns:sap="http://www.sap.com/Protocols/SAPData" Version="1.0">
   <edmx:DataServices m:DataServiceVersion="2.0">

--- a/test/cpp/test_conversion_failure_reporting.cpp
+++ b/test/cpp/test_conversion_failure_reporting.cpp
@@ -200,7 +200,7 @@ TEST_CASE("Expanded data never fabricates a zero", "[conversion_failure]")
         ]
     })");
 
-    auto row0 = extractor.ExtractExpandedDataForRow("0", "Numbers");
+    auto row0 = extractor.ExtractExpandedDataForRow(0, "Numbers");
     auto row0_children = duckdb::ListValue::GetChildren(row0);
     REQUIRE(row0_children.size() == 3);
     REQUIRE(row0_children[0].GetValue<int32_t>() == 1);
@@ -209,7 +209,7 @@ TEST_CASE("Expanded data never fabricates a zero", "[conversion_failure]")
     REQUIRE(row0_children[2].GetValue<int32_t>() == 3);
 
     // Cache alignment across rows survives the failure: row 1 is still row 1.
-    auto row1 = extractor.ExtractExpandedDataForRow("1", "Numbers");
+    auto row1 = extractor.ExtractExpandedDataForRow(1, "Numbers");
     auto row1_children = duckdb::ListValue::GetChildren(row1);
     REQUIRE(row1_children.size() == 2);
     REQUIRE(row1_children[0].GetValue<int32_t>() == 4);
@@ -237,7 +237,7 @@ TEST_CASE("Out-of-range integers are reported, not zeroed", "[conversion_failure
         "value": [ { "Counters": [4294967295] } ]
     })");
 
-    auto row0 = extractor.ExtractExpandedDataForRow("0", "Counters");
+    auto row0 = extractor.ExtractExpandedDataForRow(0, "Counters");
     auto children = duckdb::ListValue::GetChildren(row0);
     REQUIRE(children.size() == 1);
     REQUIRE(children[0].IsNull());

--- a/test/cpp/test_odata_data_extractor.cpp
+++ b/test/cpp/test_odata_data_extractor.cpp
@@ -75,6 +75,23 @@ static std::string BuildExpandedPayload(size_t order_count,
     return json;
 }
 
+
+// A page of `row_count` customers, each with one expanded order carrying a distinct id,
+// so a test can tell which row's expanded value it is looking at.
+static std::string BuildMultiRowPayload(size_t first_row, size_t row_count) {
+    std::string json = R"({"value":[)";
+    for (size_t i = 0; i < row_count; ++i) {
+        if (i > 0) {
+            json += ",";
+        }
+        const auto row = first_row + i;
+        json += R"({"id":"c)" + std::to_string(row) + R"(","Orders":[{"id":"o)" +
+                std::to_string(row) + R"(","amount":1,"total":2}]})";
+    }
+    json += "]}";
+    return json;
+}
+
 // ============================================================================
 // Expanded collections must be returned in full (GitHub #81)
 // ============================================================================
@@ -106,7 +123,7 @@ TEST_CASE("ODataDataExtractor - keeps every element of a large expanded collecti
     extractor.SetExpandedDataSchema({"Orders"});
     extractor.ExtractExpandedDataFromResponse(BuildExpandedPayload(ORDER_COUNT, "7", "8"));
 
-    auto orders = extractor.ExtractExpandedDataForRow("0", "Orders");
+    auto orders = extractor.ExtractExpandedDataForRow(0, "Orders");
     REQUIRE_FALSE(orders.IsNull());
     REQUIRE(orders.type().id() == duckdb::LogicalTypeId::LIST);
 
@@ -125,7 +142,7 @@ TEST_CASE("ODataDataExtractor - collections just under the former cap are unchan
     extractor.SetExpandedDataSchema({"Orders"});
     extractor.ExtractExpandedDataFromResponse(BuildExpandedPayload(ORDER_COUNT, "7", "8"));
 
-    auto orders = extractor.ExtractExpandedDataForRow("0", "Orders");
+    auto orders = extractor.ExtractExpandedDataForRow(0, "Orders");
     REQUIRE(duckdb::ListValue::GetChildren(orders).size() == ORDER_COUNT);
 }
 
@@ -144,7 +161,7 @@ TEST_CASE("ODataDataExtractor - rejects a value that does not fit an INTEGER col
     // The unrepresentable amount becomes a NULL in place; the rest of the
     // expanded row survives. Discarding the whole collection because one number
     // does not fit would throw away data that is perfectly good.
-    auto orders = extractor.ExtractExpandedDataForRow("0", "Orders");
+    auto orders = extractor.ExtractExpandedDataForRow(0, "Orders");
     REQUIRE_FALSE(orders.IsNull());
     auto &row = duckdb::StructValue::GetChildren(duckdb::ListValue::GetChildren(orders)[0]);
     REQUIRE(row[1].IsNull());
@@ -157,7 +174,7 @@ TEST_CASE("ODataDataExtractor - rejects a negative value below the INTEGER range
     extractor.SetExpandedDataSchema({"Orders"});
     extractor.ExtractExpandedDataFromResponse(BuildExpandedPayload(1, "-4000000000", "8"));
 
-    auto orders = extractor.ExtractExpandedDataForRow("0", "Orders");
+    auto orders = extractor.ExtractExpandedDataForRow(0, "Orders");
     REQUIRE_FALSE(orders.IsNull());
     auto &row = duckdb::StructValue::GetChildren(duckdb::ListValue::GetChildren(orders)[0]);
     REQUIRE(row[1].IsNull());
@@ -177,11 +194,11 @@ TEST_CASE("ODataDataExtractor - an out-of-range value does not shift later rows"
     extractor.ExtractExpandedDataFromResponse(json);
 
     // Row 0 keeps its shape with a NULL amount, so row 1 is still row 1.
-    auto first = extractor.ExtractExpandedDataForRow("0", "Orders");
+    auto first = extractor.ExtractExpandedDataForRow(0, "Orders");
     REQUIRE_FALSE(first.IsNull());
     REQUIRE(duckdb::StructValue::GetChildren(duckdb::ListValue::GetChildren(first)[0])[1].IsNull());
 
-    auto second = extractor.ExtractExpandedDataForRow("1", "Orders");
+    auto second = extractor.ExtractExpandedDataForRow(1, "Orders");
     REQUIRE_FALSE(second.IsNull());
     auto &children = duckdb::ListValue::GetChildren(second);
     REQUIRE(children.size() == 1);
@@ -193,7 +210,7 @@ TEST_CASE("ODataDataExtractor - accepts the INTEGER boundary values") {
     extractor.SetExpandedDataSchema({"Orders"});
     extractor.ExtractExpandedDataFromResponse(BuildExpandedPayload(1, "2147483647", "8"));
 
-    auto orders = extractor.ExtractExpandedDataForRow("0", "Orders");
+    auto orders = extractor.ExtractExpandedDataForRow(0, "Orders");
     auto &children = duckdb::ListValue::GetChildren(orders);
     REQUIRE(children.size() == 1);
 
@@ -209,10 +226,56 @@ TEST_CASE("ODataDataExtractor - keeps the full 64-bit width of a BIGINT column")
     extractor.ExtractExpandedDataFromResponse(
         BuildExpandedPayload(1, "7", "9007199254740993"));
 
-    auto orders = extractor.ExtractExpandedDataForRow("0", "Orders");
+    auto orders = extractor.ExtractExpandedDataForRow(0, "Orders");
     auto &children = duckdb::ListValue::GetChildren(orders);
     REQUIRE(children.size() == 1);
 
     auto &fields = duckdb::StructValue::GetChildren(children[0]);
     REQUIRE(fields[2].GetValue<int64_t>() == INT64_C(9007199254740993));
+}
+
+// ============================================================================
+// GitHub #159 - the expand cache must not grow with the whole scan
+// ============================================================================
+
+// One duckdb::Value per row per expand path was appended for every page and never
+// released, so memory grew with TOTAL scan rows rather than with the rows still in
+// flight. Over a large $expand read that is the whole expanded column held in memory.
+TEST_CASE("ODataDataExtractor - releases expanded values once their rows are consumed") {
+    ODataDataExtractor extractor(MakeExtractorClient());
+    extractor.SetExpandedDataSchema({"Orders"});
+
+    extractor.ExtractExpandedDataFromResponse(BuildMultiRowPayload(0, 1000));
+    extractor.ExtractExpandedDataFromResponse(BuildMultiRowPayload(1000, 1000));
+    REQUIRE(extractor.GetCacheSize() == 2000);
+
+    // The scan has emitted the first 1500 rows; their expanded values can never be asked
+    // for again, because rows are emitted strictly in order.
+    extractor.ReleaseExpandedDataBefore(1500);
+    REQUIRE(extractor.GetCacheSize() == 500);
+
+    // Releasing must not shift the rows that remain: row 1500 is still row 1500.
+    auto orders = extractor.ExtractExpandedDataForRow(1500, "Orders");
+    REQUIRE_FALSE(orders.IsNull());
+    auto &children = duckdb::ListValue::GetChildren(orders);
+    REQUIRE(children.size() == 1);
+    REQUIRE(duckdb::StructValue::GetChildren(children[0])[0].ToString() == "o1500");
+
+    auto last = extractor.ExtractExpandedDataForRow(1999, "Orders");
+    REQUIRE_FALSE(last.IsNull());
+    REQUIRE(duckdb::StructValue::GetChildren(
+                duckdb::ListValue::GetChildren(last)[0])[0].ToString() == "o1999");
+}
+
+TEST_CASE("ODataDataExtractor - a released row reads as NULL rather than another row's value") {
+    ODataDataExtractor extractor(MakeExtractorClient());
+    extractor.SetExpandedDataSchema({"Orders"});
+    extractor.ExtractExpandedDataFromResponse(BuildMultiRowPayload(0, 10));
+
+    extractor.ReleaseExpandedDataBefore(5);
+
+    // Asking for a released row is a bug in the caller; it must not silently return the
+    // value that happens to sit at that offset now.
+    REQUIRE(extractor.ExtractExpandedDataForRow(0, "Orders").IsNull());
+    REQUIRE_FALSE(extractor.ExtractExpandedDataForRow(5, "Orders").IsNull());
 }

--- a/test/cpp/test_odp_audit_totals.cpp
+++ b/test/cpp/test_odp_audit_totals.cpp
@@ -1,0 +1,75 @@
+// GitHub #158: the ODP audit row is written once per emitted chunk, on a freshly
+// constructed duckdb::Connection each time, and the UPDATE assigns rather than
+// accumulates. A completed extraction therefore records the LAST chunk's row count
+// (<= 2048) instead of the total, so the audit table cannot be used to verify that a
+// delta package was fully delivered - which is the only thing it is for.
+
+#include "catch.hpp"
+#include "duckdb.hpp"
+
+#include "odata_test_server.hpp"
+#include "odp_test_db.hpp"
+
+#include <sstream>
+#include <string>
+
+using erpl_web::test_support::CannedResponse;
+using erpl_web::test_support::ODataTestServer;
+
+namespace {
+
+// An OData v2 ODP page: the shape the ODP reader parses.
+std::string MakeOdpPage(std::size_t row_count)
+{
+    std::ostringstream out;
+    out << R"({"d":{"results":[)";
+    for (std::size_t i = 0; i < row_count; i++) {
+        if (i > 0) {
+            out << ",";
+        }
+        out << R"({"ID":")" << i << R"(","ODQ_CHANGEMODE":"C"})";
+    }
+    out << "]}}";
+    return out.str();
+}
+
+}  // namespace
+
+TEST_CASE("the ODP audit row records the whole extraction, not the last chunk",
+          "[odp_audit]") {
+    // More than one vector, so the scan emits several chunks. With a single chunk the
+    // defect is invisible: the last chunk IS the total.
+    constexpr std::size_t ROW_COUNT = 3000;
+
+    ODataTestServer server;
+    // Served at both the service root and the entity-relative path, so the test does not
+    // depend on which of the two the metadata resolver computes for a v2 payload that
+    // carries no @odata.context.
+    server.ServeMetadataFixture("/sap/opu/odata/sap/Z_TEST_SRV/$metadata",
+                                "edm_sap_odp_bw_fact.xml");
+    server.ServeMetadataFixture("/sap/opu/odata/sap/Z_TEST_SRV/FactsOf0D_NW_C01/$metadata",
+                                "edm_sap_odp_bw_fact.xml");
+    server.OnPath("/sap/opu/odata/sap/Z_TEST_SRV/FactsOf0D_NW_C01",
+                  CannedResponse::Json(MakeOdpPage(ROW_COUNT)));
+
+    odp_test::TempDatabase db("odp_audit_totals");
+    auto &con = db.Conn();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    const auto url = server.Url("/sap/opu/odata/sap/Z_TEST_SRV/FactsOf0D_NW_C01");
+    auto read = con.Query("SELECT COUNT(*) FROM odp_odata_read('" + url + "')");
+    INFO((read->HasError() ? read->GetError() : std::string()));
+    REQUIRE_FALSE(read->HasError());
+    REQUIRE(read->GetValue(0, 0).GetValue<int64_t>() == static_cast<int64_t>(ROW_COUNT));
+
+    auto audit = con.Query(
+        "SELECT max(rows_fetched) FROM erpl_web.odp_subscription_audit");
+    INFO((audit->HasError() ? audit->GetError() : std::string()));
+    REQUIRE_FALSE(audit->HasError());
+    REQUIRE(audit->RowCount() == 1);
+
+    const auto recorded = audit->GetValue(0, 0);
+    INFO("audit rows_fetched = " << recorded.ToString() << ", extraction delivered " << ROW_COUNT);
+    REQUIRE_FALSE(recorded.IsNull());
+    REQUIRE(recorded.GetValue<int64_t>() == static_cast<int64_t>(ROW_COUNT));
+}


### PR DESCRIPTION
Closes #159 and #158.

### #159 — the expand cache grew with the whole scan
One `duckdb::Value` per row per expand path was appended for every page and never released, so memory grew with **total scan rows** rather than with rows still buffered. Over a large `$expand` read that is the entire expanded column in memory — which is why the ~26x-page-size bound measured in #89 didn't hold for expanded reads: that measurement didn't use `$expand`.

Rows are emitted strictly in order, so once the scan moves past a row its expanded values can never be asked for again. `EmitRowsToOutput` now releases them, with a base row index so releasing doesn't shift the rows that remain. Asking for a *released* row returns NULL rather than whatever value now sits at that offset — a caller bug either way, but silently returning another row's data is the exact failure this area already had in #156.

`ExtractExpandedDataForRow` now takes an `idx_t`; it was passing the row index as a **string** and parsing it back with `stoull` for every expanded cell of every row.

### #158 — the ODP audit row recorded the last chunk, not the extraction
`UpdateAuditEntry` ran per emitted chunk and the UPDATE **assigns** rather than adds, so a 3000-row read recorded **952**. Each call also built a fresh `duckdb::Connection` and re-prepared the statement, taking the connection-manager lock on the row-emission hot path — ~4,900 times for a 10M-row extraction.

Totals are now accumulated and written **once**, next to the delta-token commit, guarded so a double finalize can't overwrite a complete row.

### A broken fixture, and cookies in the repo
`edm_sap_odp_bw_fact.xml` was unusable: committed as a captured terminal transcript with a shell prompt and HTTP headers ahead of the EDMX, so it never parsed — which is why this ODP path had no local test coverage. Those headers also carried **`MYSAPSSO2` and `SAP_SESSIONID_A4H_001` cookies** from the capture. Preamble removed; the file is valid XML and the credentials are gone.

### Verification
418 C++ cases / 2126 assertions; SQL suite green; live SAP tier green (37 assertions) including the real ODP service.

Both tests need **more than one chunk** to mean anything — with a single chunk the last chunk is the total, and the expand cache never gets a chance to grow. That cost me a first attempt on each.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791735161&installation_model_id=425457&pr_number=165&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F165&signature=0d50b398dd3e727185b96b3c98fbd4422e7bdbe3d932152c6beafa6891144a20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->