### PR TITLE
fix: a filter must not invalidate the database; audit totals must not blank the token

### DIFF
--- a/src/include/odp_subscription_repository.hpp
+++ b/src/include/odp_subscription_repository.hpp
@@ -109,6 +109,11 @@ public:
     int64_t CreateAuditEntry(const OdpAuditEntry& entry);
     bool UpdateAuditEntry(const OdpAuditEntry& entry);
 
+    // Update ONLY the delivered totals. UpdateAuditEntry assigns every column, so using it
+    // to record what a scan delivered blanks the delta token, status and error the page
+    // boundaries had already written. See GitHub #158.
+    bool UpdateAuditTotals(int64_t audit_id, int64_t rows_fetched, int64_t package_size_bytes);
+
     // Utility methods
     static std::string GenerateSubscriptionId(const std::string& service_url,
                                              const std::string& entity_set_name);

--- a/src/include/odp_subscription_state_manager.hpp
+++ b/src/include/odp_subscription_state_manager.hpp
@@ -83,6 +83,10 @@ public:
                          const std::string& error_message = "",
                          const std::optional<int64_t>& duration_ms = std::nullopt);
 
+    // Record what the scan actually delivered, without disturbing the token, status or
+    // error already written for the package (GitHub #158).
+    void UpdateAuditTotals(int64_t audit_id, int64_t rows_fetched, int64_t package_size_bytes);
+
     // Utility methods
     static std::string PhaseToString(SubscriptionPhase phase);
     // Throws unless the token consists only of characters SAP uses in delta

--- a/src/odata_predicate_pushdown_helper.cpp
+++ b/src/odata_predicate_pushdown_helper.cpp
@@ -681,7 +681,12 @@ std::string ODataPredicatePushdownHelper::BuildFilterClause(duckdb::optional_ptr
                 // it from the plan, so nothing re-applies it and the scan returns rows that
                 // do not satisfy the WHERE clause. See GitHub #153.
                 ERPL_TRACE_ERROR("PREDICATE_PUSHDOWN", "Column name resolver returned empty string for index " + std::to_string(filter_entry.first));
-                throw duckdb::InternalException(
+                // NotImplementedException, not InternalException: DuckDB treats
+                // ExceptionType::INTERNAL as fatal and calls ValidChecker::Invalidate on the
+                // whole database instance, so a single query with an unresolvable filter
+                // column would take down every later statement on that connection. Failing
+                // the statement is right; failing the instance is not.
+                throw duckdb::NotImplementedException(
                     "OData pushdown could not resolve a column name for filter index " +
                     std::to_string(filter_entry.first) +
                     "; refusing to drop the filter, which would return rows that do not match "
@@ -696,7 +701,8 @@ std::string ODataPredicatePushdownHelper::BuildFilterClause(duckdb::optional_ptr
             if (column_index >= all_column_names.size()) {
                 // As above: dropping the filter silently widens the result.
                 ERPL_TRACE_ERROR("PREDICATE_PUSHDOWN", "Column index " + std::to_string(column_index) + " is out of bounds for column names array");
-                throw duckdb::InternalException(
+                // See the note above on why this is not an InternalException.
+                throw duckdb::NotImplementedException(
                     "OData pushdown got a filter for column index " + std::to_string(column_index) +
                     ", but the scan has only " + std::to_string(all_column_names.size()) +
                     " columns; refusing to drop the filter, which would return rows that do not "

--- a/src/odp_odata_read_bind_data.cpp
+++ b/src/odp_odata_read_bind_data.cpp
@@ -478,8 +478,11 @@ void OdpODataReadBindData::WriteAuditTotals() {
     // a scan finalised more than once does not overwrite a complete row with a second,
     // emptier one.
     audit_written_ = true;
-    state_manager_->UpdateAuditEntry(current_audit_id_, 200, audit_rows_fetched_,
-                                     audit_package_size_bytes_);
+    // Only the totals. UpdateAuditEntry assigns every column, so using it here blanked the
+    // delta_token_after and status that the page-boundary updates had recorded - the field
+    // that says which package this audit row is about.
+    state_manager_->UpdateAuditTotals(current_audit_id_, audit_rows_fetched_,
+                                      audit_package_size_bytes_);
     ERPL_TRACE_DEBUG("ODP_BIND_DATA",
                      duckdb::StringUtil::Format("Wrote audit totals: %lld rows, %lld bytes",
                                                 (long long)audit_rows_fetched_,

--- a/src/odp_subscription_repository.cpp
+++ b/src/odp_subscription_repository.cpp
@@ -457,6 +457,28 @@ int64_t OdpSubscriptionRepository::CreateAuditEntry(const OdpAuditEntry& entry) 
     }
 }
 
+bool OdpSubscriptionRepository::UpdateAuditTotals(int64_t audit_id, int64_t rows_fetched,
+                                                 int64_t package_size_bytes)
+{
+    EnsureTablesExist();
+
+    try {
+        auto result = Execute(
+            "UPDATE " + QualifiedTable(AUDIT_TABLE) +
+                " SET response_timestamp = ?, rows_fetched = ?, package_size_bytes = ? "
+                "WHERE audit_id = ?",
+            {TimePointToValue(std::chrono::system_clock::now()),
+             duckdb::Value::BIGINT(rows_fetched),
+             duckdb::Value::BIGINT(package_size_bytes),
+             duckdb::Value::BIGINT(audit_id)});
+        return result != nullptr;
+    } catch (const std::exception& e) {
+        ERPL_TRACE_ERROR("ODP_REPOSITORY",
+                         "Failed to update audit totals: " + std::string(e.what()));
+        return false;
+    }
+}
+
 bool OdpSubscriptionRepository::UpdateAuditEntry(const OdpAuditEntry& entry) {
     ERPL_TRACE_DEBUG("ODP_REPOSITORY", duckdb::StringUtil::Format(
         "Updating audit entry %lld for subscription %s",

--- a/src/odp_subscription_state_manager.cpp
+++ b/src/odp_subscription_state_manager.cpp
@@ -147,6 +147,21 @@ int64_t OdpSubscriptionStateManager::CreateAuditEntry(const std::string& operati
     }
 }
 
+void OdpSubscriptionStateManager::UpdateAuditTotals(int64_t audit_id, int64_t rows_fetched,
+                                                    int64_t package_size_bytes) {
+    ERPL_TRACE_DEBUG("ODP_STATE_MANAGER",
+                     duckdb::StringUtil::Format("Recording audit totals for %lld: Rows=%lld, Size=%lld",
+                                                audit_id, rows_fetched, package_size_bytes));
+    try {
+        repository_->UpdateAuditTotals(audit_id, rows_fetched, package_size_bytes);
+    } catch (const std::exception& e) {
+        // An audit row is a record of the extraction, not part of it; failing to write it
+        // must not fail a scan that delivered its rows.
+        ERPL_TRACE_ERROR("ODP_STATE_MANAGER",
+                         "Failed to record audit totals: " + std::string(e.what()));
+    }
+}
+
 void OdpSubscriptionStateManager::UpdateAuditEntry(int64_t audit_id,
                                                   const std::optional<int>& http_status_code,
                                                   int64_t rows_fetched,

--- a/test/cpp/test_odata_filter_translation.cpp
+++ b/test/cpp/test_odata_filter_translation.cpp
@@ -315,7 +315,12 @@ TEST_CASE("A filter on a column that cannot be resolved fails loudly", "[odata_f
 	duckdb::TableFilterSet filter_set;
 	filter_set.filters[7] = MakeEq(Value::INTEGER(1));  // no column at index 7
 
-	REQUIRE_THROWS(helper.ConsumeFilters(&filter_set));
+	// NOT InternalException. DuckDB treats ExceptionType::INTERNAL as fatal -
+	// client_context.cpp calls ValidChecker::Invalidate(db_inst) - so every later statement
+	// on that database instance fails too. An unresolved column index is reachable from a
+	// query (a filter on an expanded column resolves against base names only), so it must
+	// fail the statement, not the instance.
+	REQUIRE_THROWS_AS(helper.ConsumeFilters(&filter_set), duckdb::NotImplementedException);
 }
 
 TEST_CASE("Advisory filters are still skipped rather than failing", "[odata_filter]") {

--- a/test/cpp/test_odata_read_expand.cpp
+++ b/test/cpp/test_odata_read_expand.cpp
@@ -371,6 +371,45 @@ TEST_CASE("odata_read expands identically whether $expand is in the URL or a par
     REQUIRE(url_text == parameter_text);
 }
 
+// A filter that the pushdown layer cannot resolve to a column must not take the database
+// down with it. #153 replaced a silent `continue` with `throw InternalException`, and
+// DuckDB treats ExceptionType::INTERNAL as fatal: client_context.cpp calls
+// ValidChecker::Invalidate(db_inst), after which EVERY later statement on that instance
+// fails. The column resolver only searches the base result names, so a filter on an
+// expanded column resolves to "" and takes exactly that path.
+//
+// Silently dropping the filter was wrong (it returned rows that did not match). Killing
+// the instance is a different and worse kind of wrong.
+TEST_CASE("a filter on an expanded column does not invalidate the database",
+          "[odata_expand][e2e]") {
+    ODataTestServer server;
+    server.ServeMetadataFixture("/nw/$metadata", "edm_northwind.xml");
+    server.OnPath(
+        "/nw/Products",
+        CannedResponse::Json(MakeV4Page(
+            server.Url("/nw/$metadata") + "#Products",
+            {R"({"ProductID":1,"ProductName":"Chai","SupplierID":1,"CategoryID":1,)"
+             R"("QuantityPerUnit":"10 boxes x 20 bags","UnitPrice":18.0,"UnitsInStock":39,)"
+             R"("UnitsOnOrder":0,"ReorderLevel":10,"Discontinued":false,)"
+             R"("Category":{"CategoryID":1,"CategoryName":"Beverages",)"
+             R"("Description":"Soft drinks, coffees, teas"}})"})));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    // Whether this particular filter is pushed, translated or errors is not the point.
+    auto result = con.Query("SELECT ProductName FROM odata_read('" + server.Url("/nw/Products") +
+                            "', expand = 'Category') WHERE Category IS NOT NULL");
+    (void)result;
+
+    // The point: the connection must still be usable afterwards.
+    auto after = con.Query("SELECT 1");
+    INFO((after->HasError() ? after->GetError() : std::string()));
+    REQUIRE_FALSE(after->HasError());
+    REQUIRE(after->GetValue(0, 0).GetValue<int32_t>() == 1);
+}
+
 // Catches: an expand that is dropped as soon as another query option is present.
 // $top/$skip and $expand are assembled from the same helper, so a clause that
 // overwrites rather than adds is a plausible regression.

--- a/test/cpp/test_odp_subscription_state_manager.cpp
+++ b/test/cpp/test_odp_subscription_state_manager.cpp
@@ -153,6 +153,41 @@ TEST_CASE("OdpSubscriptionStateManager - Delta Token Management", "[odp_delta_to
     }
 }
 
+// GitHub #158 follow-up: writing the extraction totals must not blank the rest of the row.
+// UpdateAuditEntry assigns EVERY column, so calling it at the end of a scan with only rows
+// and bytes wiped out the delta_token_after a page-boundary update had recorded - the one
+// field that says which package the audit row refers to.
+TEST_CASE("OdpSubscriptionStateManager - writing totals preserves the delta token",
+          "[odp_audit]") {
+    odp_test::TempDatabase temp_db;
+    ClientContext &context = temp_db.Context();
+
+    const std::string service_url = "https://test.com/sap/opu/odata/sap/TEST_SRV/EntityOfTotals";
+    OdpSubscriptionStateManager manager(context, service_url, "EntityOfTotals");
+
+    const int64_t audit_id = manager.CreateAuditEntry("initial_load", service_url);
+    REQUIRE(audit_id > 0);
+
+    // A page boundary records the token and status for the package.
+    manager.UpdateAuditEntry(audit_id, 200, 0, 4096, "TOKEN_FOR_PACKAGE", "", 100);
+
+    // The scan then finishes and records what it actually delivered.
+    manager.UpdateAuditTotals(audit_id, 3000, 24000);
+
+    auto row = temp_db.Conn().Query(
+        "SELECT rows_fetched, package_size_bytes, delta_token_after, http_status_code "
+        "FROM erpl_web.odp_subscription_audit WHERE audit_id = " + std::to_string(audit_id));
+    INFO((row->HasError() ? row->GetError() : std::string()));
+    REQUIRE_FALSE(row->HasError());
+    REQUIRE(row->RowCount() == 1);
+
+    CHECK(row->GetValue(0, 0).GetValue<int64_t>() == 3000);
+    CHECK(row->GetValue(1, 0).GetValue<int64_t>() == 24000);
+    // The token and status must survive the totals write.
+    CHECK(row->GetValue(2, 0).ToString() == "TOKEN_FOR_PACKAGE");
+    CHECK(row->GetValue(3, 0).GetValue<int32_t>() == 200);
+}
+
 TEST_CASE("OdpSubscriptionStateManager - Audit Operations", "[odp_audit]") {
     odp_test::TempDatabase temp_db;
     ClientContext& context = temp_db.Context();


### PR DESCRIPTION
Two regressions from the previous batch, both caught by the crew review — neither by me, neither by the suites.

### A filter could take down the whole database instance
`#153` replaced a silent `continue` with `throw duckdb::InternalException` for an unresolved filter column. DuckDB treats `ExceptionType::INTERNAL` as **fatal**: `client_context.cpp` calls `ValidChecker::Invalidate(db_inst)`, after which every later statement on that instance fails. I confirmed that in DuckDB's source.

The path is reachable from a query — the pushdown column resolver searches only `base_result_names`, so a filter on an expanded column resolves to `""`. Both throws are now `NotImplementedException`, consistent with the rest of the #153 policy.

**Honest limit:** I could not construct a query that actually reaches it. The obvious candidate — `WHERE Category IS NOT NULL` with `expand='Category'` — is not pushed as a `TableFilter` in the shape I tried, and that e2e test passes both before and after. The exception *type* is wrong whether or not a trigger exists today, so the unit test pins it where the path is reachable, and the e2e test pins the weaker user-visible property: after a filtered expand query, the connection still answers `SELECT 1`.

### Audit totals blanked the delta token
My #158 change recorded totals through `UpdateAuditEntry`, which assigns **every** column — wiping the `delta_token_after` and `http_status_code` the page-boundary updates had written, i.e. the fields that say which package the row refers to. Totals now go through a narrow `UpdateAuditTotals` touching only rows, bytes and timestamp.

### Verification
426 C++ cases / 2153 assertions. Live SAP ODP: a 3000-row extraction records **3000** rows and keeps status **200**; SAP tier 37 assertions green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791740811&installation_model_id=425457&pr_number=167&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F167&signature=5afa6d3169eb4d5e62ee2aa69f802a97b09144212b68f61340b9692e04a882fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->