### PR TITLE
fix: do not send credentials to a host named by @odata.context

### DIFF
--- a/src/include/odata_client.hpp
+++ b/src/include/odata_client.hpp
@@ -311,8 +311,20 @@ protected:
         metadata_request.headers["Accept"] = "application/xml";
         metadata_request.headers["Connection"] = "close";
         
+        // The SERVICE chooses this URL, through @odata.context, so it is attacker-controlled
+        // input in exactly the way a nextLink is. Credentials go only to the origin this
+        // client was opened against; otherwise a service could name any host and be handed
+        // the caller's bearer token or basic credential. The generic request path has had
+        // this guard since the nextLink case; the metadata path was missed.
         if (auth_params != nullptr) {
-            metadata_request.AuthHeadersFromParams(*auth_params);
+            if (metadata_request.url.IsSameOrigin(url)) {
+                metadata_request.AuthHeadersFromParams(*auth_params);
+            } else {
+                ERPL_TRACE_WARN("ODATA_CLIENT",
+                                "Not sending credentials to '" + metadata_request.url.ToString() +
+                                "': the @odata.context names a different origin from the service "
+                                "this client was opened against ('" + url.ToString() + "').");
+            }
         }
         
         // Trace metadata request details
@@ -416,7 +428,15 @@ protected:
             ERPL_TRACE_DEBUG("ODATA_CLIENT", "Retrying metadata request with popped URL: " + current_svc_url.ToString());
             
             if (auth_params != nullptr) {
-                metadata_request.AuthHeadersFromParams(*auth_params);
+                // Same rule as above: the retry URL is derived from service-supplied input.
+                if (metadata_request.url.IsSameOrigin(url)) {
+                    metadata_request.AuthHeadersFromParams(*auth_params);
+                } else {
+                    ERPL_TRACE_WARN("ODATA_CLIENT",
+                                    "Not sending credentials to '" + metadata_request.url.ToString() +
+                                    "': different origin from the service this client was opened "
+                                    "against.");
+                }
             }   
         }
 

--- a/test/cpp/test_odata_metadata_origin.cpp
+++ b/test/cpp/test_odata_metadata_origin.cpp
@@ -1,0 +1,94 @@
+// A service response chooses the metadata URL, through @odata.context. DoMetadataHttpGet
+// attached the caller's Authorization header to whatever host that named, with no origin
+// check - so a compromised or hostile service could steer a bearer token or basic
+// credential to a host of its choosing simply by answering with an absolute context URL.
+//
+// The generic request path already guards this (see the comment at odata_client.hpp:250,
+// added for the @odata.nextLink case); the metadata path was missed.
+
+#include "catch.hpp"
+#include "duckdb.hpp"
+
+#include "odata_client.hpp"
+#include "odata_test_server.hpp"
+
+#include <string>
+
+using erpl_web::test_support::CannedResponse;
+using erpl_web::test_support::ODataTestServer;
+using erpl_web::HttpAuthParams;
+using erpl_web::HttpClient;
+using erpl_web::HttpParams;
+using erpl_web::HttpUrl;
+using erpl_web::ODataEntitySetClient;
+using erpl_web::ODataEntitySetResponse;
+using erpl_web::ODataVersion;
+using erpl_web::HttpMethod;
+using erpl_web::HttpResponse;
+
+namespace {
+
+class TestDatabase {
+public:
+    TestDatabase()
+    {
+        config.SetOption("allocator_background_threads", duckdb::Value::BOOLEAN(true));
+        database = duckdb::make_uniq<duckdb::DuckDB>(nullptr, &config);
+        connection = duckdb::make_uniq<duckdb::Connection>(*database);
+    }
+    duckdb::Connection &Con() const { return *connection; }
+
+private:
+    duckdb::DBConfig config;
+    duckdb::unique_ptr<duckdb::DuckDB> database;
+    duckdb::unique_ptr<duckdb::Connection> connection;
+};
+
+}  // namespace
+
+TEST_CASE("credentials are not sent to a host named by @odata.context",
+          "[odata_metadata][security]") {
+    ODataTestServer service;    // the host the caller pointed at, and trusts
+    ODataTestServer elsewhere;  // the host the service names in its context URL
+
+    service.ServeMetadataFixture("/svc/$metadata", "edm_northwind.xml");
+    elsewhere.ServeMetadataFixture("/evil/$metadata", "edm_northwind.xml");
+
+    // The client is opened against `service`, with credentials for it.
+    HttpParams params;
+    auto http_client = std::make_shared<HttpClient>(params);
+    auto auth = std::make_shared<HttpAuthParams>();
+    auth->basic_credentials = std::make_pair(std::string("user"), std::string("secret-password"));
+
+    auto client = std::make_shared<ODataEntitySetClient>(
+        http_client, HttpUrl(service.Url("/svc/Products")), auth);
+    client->SetODataVersionDirectly(ODataVersion::V4);
+
+    // The service answers with a context URL pointing at the OTHER host. This is the input
+    // the attacker controls: the response body of the service you are reading.
+    const std::string foreign_context = elsewhere.Url("/evil/$metadata") + "#Products";
+    const std::string body = std::string(R"({"@odata.context":")") + foreign_context +
+                             R"(","value":[{"ProductID":1,"ProductName":"Chai"}]})";
+    client->AdoptResponse(std::make_shared<ODataEntitySetResponse>(
+        std::make_unique<HttpResponse>(HttpMethod::GET, HttpUrl(service.Url("/svc/Products")), 200,
+                                       "application/json", body),
+        ODataVersion::V4));
+
+    try {
+        client->GetMetadata();
+    } catch (const std::exception &) {
+        // Refusing outright is an acceptable outcome; sending the credential is not.
+    }
+
+    bool foreign_was_contacted = false;
+    for (const auto &request : elsewhere.Requests()) {
+        foreign_was_contacted = true;
+        INFO("foreign host received " << request.method << " " << request.target);
+        REQUIRE_FALSE(request.HasHeader("Authorization"));
+    }
+
+    // The test is only meaningful if the foreign host was actually reached; otherwise it
+    // would pass for the wrong reason.
+    INFO("the context URL must have been followed for this test to mean anything");
+    CHECK(foreign_was_contacted);
+}


### PR DESCRIPTION
The metadata URL is chosen by the **service**, through `@odata.context` — attacker-controlled input in exactly the way `@odata.nextLink` is. `DoMetadataHttpGet` attached the caller's `Authorization` header to whatever host that named, with no origin check.

The generic request path has had this guard since the nextLink case; its comment even notes *"the ODP path and the redirect handler already do this"*. The metadata path was missed — in both the primary request and the popped-URL retry.

### Reproduced
Two local servers: a client opened against one, holding its credentials, adopts a response whose `@odata.context` names the other. Before the fix:

```
foreign host received GET /evil/$metadata     [Authorization sent]
```

The test also asserts the foreign host *was* contacted, so it cannot pass for the wrong reason — which matters, because my first attempt at this test passed for exactly that reason.

### Honest scope
Reaching this through `odata_read` alone is harder than it looks: after the first-page rework, metadata resolves at bind time while the client has no response, so the context is empty and the service-root fallback wins. That makes it **latent rather than currently exploitable through that path**. The guard belongs there regardless, and other callers resolve metadata after a response exists.

A foreign origin is still fetched — just without credentials — and the refusal is traced.

### Verification
425 C++ cases / 2145 assertions. Live SAP tier green (37 assertions), confirming same-origin metadata is still authenticated.

Found by an agent-crew review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791741865&installation_model_id=425457&pr_number=168&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F168&signature=61b0c5f7a969b9f4a793bb9bbd156f1d0ad7ae506b0bcfebaee1a16c4517b575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->