### PR TITLE
fix: cross-origin credential strip, stale per-scan state, and expand-alignment guards

### DIFF
--- a/src/odata_read_pushdown.cpp
+++ b/src/odata_read_pushdown.cpp
@@ -206,6 +206,10 @@ void ODataReadBindData::UpdateUrlFromPredicatePushdown() {
         }
         emitted_row_index_ = 0;
         first_page_cached_ = false;
+        // The stored probe page belongs to the OLD url. Keeping it here is how a scan ends
+        // up adopting a page that does not match the request it is about to make.
+        first_page_response_.reset();
+        first_page_expand_extracted_ = false;
     }
 }
 

--- a/src/odata_read_scan_state.cpp
+++ b/src/odata_read_scan_state.cpp
@@ -443,6 +443,11 @@ duckdb::unique_ptr<ODataReadBindData> ODataReadBindData::CloneForScan() const {
 
   auto clone = duckdb::make_uniq<ODataReadBindData>(scan_client, true);
   clone->first_page_response_ = first_page_response_;
+  // Carry the row count the service reported at bind time. The clone gets a fresh tracker,
+  // so without this the scan has no denominator and DuckDB shows no progress at all.
+  if (progress_tracker && clone->progress_tracker && progress_tracker->HasTotalCount()) {
+    clone->progress_tracker->SetTotalCount(progress_tracker->GetTotalCount());
+  }
   // first_page_expand_extracted_ is deliberately NOT copied. The clone gets a fresh
   // extractor with an empty expand cache, so this execution must extract page one's
   // expanded data into it again; copying the flag would leave the first page's expanded

--- a/test/cpp/test_http_redirect_credentials.cpp
+++ b/test/cpp/test_http_redirect_credentials.cpp
@@ -1,0 +1,51 @@
+// Three places decide what counts as a credential header: the trace redactor, the response
+// cache key, and the cross-origin redirect strip. They had drifted apart - the redirect
+// strip listed five names where the redactor listed seven, so X-Access-Token survived a
+// redirect to another origin and was sent to whatever host the Location named.
+
+#include "catch.hpp"
+#include "duckdb.hpp"
+
+#include "datazoo/oauth2/http_client.hpp"
+#include "odata_test_server.hpp"
+
+#include <string>
+
+using erpl_web::HttpClient;
+using erpl_web::HttpMethod;
+using erpl_web::HttpParams;
+using erpl_web::HttpRequest;
+using erpl_web::HttpUrl;
+using erpl_web::test_support::CannedResponse;
+using erpl_web::test_support::ODataTestServer;
+
+TEST_CASE("a cross-origin redirect strips every credential header", "[http_redirect][security]") {
+    ODataTestServer origin;       // where the caller sent the request
+    ODataTestServer destination;  // where the response redirects it
+
+    destination.OnPath("/landed", CannedResponse::Json(R"({"value":[]})"));
+    origin.OnPath("/start", CannedResponse::Error(302).WithHeader("Location", destination.Url("/landed")));
+
+    HttpParams params;
+    HttpClient client(params);
+
+    HttpRequest request(HttpMethod::GET, HttpUrl(origin.Url("/start")));
+    request.headers["Authorization"] = "Bearer token-value";
+    request.headers["Cookie"] = "session=abc";
+    request.headers["X-API-Key"] = "api-key-value";
+    request.headers["X-Auth-Token"] = "auth-token-value";
+    request.headers["X-Access-Token"] = "access-token-value";
+    request.headers["X-CSRF-Token"] = "csrf-token-value";
+
+    auto response = client.SendRequest(request);
+    REQUIRE(response != nullptr);
+
+    auto landed = destination.RequestsFor("/landed");
+    REQUIRE(landed.size() == 1);
+
+    for (const char *header : {"Authorization", "Cookie", "X-API-Key", "X-Auth-Token",
+                              "X-Access-Token", "X-CSRF-Token"}) {
+        INFO("header that reached the redirect destination: " << header);
+        REQUIRE_FALSE(landed[0].HasHeader(header));
+    }
+}

--- a/test/cpp/test_odata_data_extractor.cpp
+++ b/test/cpp/test_odata_data_extractor.cpp
@@ -279,3 +279,60 @@ TEST_CASE("ODataDataExtractor - a released row reads as NULL rather than another
     REQUIRE(extractor.ExtractExpandedDataForRow(0, "Orders").IsNull());
     REQUIRE_FALSE(extractor.ExtractExpandedDataForRow(5, "Orders").IsNull());
 }
+
+// ============================================================================
+// GitHub #159 follow-up: does a short extraction shift later rows?
+// ============================================================================
+
+// The crew's hypothesis: the cache holds one entry per row per path, and rows are looked
+// up by position. If a page ever yields FEWER entries than it has rows - one row's expand
+// payload unparseable, say - every later row reads its neighbour's value. That is the #156
+// failure mode arriving by a different route, and #159's release makes it permanent
+// because the base index advances regardless.
+TEST_CASE("ODataDataExtractor - a row whose expand payload is unusable does not shift its neighbours") {
+    ODataDataExtractor extractor(MakeExtractorClient());
+    extractor.SetExpandedDataSchema({"Orders"});
+
+    // Three rows. The middle one carries something that is not a collection of orders.
+    const std::string payload =
+        R"({"value":[)"
+        R"({"id":"c0","Orders":[{"id":"o0","amount":1,"total":2}]},)"
+        R"({"id":"c1","Orders":"not-a-collection"},)"
+        R"({"id":"c2","Orders":[{"id":"o2","amount":3,"total":4}]}]})";
+    extractor.ExtractExpandedDataFromResponse(payload);
+
+    // Row 2 must read row 2's order, whatever happened to row 1.
+    auto row2 = extractor.ExtractExpandedDataForRow(2, "Orders");
+    INFO("cache holds " << extractor.GetCacheSize() << " entries for 3 rows");
+    REQUIRE_FALSE(row2.IsNull());
+    auto &children = duckdb::ListValue::GetChildren(row2);
+    REQUIRE(children.size() == 1);
+    CHECK(duckdb::StructValue::GetChildren(children[0])[0].ToString() == "o2");
+
+    // And the cache must carry one entry per row, so positions stay meaningful.
+    CHECK(extractor.GetCacheSize() == 3);
+}
+
+// The other shape: the expand property is ABSENT from a row rather than unusable. A page
+// that omits it for one row would, if nothing is appended, make every later row read its
+// neighbour's value.
+TEST_CASE("ODataDataExtractor - a row missing the expand property does not shift its neighbours") {
+    ODataDataExtractor extractor(MakeExtractorClient());
+    extractor.SetExpandedDataSchema({"Orders"});
+
+    const std::string payload =
+        R"({"value":[)"
+        R"({"id":"c0","Orders":[{"id":"o0","amount":1,"total":2}]},)"
+        R"({"id":"c1"},)"
+        R"({"id":"c2","Orders":[{"id":"o2","amount":3,"total":4}]}]})";
+    extractor.ExtractExpandedDataFromResponse(payload);
+
+    INFO("cache holds " << extractor.GetCacheSize() << " entries for 3 rows");
+    CHECK(extractor.GetCacheSize() == 3);
+
+    auto row2 = extractor.ExtractExpandedDataForRow(2, "Orders");
+    REQUIRE_FALSE(row2.IsNull());
+    auto &children = duckdb::ListValue::GetChildren(row2);
+    REQUIRE(children.size() == 1);
+    CHECK(duckdb::StructValue::GetChildren(children[0])[0].ToString() == "o2");
+}


### PR DESCRIPTION
Cleanup batch from the crew review, plus the verification you asked for.

### Credential headers on a redirect (submodule bump)
Three places decided what counts as a credential header and had drifted: the trace redactor listed **seven**, the cross-origin redirect strip **five**. `X-Access-Token` survived a redirect and was sent to whatever host `Location` named. Reproduced with six credential headers through a 302 to a second local server. Fixed in [datazoo-oauth2#8](https://github.com/DataZooDE/datazoo-oauth2/pull/8) by erasing **by predicate over the single list** — which also fixes case sensitivity, since the old code matched names verbatim.

### Two latent per-scan traps
- `first_page_response_` outlived the URL it belonged to: when pushdown changed the URL the buffer was discarded but the stored page was not, so a scan could adopt a page that does not match the request it is about to make.
- The per-execution clone got a fresh progress tracker but not the total the service had already reported, so a scan that knew its row count at bind time showed **no progress at all**.

Neither has a visible symptom yet; both are the shape that produced #149 and #156.

### The expand-alignment claim: not reproduced
The review argued that #159's release makes a short extraction permanent — one page yielding fewer entries than rows, and every later row reads its neighbour's value. **It does not reproduce.** Tested both shapes (payload unusable, property absent): the extractor already appends a NULL on each failure branch, so the cache keeps one entry per row.

The tests stay as regression guards, because that padding is exactly the invariant #159's release depends on and nothing else pinned it. Recorded as not-reproduced rather than fixed on a hypothesis.

### Not done, deliberately
I did **not** redact the ODP delta-token trace, which the review also suggested. A delta token is an ODQ queue pointer, not authentication material — it grants nothing without credentials — and it is genuinely useful for debugging the delta problems we have just been finding.

430 cases / 2171 assertions; live SAP tier green (37 assertions).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791776643&installation_model_id=425457&pr_number=170&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F170&signature=0ad3dac1b07f4bf34d3da6cd7160e7594c857747b03acf96ca708e26addfb08d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->