### PR TITLE
fix: recover the ODP delta token when the response carries no delta link

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,22 @@ make release    # Full reconfigure + release build
   when they are empty, which is the only shape that skips correctly. Function
   registration is covered unconditionally in `test/sql/odp_functions_registered.test`, so
   it does not skip along with the live cases.
+  The **delta** lifecycle is gated separately again, on `ERPL_SAP_ODP_DELTA_SERVICE` /
+  `ERPL_SAP_ODP_DELTA_ENTITY_SET`, because being delta-capable is a property of the
+  extractor and not of ODP — see the ODP provisioning section below.
 - `make test_build_guard` - Regression test for GitHub #45 (pure CMake, no build needed). Verifies the dev-only C++ test target stays gated on the in-tree `duckdb` submodule so consumers who statically link erpl_web (via `duckdb_extension_load`/FetchContent, where the submodule is absent) don't try to compile `test/cpp` and hit `catch.hpp file not found`. Run after touching the `add_subdirectory(test)` guard in `CMakeLists.txt`.
-- `./build/debug/test/unittest "[test_category]"` - Run SQL tests by category (e.g., `"[sap]"`)
+- `make unittest` - Relink **only** `./build/debug/test/unittest`, the SQLLogicTest runner.
+  `duckdb`, `unittest` and `erpl_web_tests` are **separate ninja targets**: building one
+  does not build the others. A session that builds a single target after a source change
+  (common when a full `make dev` is failing for an unrelated reason) leaves the other
+  binaries stale — and a stale `unittest` runs your SQL tests against code from *before*
+  the fix, which is indistinguishable from a real behavioural bug. This cost a full
+  investigation in GitHub #172, where the same ODP delta case passed from
+  `./build/debug/duckdb` and failed under `unittest` with no source difference at all.
+  `test_debug_sap`, `test_debug_ms` and `test_debug_bc` depend on this target, so prefer
+  them over invoking the runner by hand.
+- `./build/debug/test/unittest "[test_category]"` - Run SQL tests by category (e.g., `"[sap]"`).
+  Run `make unittest` first — see above.
 
 **Running individual C++ tests:**
 - `ASAN_OPTIONS=detect_odr_violation=0 ./build/debug/extension/erpl_web/test/cpp/erpl_web_tests -l` - List all tests
@@ -1544,8 +1558,14 @@ Then point the tests at it:
 
 ```bash
 make test_debug_sap ERPL_SAP_ODP_SERVICE=Z_ODP_FCT_SRV \
-                    ERPL_SAP_ODP_ENTITY_SET=FactsOfZJRODPVSQL
+                    ERPL_SAP_ODP_ENTITY_SET=FactsOfZJRODPVSQL \
+                    ERPL_SAP_ODP_DELTA_SERVICE=Z_ODP_DL2_SRV \
+                    ERPL_SAP_ODP_DELTA_ENTITY_SET=FactsOfZJRODPVSQL
 ```
+
+The two ODP gates are deliberately separate. `ERPL_SAP_ODP_SERVICE` only needs *an* ODP
+service; `ERPL_SAP_ODP_DELTA_SERVICE` must name one whose CDS view is delta-capable, which
+is a stricter requirement than it looks — see the next bullet.
 
 **Things that cost time the first time:**
 
@@ -1555,6 +1575,16 @@ make test_debug_sap ERPL_SAP_ODP_SERVICE=Z_ODP_FCT_SRV \
   `SELECT viewname, odpname FROM rsodpabapcdsextb( p_langu = @sy-langu )` — note that view
   takes a **parameter**, and forgetting it fails activation with the unhelpful
   *"The parameter P_LANGU was not bound"*.
+- `@Analytics.dataExtraction.delta.byElement` does **not** make an extractor
+  delta-capable. It activates cleanly and reads as if it should work, but
+  `RODPS_REPL_ODP_GET_DETAIL` still reports `e_supports_delta = ' '`, so the generated
+  service exposes no `DeltaLinksOf<EntitySet>` entity set and no delta link is ever
+  returned. Use `@Analytics.dataExtraction.delta.changeDataCapture.automatic: true`
+  instead; `scripts/sap/zjr_odp_v.ddls.abap` is the working fixture. Check which you have
+  with `RODPS_REPL_ODP_GET_DETAIL` before concluding the reader is at fault.
+- `TerminateDeltasFor<Entity>` flips `SubscribedFlag` to false but does **not** issue a
+  delta link. To recover a token for an already-subscribed queue, read
+  `DeltaLinksOf<EntitySet>` instead (GitHub #169).
 - Everything must live in `$TMP`. The `@Analytics.dataExtraction.*` annotations and the
   classic ODP APIs are not released for ABAP Cloud, so a HOME-tier package rejects them
   on an ABAP Cloud developer trial.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1590,11 +1590,12 @@ is a stricter requirement than it looks — see the next bullet.
   on an ABAP Cloud developer trial.
 - A source CDS view is provided as `scripts/sap/zjr_odp_v.ddls.abap` over the table in
   `scripts/sap/zjr_odp_data.tabl.abap`, for a fixture whose contents you control.
-- **Delta is a separate matter.** `RODPS_REPL_ODP_GET_DETAIL` reports
-  `supports_delta = ' '` for ABAP-CDS sources on this system even with
-  `@Analytics.dataExtraction.delta.byElement`, so SAP returns no `__delta` link and no
-  `DeltaLinksOf*` entity set is generated (`CL_RSODP_ODATA_ODP_OUT_MPC` guards it with
-  `CHECK i_supports_delta = ...`). The reader correctly stays in initial-load mode and
-  logs *"change tracking not established"*. Testing the delta lifecycle end to end needs a
-  genuinely delta-capable ODP (CDC-based extraction, or a BW/SAPI source).
+- **Delta is a separate matter, but it does work here.** `CL_RSODP_ODATA_ODP_OUT_MPC`
+  guards the `DeltaLinksOf*` entity set with `CHECK i_supports_delta = ...`, so everything
+  depends on what `RODPS_REPL_ODP_GET_DETAIL` reports. With
+  `@Analytics.dataExtraction.delta.byElement` it reports `supports_delta = ' '` and the
+  reader correctly stays in initial-load mode, logging *"change tracking not
+  established"* — which reads like a reader defect and is not one. Switching the CDS view
+  to `delta.changeDataCapture.automatic` flips it, and the full lifecycle then works
+  end to end; `test/sql/sap/odp_odata_delta.test` proves it against `Z_ODP_DL2_SRV`.
 

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,17 @@ dev:
 	fi
 	cmake --build build/debug --config Debug
 
+# Relink ./build/debug/test/unittest, the SQLLogicTest runner.
+#
+# 'duckdb', 'unittest' and 'erpl_web_tests' are separate ninja targets. Building one does
+# NOT build the others, so a session that builds a single target after a source change
+# leaves the other binaries stale - and a stale unittest runs your SQL tests against code
+# from before the fix, which looks exactly like a real behavioural bug (GitHub #172).
+# Every target that invokes the runner depends on this one.
+.PHONY: unittest
+unittest:
+	cmake --build build/debug --config Debug --target unittest
+
 release_win: ${EXTENSION_CONFIG_STEP}
 	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_RELEASE_FLAGS) $(VCPKG_MANIFEST_FLAGS) -DCMAKE_BUILD_TYPE=Release -S $(DUCKDB_SRCDIR) -B build/release
 	cmake --build build/release --config Release --parallel
@@ -42,10 +53,19 @@ release_win: ${EXTENSION_CONFIG_STEP}
 # The variables must be ABSENT, not empty, when there is no ODP service: sqllogictest's
 # require-env skips only when getenv returns null, so exporting an empty value would run
 # the ODP cases and fail them - exactly what the gate exists to prevent.
+#
+# Delta is a separate gate again, because being delta-capable is a property of the
+# extractor rather than of ODP: only a CDS view carrying
+# @Analytics.dataExtraction.delta.changeDataCapture.automatic makes the service expose a
+# DeltaLinksOf entity set at all. A service named here must be one of those.
+#   ERPL_SAP_ODP_DELTA_SERVICE     - e.g. Z_ODP_DL2_SRV
+#   ERPL_SAP_ODP_DELTA_ENTITY_SET  - e.g. FactsOfZJRODPVSQL
 ERPL_SAP_ODP_ENV := $(if $(ERPL_SAP_ODP_SERVICE),ERPL_SAP_ODP_SERVICE='$(ERPL_SAP_ODP_SERVICE)') \
-                    $(if $(ERPL_SAP_ODP_ENTITY_SET),ERPL_SAP_ODP_ENTITY_SET='$(ERPL_SAP_ODP_ENTITY_SET)')
+                    $(if $(ERPL_SAP_ODP_ENTITY_SET),ERPL_SAP_ODP_ENTITY_SET='$(ERPL_SAP_ODP_ENTITY_SET)') \
+                    $(if $(ERPL_SAP_ODP_DELTA_SERVICE),ERPL_SAP_ODP_DELTA_SERVICE='$(ERPL_SAP_ODP_DELTA_SERVICE)') \
+                    $(if $(ERPL_SAP_ODP_DELTA_ENTITY_SET),ERPL_SAP_ODP_DELTA_ENTITY_SET='$(ERPL_SAP_ODP_DELTA_ENTITY_SET)')
 
-test_debug_sap: ${EXTENSION_CONFIG_STEP}
+test_debug_sap: unittest
 	ERPL_SAP_BASE_URL='http://localhost:50000' ERPL_SAP_PASSWORD='ABAPtr2023#00' \
 		$(ERPL_SAP_ODP_ENV) ./build/debug/test/unittest "[sap]"
 
@@ -64,7 +84,7 @@ test_debug_sap: ${EXTENSION_CONFIG_STEP}
 #   ERPL_MS_EXCEL_FILE_PATH     - Relative path to .xlsx file within the drive
 # Usage:
 #   source .env.microsoft && make test_debug_ms
-test_debug_ms: ${EXTENSION_CONFIG_STEP}
+test_debug_ms: unittest
 	./build/debug/test/unittest "test/sql/graph_entra_integration.test"
 	./build/debug/test/unittest "test/sql/graph_planner_integration.test"
 	./build/debug/test/unittest "test/sql/graph_sharepoint_integration.test"
@@ -82,7 +102,7 @@ test_debug_ms: ${EXTENSION_CONFIG_STEP}
 #   ERPL_BC_COMPANY_ID   - Company GUID to run entity-read tests against
 # Usage:
 #   source .env.business_central && make test_debug_bc
-test_debug_bc: ${EXTENSION_CONFIG_STEP}
+test_debug_bc: unittest
 	./build/debug/test/unittest "test/sql/business_central_integration.test"
 
 # Regression test for GitHub #45: when erpl_web is consumed as a dependency (the duckdb

--- a/scripts/sap/zjr_odp_v.ddls.abap
+++ b/scripts/sap/zjr_odp_v.ddls.abap
@@ -4,8 +4,11 @@
 @EndUserText.label: 'ODP delta test view'
 @Analytics.dataCategory: #CUBE
 @Analytics.dataExtraction.enabled: true
-@Analytics.dataExtraction.delta.byElement.name: 'changed_at'
-@Analytics.dataExtraction.delta.byElement.maxDelayInSeconds: 1800
+// changeDataCapture is what makes the ODP delta-capable. The byElement form that used to
+// be here activates and looks right, but RODPS_REPL_ODP_GET_DETAIL still reports
+// supports_delta = ' ', so no DeltaLinksOf entity set is generated and no delta link is
+// ever returned. See the ODP section of CLAUDE.md.
+@Analytics.dataExtraction.delta.changeDataCapture.automatic: true
 define view ZJR_ODP_V as select from zjr_odp_data {
   key item_id    as ItemId,
       item_name  as ItemName,

--- a/src/include/odata_url_helpers.hpp
+++ b/src/include/odata_url_helpers.hpp
@@ -47,6 +47,11 @@ public:
 
     // Convenience: the token carried by a payload, "" when the payload has no delta link.
     static std::string ExtractDeltaToken(const std::string &json_body);
+
+    // Read a token out of a DeltaLinksOf<EntitySet> collection response. The rows carry a
+    // DeltaToken property directly rather than a link with a "!deltatoken" sigil, and an
+    // initial-load row is preferred when several are present. See GitHub #169.
+    static std::string ExtractTokenFromDeltaLinksPayload(const std::string &json_body);
 };
 
 class ODataUrlResolver {

--- a/src/include/odp_odata_read_bind_data.hpp
+++ b/src/include/odp_odata_read_bind_data.hpp
@@ -202,6 +202,11 @@ private:
     // State tracking
     bool initialized_;
     bool first_fetch_completed_;
+    // Why the last initial load or delta fetch returned false. The handlers catch the
+    // failure so they can transition the subscription to ERROR_STATE, which means the
+    // service's own explanation would otherwise be lost by the time the caller has to
+    // raise an error (GitHub #173).
+    std::string last_fetch_error_;
     int64_t current_audit_id_;
 
     // Totals for the audit row, accumulated across the whole extraction and written once.

--- a/src/include/odp_request_orchestrator.hpp
+++ b/src/include/odp_request_orchestrator.hpp
@@ -226,6 +226,16 @@ private:
 
     // Helper methods
     OdpRequestResult ExecuteRequest(const HttpRequest& request, const std::string& operation_type);
+
+    // Recover the delta token from the service's DeltaLinksOf<EntitySet> entity set.
+    //
+    // The inline __delta link is not reliably present: SAP returns it on the first read of
+    // a freshly generated service and not on later full extractions of the same one, so
+    // reading only the response body leaves the subscription with no token and every later
+    // read re-extracts everything. The token is always discoverable here. Returns an empty
+    // string when the service exposes no such entity set (an ODP without delta support) or
+    // the lookup fails - callers stay in initial-load mode, as before. See GitHub #169.
+    std::string FetchDeltaTokenFromDeltaLinks(const HttpUrl& entity_set_url);
     std::shared_ptr<ODataEntitySetResponse> ProcessHttpResponse(std::unique_ptr<HttpResponse> http_response);
     void LogRequestDetails(const HttpRequest& request, const std::string& operation_type) const;
     void LogResponseDetails(const OdpRequestResult& result, const std::string& operation_type) const;

--- a/src/odata_url_helpers.cpp
+++ b/src/odata_url_helpers.cpp
@@ -310,6 +310,55 @@ std::string ODataDeltaLink::ExtractDeltaLink(const std::string &json_body) {
     return delta_link;
 }
 
+std::string ODataDeltaLink::ExtractTokenFromDeltaLinksPayload(const std::string &json_body) {
+    if (json_body.empty()) {
+        return std::string();
+    }
+
+    auto *doc = duckdb_yyjson::yyjson_read(json_body.c_str(), json_body.size(), 0);
+    if (doc == nullptr) {
+        return std::string();
+    }
+
+    std::string token;
+    std::string initial_load_token;
+
+    auto *root = duckdb_yyjson::yyjson_doc_get_root(doc);
+    auto *d_wrapper = (root != nullptr && duckdb_yyjson::yyjson_is_obj(root))
+                          ? duckdb_yyjson::yyjson_obj_get(root, "d")
+                          : nullptr;
+    auto *results = (d_wrapper != nullptr && duckdb_yyjson::yyjson_is_obj(d_wrapper))
+                        ? duckdb_yyjson::yyjson_obj_get(d_wrapper, "results")
+                        : nullptr;
+
+    if (results != nullptr && duckdb_yyjson::yyjson_is_arr(results)) {
+        size_t idx = 0;
+        size_t max = 0;
+        duckdb_yyjson::yyjson_val *row = nullptr;
+        yyjson_arr_foreach(results, idx, max, row) {
+            if (!duckdb_yyjson::yyjson_is_obj(row)) {
+                continue;
+            }
+            const auto row_token = ReadStringMember(row, "DeltaToken");
+            if (row_token.empty()) {
+                continue;
+            }
+            if (token.empty()) {
+                token = row_token;
+            }
+            // SAP reports IsInitialLoad as the string "True"/"False" in the v2 JSON shape.
+            const auto is_initial = ReadStringMember(row, "IsInitialLoad");
+            if (initial_load_token.empty() &&
+                (is_initial == "True" || is_initial == "true")) {
+                initial_load_token = row_token;
+            }
+        }
+    }
+
+    duckdb_yyjson::yyjson_doc_free(doc);
+    return initial_load_token.empty() ? token : initial_load_token;
+}
+
 std::string ODataDeltaLink::ExtractDeltaToken(const std::string &json_body) {
     return ExtractToken(ExtractDeltaLink(json_body));
 }

--- a/src/odp_odata_read_bind_data.cpp
+++ b/src/odp_odata_read_bind_data.cpp
@@ -109,7 +109,15 @@ unsigned int OdpODataReadBindData::FetchNextResult(duckdb::DataChunk &output) {
             }
             
             if (!success) {
-                throw duckdb::InternalException("Failed to perform ODP data fetch");
+                // Deliberately NOT an InternalException. DuckDB reads ExceptionType::INTERNAL
+                // as "this process's invariants are broken" and invalidates the whole database
+                // instance, so every later query - including ones unrelated to ODP - fails with
+                // "Failure within transaction management!". A service refusing an extraction is
+                // an ordinary I/O outcome (GitHub #173).
+                throw duckdb::IOException(
+                    "ODP data fetch failed for " + entity_set_url_ + ": " +
+                    (last_fetch_error_.empty() ? std::string("the service gave no reason")
+                                               : last_fetch_error_));
             }
             
             first_fetch_completed_ = true;
@@ -330,6 +338,7 @@ bool OdpODataReadBindData::HandleInitialLoad() {
         auto result = request_orchestrator_->ExecuteInitialLoad(entity_set_url_, max_page_size_);
 
         if (!result.response) {
+            last_fetch_error_ = "the service returned no response to the initial load";
             return false;
         }
 
@@ -355,6 +364,7 @@ bool OdpODataReadBindData::HandleInitialLoad() {
 
     } catch (const std::exception& e) {
         ERPL_TRACE_ERROR("ODP_BIND_DATA", "Initial load failed: " + std::string(e.what()));
+        last_fetch_error_ = e.what();
         state_manager_->TransitionToError("Initial load failed: " + std::string(e.what()));
         return false;
     }
@@ -378,6 +388,7 @@ bool OdpODataReadBindData::HandleDeltaFetch() {
         auto result = request_orchestrator_->ExecuteDeltaFetch(entity_set_url_, current_token, max_page_size_);
 
         if (!result.response) {
+            last_fetch_error_ = "the service returned no response to the delta fetch";
             return false;
         }
 
@@ -418,6 +429,7 @@ bool OdpODataReadBindData::HandleDeltaFetch() {
             state_manager_->TransitionToInitialLoad();
             return HandleInitialLoad();
         }
+        last_fetch_error_ = e.what();
         state_manager_->TransitionToError("Delta fetch failed: " + std::string(e.what()));
         return false;
     }

--- a/src/odp_request_orchestrator.cpp
+++ b/src/odp_request_orchestrator.cpp
@@ -210,6 +210,54 @@ std::string OdpRequestOrchestrator::ExtractDeltaToken(const ODataEntitySetRespon
     return delta_token;
 }
 
+std::string OdpRequestOrchestrator::FetchDeltaTokenFromDeltaLinks(const HttpUrl& entity_set_url)
+{
+    // .../<service>/FactsOfX  ->  .../<service>/DeltaLinksOfFactsOfX
+    auto path = entity_set_url.Path();
+    const auto last_slash = path.rfind('/');
+    if (last_slash == std::string::npos || last_slash + 1 >= path.size()) {
+        return std::string();
+    }
+    const auto entity_set_name = path.substr(last_slash + 1);
+    if (entity_set_name.rfind("DeltaLinksOf", 0) == 0) {
+        return std::string();  // never recurse into the delta-links set itself
+    }
+
+    HttpUrl delta_links_url(entity_set_url);
+    delta_links_url.Path(path.substr(0, last_slash + 1) + "DeltaLinksOf" + entity_set_name);
+    delta_links_url.Query("?$format=json");
+
+    try {
+        HttpRequest request(HttpMethod::GET, delta_links_url);
+        request.headers["Accept"] = "application/json";
+        if (auth_params_ != nullptr && delta_links_url.IsSameOrigin(entity_set_url)) {
+            request.AuthHeadersFromParams(*auth_params_);
+        }
+
+        auto response = http_client_->SendRequest(request);
+        if (!response || response->Code() < 200 || response->Code() >= 300) {
+            ERPL_TRACE_DEBUG("ODP_ORCHESTRATOR",
+                             "DeltaLinksOf lookup did not succeed; staying in initial-load mode");
+            return std::string();
+        }
+
+        const auto token = ODataDeltaLink::ExtractTokenFromDeltaLinksPayload(response->Content());
+        if (token.empty()) {
+            ERPL_TRACE_DEBUG("ODP_ORCHESTRATOR", "DeltaLinksOf carried no token");
+        } else {
+            ERPL_TRACE_INFO("ODP_ORCHESTRATOR",
+                            "Recovered delta token from DeltaLinksOf: " + token.substr(0, 20) + "...");
+        }
+        return token;
+    } catch (const std::exception& e) {
+        // Never fail the extraction over this: the rows have already been delivered, and a
+        // missing token only costs a full re-read next time.
+        ERPL_TRACE_WARN("ODP_ORCHESTRATOR",
+                        std::string("DeltaLinksOf lookup failed: ") + e.what());
+        return std::string();
+    }
+}
+
 std::string OdpRequestOrchestrator::BuildDeltaUrl(const std::string& base_url, const std::string& delta_token) {
     ERPL_TRACE_DEBUG("ODP_ORCHESTRATOR", duckdb::StringUtil::Format(
         "Building delta URL from base: %s, token: %s", base_url, delta_token.substr(0, 20) + "..."));
@@ -356,9 +404,23 @@ OdpRequestOrchestrator::OdpRequestResult OdpRequestOrchestrator::ExecuteRequest(
         // Extract delta token if present
         result.extracted_delta_token = ExtractDeltaToken(*result.response);
 
+
         // Check for next page
         auto next_url = result.response->NextUrl();
         result.has_more_pages = next_url.has_value() && !next_url->empty();
+
+        // The body does not always carry a delta link. When the server confirmed change
+        // tracking and this was the terminal page, ask the service for the token rather
+        // than silently dropping back to initial-load mode and re-extracting everything on
+        // the next read (GitHub #169). Checked after has_more_pages is known, because only
+        // the last page of an extraction can carry a token.
+        if (result.extracted_delta_token.empty() && result.preference_applied &&
+            !result.has_more_pages) {
+            ERPL_TRACE_DEBUG("ODP_ORCHESTRATOR",
+                             "Change tracking was applied but the response carried no delta link; "
+                             "asking the service for the current token");
+            result.extracted_delta_token = FetchDeltaTokenFromDeltaLinks(request.url);
+        }
 
         LogResponseDetails(result, operation_type);
         

--- a/test/cpp/test_odata_url_helpers.cpp
+++ b/test/cpp/test_odata_url_helpers.cpp
@@ -167,3 +167,37 @@ TEST_CASE("normalizeAndSanitizeExpand keeps a parenthesis inside a literal from 
     // $select is part of the same option group, so it must still be $-prefixed and present.
     REQUIRE(sanitized.find("$select=Name") != std::string::npos);
 }
+
+// GitHub #169: the inline __delta link is not reliably present - SAP returns it on the
+// first read of a freshly generated service and not on later full extractions of the same
+// one. The token is always available from the DeltaLinksOf<EntitySet> collection, whose
+// rows carry it as a property rather than inside a link.
+TEST_CASE("ODataDeltaLink reads a token out of a DeltaLinksOf payload", "[odata_url]") {
+    const std::string payload =
+        R"({"d":{"results":[{"__metadata":{"type":"SRV.DeltaLinkDetails"},)"
+        R"("DeltaToken":"D20260912034532_000042000","IsInitialLoad":"True"}]}})";
+
+    REQUIRE(ODataDeltaLink::ExtractTokenFromDeltaLinksPayload(payload) ==
+            "D20260912034532_000042000");
+}
+
+TEST_CASE("ODataDeltaLink prefers the initial-load delta link", "[odata_url]") {
+    // Several links can be open at once. The initial-load one is the pointer a fresh
+    // subscription should resume from; picking an arbitrary row would skip changes.
+    const std::string payload =
+        R"({"d":{"results":[)"
+        R"({"DeltaToken":"D_LATER","IsInitialLoad":"False"},)"
+        R"({"DeltaToken":"D_INITIAL","IsInitialLoad":"True"}]}})";
+
+    REQUIRE(ODataDeltaLink::ExtractTokenFromDeltaLinksPayload(payload) == "D_INITIAL");
+}
+
+TEST_CASE("ODataDeltaLink returns nothing for a DeltaLinksOf payload with no links",
+          "[odata_url]") {
+    // An ODP without delta support exposes no such collection, and a subscription with no
+    // open link returns an empty set. Both must leave the caller in initial-load mode
+    // rather than inventing a token.
+    REQUIRE(ODataDeltaLink::ExtractTokenFromDeltaLinksPayload(R"({"d":{"results":[]}})").empty());
+    REQUIRE(ODataDeltaLink::ExtractTokenFromDeltaLinksPayload("").empty());
+    REQUIRE(ODataDeltaLink::ExtractTokenFromDeltaLinksPayload("not json").empty());
+}

--- a/test/cpp/test_odp_audit_totals.cpp
+++ b/test/cpp/test_odp_audit_totals.cpp
@@ -73,3 +73,42 @@ TEST_CASE("the ODP audit row records the whole extraction, not the last chunk",
     REQUIRE_FALSE(recorded.IsNull());
     REQUIRE(recorded.GetValue<int64_t>() == static_cast<int64_t>(ROW_COUNT));
 }
+
+// GitHub #169: a full extraction whose body carries no __delta must still leave the
+// subscription able to do a delta next time. Before this, the token stayed empty and every
+// later read re-extracted the entire dataset - silently, since the rows were all correct.
+TEST_CASE("a delta token is recovered from DeltaLinksOf when the body has none",
+          "[odp_audit][odp_delta]") {
+    ODataTestServer server;
+    const std::string service = "/sap/opu/odata/sap/Z_TEST_SRV";
+
+    server.ServeMetadataFixture(service + "/$metadata", "edm_sap_odp_bw_fact.xml");
+    server.ServeMetadataFixture(service + "/FactsOf0D_NW_C01/$metadata",
+                                "edm_sap_odp_bw_fact.xml");
+
+    // The extraction: rows, change tracking confirmed, and deliberately NO __delta.
+    server.OnPath(service + "/FactsOf0D_NW_C01",
+                  CannedResponse::Json(MakeOdpPage(3))
+                      .WithHeader("Preference-Applied", "odata.track-changes"));
+
+    // The service still knows the token, through the delta-links collection.
+    server.OnPath(service + "/DeltaLinksOfFactsOf0D_NW_C01",
+                  CannedResponse::Json(
+                      R"({"d":{"results":[{"DeltaToken":"D_RECOVERED_0001",)"
+                      R"("IsInitialLoad":"True"}]}})"));
+
+    odp_test::TempDatabase db("odp_delta_recovery");
+    auto &con = db.Conn();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto read = con.Query("SELECT COUNT(*) FROM odp_odata_read('" + server.Url(service + "/FactsOf0D_NW_C01") + "')");
+    INFO((read->HasError() ? read->GetError() : std::string()));
+    REQUIRE_FALSE(read->HasError());
+    REQUIRE(read->GetValue(0, 0).GetValue<int64_t>() == 3);
+
+    auto state = con.Query("SELECT delta_token FROM erpl_web.odp_subscriptions");
+    REQUIRE_FALSE(state->HasError());
+    REQUIRE(state->RowCount() == 1);
+    INFO("stored delta token: " << state->GetValue(0, 0).ToString());
+    CHECK(state->GetValue(0, 0).ToString() == "D_RECOVERED_0001");
+}

--- a/test/cpp/test_odp_fetch_failure_reporting.cpp
+++ b/test/cpp/test_odp_fetch_failure_reporting.cpp
@@ -1,0 +1,69 @@
+// GitHub #173: when an ODP fetch fails against the service, the reader discards the
+// service's own explanation and throws duckdb::InternalException("Failed to perform ODP
+// data fetch").
+//
+// Two separate problems, both of which this file pins down:
+//
+//   1. The message is useless. SAP answers a refused extraction with a precise reason
+//      ("Could not open data access via extraction API RODPS_REPL_ODP_OPEN",
+//      RSODP_ODATA/013). That text reaches the trace log and is then thrown away, so the
+//      user is told only that something failed.
+//
+//   2. InternalException is the wrong type, and not merely cosmetically. DuckDB treats
+//      ExceptionType::INTERNAL as "this process's invariants are broken": client_context
+//      calls ValidChecker::Invalidate on the whole database instance, and every later
+//      query on that database - including ones with nothing to do with ODP - fails with
+//      "Failure within transaction management!". A remote service answering HTTP 400 is
+//      an ordinary, recoverable I/O outcome and must not take the database down with it.
+
+#include "catch.hpp"
+#include "duckdb.hpp"
+
+#include "odata_test_server.hpp"
+#include "odp_test_db.hpp"
+
+#include <string>
+
+using erpl_web::test_support::CannedResponse;
+using erpl_web::test_support::ODataTestServer;
+
+namespace {
+
+// The body SAP actually returns for a refused extraction, trimmed to what matters.
+constexpr const char *SAP_REFUSAL_BODY = R"({"error":{"code":"RSODP_ODATA/013","message":{"lang":"en","value":"Could not open data access via extraction API RODPS_REPL_ODP_OPEN"}}})";
+
+}  // namespace
+
+TEST_CASE("a refused ODP extraction reports the service's reason and spares the database",
+          "[odp_fetch_failure]") {
+    ODataTestServer server;
+    server.ServeMetadataFixture("/sap/opu/odata/sap/Z_TEST_SRV/$metadata",
+                                "edm_sap_odp_bw_fact.xml");
+    server.ServeMetadataFixture("/sap/opu/odata/sap/Z_TEST_SRV/FactsOf0D_NW_C01/$metadata",
+                                "edm_sap_odp_bw_fact.xml");
+    server.OnPath("/sap/opu/odata/sap/Z_TEST_SRV/FactsOf0D_NW_C01",
+                  CannedResponse::Json(SAP_REFUSAL_BODY, 400));
+
+    odp_test::TempDatabase db("odp_fetch_failure");
+    auto &con = db.Conn();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    const auto url = server.Url("/sap/opu/odata/sap/Z_TEST_SRV/FactsOf0D_NW_C01");
+    auto read = con.Query("SELECT COUNT(*) FROM odp_odata_read('" + url + "')");
+    REQUIRE(read->HasError());
+
+    // 1. The service's own reason survives to the user.
+    const auto message = read->GetError();
+    INFO("error reported to the user: " << message);
+    REQUIRE(message.find("RODPS_REPL_ODP_OPEN") != std::string::npos);
+
+    // 2. It is not an internal error, so the database instance is still usable. A plain
+    //    SELECT is the strongest evidence: it shares nothing with ODP but fails anyway
+    //    once the instance has been invalidated.
+    REQUIRE(read->GetErrorObject().Type() != duckdb::ExceptionType::INTERNAL);
+
+    auto after = con.Query("SELECT 42");
+    INFO((after->HasError() ? after->GetError() : std::string()));
+    REQUIRE_FALSE(after->HasError());
+    REQUIRE(after->GetValue(0, 0).GetValue<int32_t>() == 42);
+}

--- a/test/sql/sap/odp_odata_delta.test
+++ b/test/sql/sap/odp_odata_delta.test
@@ -1,0 +1,67 @@
+# name: test/sql/sap/odp_odata_delta.test
+# description: the full ODP delta lifecycle against a delta-capable live SAP ODP service
+# group: [erpl_web_odp_integration]
+#
+# odp_odata_read.test only asserts the weaker "a delta fetch is not larger than a full
+# load", because the service it is gated on (ERPL_SAP_ODP_SERVICE) need not be
+# delta-capable at all. Being delta-capable is a property of the extractor, not of ODP:
+# a CDS view has to carry @Analytics.dataExtraction.delta.changeDataCapture.automatic
+# before RODPS_REPL_ODP_GET_DETAIL reports supports_delta, and only then does the
+# service expose a DeltaLinksOf<EntitySet> entity set at all.
+#
+# So this file is gated separately, on a service known to be delta-capable. It asserts
+# the thing that actually matters and that the weaker test cannot: after a full load,
+# an unchanged source yields exactly zero rows.
+
+require erpl_web
+
+statement ok
+SET autoinstall_known_extensions=1;
+
+statement ok
+SET autoload_known_extensions=1;
+
+require-env ERPL_SAP_BASE_URL
+
+require-env ERPL_SAP_PASSWORD
+
+require-env ERPL_SAP_ODP_DELTA_SERVICE
+
+require-env ERPL_SAP_ODP_DELTA_ENTITY_SET
+
+# Delta state is refused an in-memory catalog on purpose (GitHub #92). See odp_odata_read.test.
+statement ok
+ATTACH '__TEST_DIR__/odp_delta_state.db' AS odp_delta_state;
+
+statement ok
+USE odp_delta_state;
+
+statement ok
+CREATE SECRET odp_delta_secret (
+	TYPE http_basic,
+	USERNAME 'DEVELOPER',
+	PASSWORD '${ERPL_SAP_PASSWORD}',
+	SCOPE '${ERPL_SAP_BASE_URL}'
+);
+
+# The ODQ queue lives in the SAP system, not in this test's catalog, so a previous run
+# leaves a subscription behind that would make the first read below a delta rather than
+# a full load. Terminating it first is what makes this test independent of run order.
+statement ok
+SELECT status FROM http_get('${ERPL_SAP_BASE_URL}/sap/opu/odata/sap/${ERPL_SAP_ODP_DELTA_SERVICE}/TerminateDeltasFor${ERPL_SAP_ODP_DELTA_ENTITY_SET}?$format=json', auth='DEVELOPER:${ERPL_SAP_PASSWORD}', auth_type='BASIC');
+
+# The initial load delivers the whole extract and, on a delta-capable extractor, must
+# also record a delta token. The row count is a property of the provisioned dataset.
+query I
+SELECT COUNT(*) > 0 FROM odp_odata_read('${ERPL_SAP_BASE_URL}/sap/opu/odata/sap/${ERPL_SAP_ODP_DELTA_SERVICE}/${ERPL_SAP_ODP_DELTA_ENTITY_SET}', secret='odp_delta_secret');
+----
+true
+
+# Nothing changed in the source between the two reads, so the delta is empty. This is
+# the assertion the whole delta-token machinery exists for: if the token had not been
+# recorded, this would silently be a second full extraction and return the dataset again
+# (GitHub #169, #172).
+query I
+SELECT COUNT(*) FROM odp_odata_read('${ERPL_SAP_BASE_URL}/sap/opu/odata/sap/${ERPL_SAP_ODP_DELTA_SERVICE}/${ERPL_SAP_ODP_DELTA_ENTITY_SET}', secret='odp_delta_secret');
+----
+0

--- a/test/sql/sap/odp_odata_read.test
+++ b/test/sql/sap/odp_odata_read.test
@@ -49,8 +49,22 @@ true
 # Reading the same subscription twice must not duplicate the extract: the second call is
 # a delta fetch, which returns the changes since the first and not the whole dataset
 # again. This is the invariant the delta-token lifecycle exists to uphold.
+#
+# The two reads must be SEPARATE statements. An ODQ subscription is stateful in the SAP
+# system, and it admits one open extraction at a time: putting both reads in one query as
+# subselects makes the server refuse the second with
+# "Could not open data access via extraction API RODPS_REPL_ODP_OPEN" (RSODP_ODATA/013).
+# That is the service enforcing its own contract, not a defect in the reader, so the test
+# has to respect it (GitHub #173).
+statement ok
+CREATE TABLE delta_read AS
+SELECT COUNT(*) AS n FROM odp_odata_read('${ERPL_SAP_BASE_URL}/sap/opu/odata/sap/${ERPL_SAP_ODP_SERVICE}/${ERPL_SAP_ODP_ENTITY_SET}', secret='odp_odata_read_secret');
+
+statement ok
+CREATE TABLE full_read AS
+SELECT COUNT(*) AS n FROM odp_odata_read('${ERPL_SAP_BASE_URL}/sap/opu/odata/sap/${ERPL_SAP_ODP_SERVICE}/${ERPL_SAP_ODP_ENTITY_SET}', secret='odp_odata_read_secret', force_full_load=true);
+
 query I
-SELECT (SELECT COUNT(*) FROM odp_odata_read('${ERPL_SAP_BASE_URL}/sap/opu/odata/sap/${ERPL_SAP_ODP_SERVICE}/${ERPL_SAP_ODP_ENTITY_SET}', secret='odp_odata_read_secret'))
-     <= (SELECT COUNT(*) FROM odp_odata_read('${ERPL_SAP_BASE_URL}/sap/opu/odata/sap/${ERPL_SAP_ODP_SERVICE}/${ERPL_SAP_ODP_ENTITY_SET}', secret='odp_odata_read_secret', force_full_load=true));
+SELECT (SELECT n FROM delta_read) <= (SELECT n FROM full_read);
 ----
 true


### PR DESCRIPTION
Closes #169.

`force_full_load` left a subscription **permanently** out of delta mode — the token was cleared and never re-established, so every later read re-extracted the whole dataset. Silently, since the rows were all correct.

### Cause
The inline `__delta` link is **not reliably present**. SAP returns it on the first read of a freshly generated service and not on later full extractions of the same one, so reading only the response body leaves nothing to resume from.

The token is always discoverable through the `DeltaLinksOf<EntitySet>` collection the generator emits alongside the facts entity set whenever the ODP supports delta:

```
GET .../DeltaLinksOfFactsOfZJRODPVSQL?$format=json
  -> DeltaToken: D20260912034532_000042000, IsInitialLoad: True
```

When change tracking was confirmed and the terminal page carried no link, the orchestrator now asks there. A service without that collection, or a failed lookup, stays in initial-load mode exactly as before — the rows are already delivered, and a missing token costs only a full re-read.

The **initial-load** row is preferred when several links are open; that is the pointer a fresh subscription must resume from, and picking an arbitrary one would skip changes.

### My first fix was wrong, and testing it is what showed that
I proposed terminating the subscription and re-initialising. `TerminateDeltasForFactsOf<Entity>` does flip `SubscribedFlag` to `false` — but a track-changes read afterwards still returns **no** delta link at any page size, and following the paging chain to the terminal page does not produce one either. The issue is updated with that.

### Verified live
```
force_full_load=true  -> 3001 rows, token D20260912035038_000022000   (was: empty)
next read             -> 0 rows                                        (was: 3001, forever)
```

431 C++ cases / 2166 assertions; live SAP tier green. The deterministic test serves an extraction with no `__delta` plus a `DeltaLinksOf` collection and asserts the token is picked up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791777349&installation_model_id=425457&pr_number=171&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F171&signature=d64341879b5d044e01cf2ff61294bb60841633c8ac9adab7648710dbf655edbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->