### PR TITLE
feat: add max_page_size to odata_read, sending Prefer: odata.maxpagesize

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,12 +410,23 @@ WHERE Country = 'Germany';
 -- Fail the query on the first value that cannot be converted to its column
 -- type, instead of receiving it as a NULL that looks like server-sent NULL
 SELECT * FROM odata_read('https://example.com/svc/Orders', strict_typing = true);
+
+-- Ask the service for larger pages, so a big extraction needs fewer round trips
+SELECT * FROM odata_read('https://example.com/svc/Orders', max_page_size = 5000);
 ```
 
 By default (`strict_typing = false`) a value that cannot be converted is
 returned as `NULL`, the rest of the row is kept, and a warning naming the
 column, the number of failures and the first offending value is printed once
 per scan. Values are never silently replaced by `0`, `''` or `false`.
+
+`max_page_size` sends `Prefer: odata.maxpagesize=N`, which is OData's way for a
+client to ask for larger pages. It is a *preference*: a service is free to
+ignore it or to cap it lower, and the reader follows whatever pages it actually
+gets. Omit the parameter to send no preference at all — that is not the same as
+sending a default, since a `Prefer` header can itself change how a service
+pages. Raising it is the supported answer when a very large extraction hits the
+10,000-page server-driven paging ceiling.
 
 Attach usage:
 

--- a/src/include/odata_client.hpp
+++ b/src/include/odata_client.hpp
@@ -123,6 +123,12 @@ private:
 
 // ----------------------------------------------------------------------
 
+// Built as a named function rather than inline at the throw site so it can be asserted
+// without driving 10000 real round trips. The advice has to name max_page_size: telling a
+// caller to "ask the service for larger pages" without naming the parameter that does so
+// is advice they cannot act on (GitHub #161).
+std::string BuildPageLimitExceededMessage(idx_t limit, const std::string& last_url);
+
 template <typename TResponse>
 class ODataClient {
 public:    
@@ -213,6 +219,18 @@ public:
     // links forever.
     static constexpr idx_t MAX_PAGE_REQUESTS = 10000;
 
+    // OData's way for a client to ask a service for bigger pages
+    // (Prefer: odata.maxpagesize=N). Unset means "send no preference at all", which is not
+    // the same as sending a default: a Prefer header the caller never asked for can make a
+    // service page differently than it otherwise would.
+    void SetMaxPageSize(uint32_t max_page_size) { max_page_size_ = max_page_size; }
+
+    // Read back so the setting survives the places a client is re-minted mid-query:
+    // CloneForScan gives each execution a private cursor, and predicate pushdown rebuilds
+    // the client when it changes the URL. Anything not copied at those two sites is
+    // silently lost, which is how this was first written.
+    std::optional<uint32_t> GetMaxPageSize() const { return max_page_size_; }
+
 protected:
     // Deliberately the bare client, not CachingHttpClient. That wrapper is a process-wide
     // 30s response cache keyed on method + URL + body hash, with credentials excluded from
@@ -229,6 +247,7 @@ protected:
     ODataVersion odata_version;
     std::string metadata_context_url; // For Datasphere dual-URL pattern
     idx_t page_requests = 0;          // Pages fetched via a next link on this client
+    std::optional<uint32_t> max_page_size_;  // Prefer: odata.maxpagesize=N, when asked for
 
     std::unique_ptr<HttpResponse> DoHttpGet(const HttpUrl& url) {
         // Create a copy of the URL to modify with input parameters
@@ -246,6 +265,11 @@ protected:
         // Set OData version and add appropriate headers
         http_request.SetODataVersion(odata_version);
         http_request.AddODataVersionHeaders();
+
+        if (max_page_size_.has_value()) {
+            http_request.headers["Prefer"] =
+                "odata.maxpagesize=" + std::to_string(max_page_size_.value());
+        }
         
         // Credentials go only to the origin this client was pointed at. Server-driven
         // paging follows whatever URL the service puts in @odata.nextLink / __next, so

--- a/src/include/odata_client.hpp
+++ b/src/include/odata_client.hpp
@@ -129,6 +129,16 @@ private:
 // is advice they cannot act on (GitHub #161).
 std::string BuildPageLimitExceededMessage(idx_t limit, const std::string& last_url);
 
+// Validate a max_page_size named parameter. Shared by odata_read and odp_odata_read so the
+// same user-facing parameter cannot behave differently depending on which reader is asked:
+// odp_odata_read used to take a bare GetValue<uint32_t> with no checks, which let
+// `Prefer: odata.maxpagesize=0` reach the wire and fail service-side instead of locally
+// (GitHub #185).
+//
+// Throws InvalidInputException - a bad argument is the caller's, not a broken invariant of
+// ours, and ExceptionType::INTERNAL would invalidate the whole database instance.
+uint32_t ValidateMaxPageSizeParameter(const duckdb::Value& value);
+
 template <typename TResponse>
 class ODataClient {
 public:    
@@ -580,7 +590,12 @@ public:
     };
     
     // Single probe to determine content type and version
-    static ProbeResult ProbeUrl(const std::string& url, std::shared_ptr<HttpAuthParams> auth_params);
+    // max_page_size is taken here, not applied to the client afterwards, because the probe
+    // response IS page one: FromProbeResult buffers it, and for an unprojected read the URL
+    // never changes so that buffer is never refetched. Setting the preference after the
+    // probe therefore missed the first page entirely (GitHub #185).
+    static ProbeResult ProbeUrl(const std::string& url, std::shared_ptr<HttpAuthParams> auth_params,
+                                std::optional<uint32_t> max_page_size = std::nullopt);
     
     // Create appropriate client based on probe result
     static std::shared_ptr<ODataEntitySetClient> CreateEntitySetClient(const ProbeResult& result);

--- a/src/odata_client.cpp
+++ b/src/odata_client.cpp
@@ -9,6 +9,14 @@ namespace erpl_web {
 
 uint32_t ValidateMaxPageSizeParameter(const duckdb::Value& value)
 {
+    // NULL reaches GetValue<uint64_t>() as 0 on some paths and throws on others; either
+    // way "max_page_size => NULL" is a caller mistake that deserves its own message rather
+    // than the reject-zero one, which would misdescribe what they wrote (GitHub #185).
+    if (value.IsNull()) {
+        throw duckdb::InvalidInputException(
+            "max_page_size must be a positive integer, not NULL; omit the parameter to send "
+            "no page-size preference at all");
+    }
     const auto requested = value.GetValue<uint64_t>();
     if (requested == 0) {
         throw duckdb::InvalidInputException(

--- a/src/odata_client.cpp
+++ b/src/odata_client.cpp
@@ -6,6 +6,17 @@
 
 namespace erpl_web {
 
+std::string BuildPageLimitExceededMessage(idx_t limit, const std::string& last_url)
+{
+    return "OData server-driven paging exceeded the limit of " + std::to_string(limit) +
+           " pages; the service keeps advertising a next link. Either the service is "
+           "looping, or this extraction genuinely needs more pages than the limit allows. "
+           "In that case narrow the read with a filter, or ask the service for larger pages "
+           "with the max_page_size parameter (odata_read(..., max_page_size => 5000)), which "
+           "sends Prefer: odata.maxpagesize. Last URL: " + last_url;
+}
+
+
 
 // ----------------------------------------------------------------------
 
@@ -213,11 +224,7 @@ std::shared_ptr<ODataEntitySetResponse> ODataEntitySetClient::Get(bool get_next)
             // extraction has no way to guess that a narrower query or a larger server page
             // size is the answer, and a bare "limit exceeded" reads like a bug in us.
             throw std::runtime_error(
-                "OData server-driven paging exceeded the limit of " + std::to_string(MAX_PAGE_REQUESTS) +
-                " pages; the service keeps advertising a next link. Either the service is "
-                "looping, or this extraction genuinely needs more pages than the limit "
-                "allows - in which case narrow the read with a filter, or ask the service "
-                "for larger pages. Last URL: " + resolved_next_url.ToString());
+                BuildPageLimitExceededMessage(MAX_PAGE_REQUESTS, resolved_next_url.ToString()));
         }
         page_requests++;
 

--- a/src/odata_client.cpp
+++ b/src/odata_client.cpp
@@ -1,3 +1,4 @@
+#include <limits>
 #include <cpptrace/cpptrace.hpp>
 
 #include "odata_client.hpp"
@@ -5,6 +6,22 @@
 #include "odata_url_helpers.hpp"
 
 namespace erpl_web {
+
+uint32_t ValidateMaxPageSizeParameter(const duckdb::Value& value)
+{
+    const auto requested = value.GetValue<uint64_t>();
+    if (requested == 0) {
+        throw duckdb::InvalidInputException(
+            "max_page_size must be greater than 0; omit the parameter to send no page-size "
+            "preference at all");
+    }
+    if (requested > std::numeric_limits<uint32_t>::max()) {
+        throw duckdb::InvalidInputException(
+            "max_page_size must fit in 32 bits; %llu is larger than any service will honour",
+            static_cast<unsigned long long>(requested));
+    }
+    return static_cast<uint32_t>(requested);
+}
 
 std::string BuildPageLimitExceededMessage(idx_t limit, const std::string& last_url)
 {
@@ -684,7 +701,7 @@ Edmx ODataServiceClient::GetMetadata()
 // ODataClientFactory Implementation
 // -------------------------------------------------------------------------------------------------
 
-ODataClientFactory::ProbeResult ODataClientFactory::ProbeUrl(const std::string& url, std::shared_ptr<HttpAuthParams> auth_params)
+ODataClientFactory::ProbeResult ODataClientFactory::ProbeUrl(const std::string& url, std::shared_ptr<HttpAuthParams> auth_params, std::optional<uint32_t> max_page_size)
 {
     ERPL_TRACE_DEBUG("ODATA_FACTORY", "Probing URL: " + url);
     
@@ -774,6 +791,13 @@ ODataClientFactory::ProbeResult ODataClientFactory::ProbeUrl(const std::string& 
     // Don't add OData version headers for the probe - let the service respond naturally
     if (auth_params != nullptr) {
         http_request.AuthHeadersFromParams(*auth_params);
+    }
+
+    // The probe body becomes page one, so the caller's page-size preference has to travel
+    // with it or the first page is fetched at the service's default size (GitHub #185).
+    if (max_page_size.has_value()) {
+        http_request.headers["Prefer"] =
+            "odata.maxpagesize=" + std::to_string(max_page_size.value());
     }
     
     auto http_response = http_client->SendRequest(http_request);

--- a/src/odata_read_functions.cpp
+++ b/src/odata_read_functions.cpp
@@ -1,3 +1,4 @@
+#include <limits>
 #include "duckdb/function/table_function.hpp"
 
 #include "datazoo/oauth2/http_client.hpp"
@@ -173,6 +174,32 @@ void ProcessNamedParameters(ODataReadBindData *bind_data,
       bind_data->SetStrictTyping(strict_value);
   }
 
+  // Handle MAX_PAGE_SIZE parameter
+  if (input.named_parameters.find("max_page_size") !=
+      input.named_parameters.end()) {
+    const auto requested =
+        input.named_parameters["max_page_size"].GetValue<duckdb::idx_t>();
+    // Zero is not "no preference" - it is a preference no service can honour. Rejecting it
+    // here, where the caller can see why, beats putting it on the wire. This is a bad
+    // argument from the caller, so it must not be an InternalException: DuckDB treats
+    // ExceptionType::INTERNAL as a broken process invariant and invalidates the whole
+    // database instance.
+    if (requested == 0) {
+      throw duckdb::InvalidInputException(
+          "max_page_size must be greater than 0; omit the parameter to send no page-size "
+          "preference at all");
+    }
+    if (requested > std::numeric_limits<uint32_t>::max()) {
+      throw duckdb::InvalidInputException(
+          "max_page_size must fit in 32 bits; %llu is larger than any service will honour",
+          static_cast<unsigned long long>(requested));
+    }
+    ERPL_TRACE_DEBUG("ODATA_BIND",
+                     duckdb::StringUtil::Format(
+                         "Named parameter 'max_page_size' set to: %d", requested));
+    bind_data->GetODataClient()->SetMaxPageSize(static_cast<uint32_t>(requested));
+  }
+
   // Handle COUNT parameter
   if (input.named_parameters.find("count") != input.named_parameters.end()) {
       auto count_value =
@@ -301,6 +328,7 @@ TableFunctionSet CreateODataReadFunction() {
     read_entity_set.named_parameters["skip"] = LogicalTypeId::UBIGINT;
     read_entity_set.named_parameters["expand"] = LogicalTypeId::VARCHAR;
     read_entity_set.named_parameters["count"] = LogicalTypeId::BOOLEAN;
+    read_entity_set.named_parameters["max_page_size"] = LogicalTypeId::UBIGINT;
     // Off by default: turning today's silently-wrong queries into hard
     // failures would be its own regression. On, a value we cannot convert
     // fails the query instead of arriving as an indistinguishable NULL.

--- a/src/odata_read_functions.cpp
+++ b/src/odata_read_functions.cpp
@@ -1,3 +1,4 @@
+#include <optional>
 #include <limits>
 #include "duckdb/function/table_function.hpp"
 
@@ -177,27 +178,14 @@ void ProcessNamedParameters(ODataReadBindData *bind_data,
   // Handle MAX_PAGE_SIZE parameter
   if (input.named_parameters.find("max_page_size") !=
       input.named_parameters.end()) {
+    // Validation is shared with odp_odata_read so the same parameter cannot behave
+    // differently depending on which reader is asked (GitHub #185).
     const auto requested =
-        input.named_parameters["max_page_size"].GetValue<duckdb::idx_t>();
-    // Zero is not "no preference" - it is a preference no service can honour. Rejecting it
-    // here, where the caller can see why, beats putting it on the wire. This is a bad
-    // argument from the caller, so it must not be an InternalException: DuckDB treats
-    // ExceptionType::INTERNAL as a broken process invariant and invalidates the whole
-    // database instance.
-    if (requested == 0) {
-      throw duckdb::InvalidInputException(
-          "max_page_size must be greater than 0; omit the parameter to send no page-size "
-          "preference at all");
-    }
-    if (requested > std::numeric_limits<uint32_t>::max()) {
-      throw duckdb::InvalidInputException(
-          "max_page_size must fit in 32 bits; %llu is larger than any service will honour",
-          static_cast<unsigned long long>(requested));
-    }
+        ValidateMaxPageSizeParameter(input.named_parameters["max_page_size"]);
     ERPL_TRACE_DEBUG("ODATA_BIND",
                      duckdb::StringUtil::Format(
                          "Named parameter 'max_page_size' set to: %d", requested));
-    bind_data->GetODataClient()->SetMaxPageSize(static_cast<uint32_t>(requested));
+    bind_data->GetODataClient()->SetMaxPageSize(requested);
   }
 
   // Handle COUNT parameter
@@ -244,8 +232,17 @@ ODataReadBind(ClientContext &context, TableFunctionBindInput &input,
                       "Binding OData read function for URL: %s", url.c_str()));
 
   try {
+    // Read and validate max_page_size BEFORE probing. The probe response is page one -
+    // FromProbeResult buffers it - and for an unprojected read the URL never changes, so
+    // that buffer is never refetched. Applying the preference only afterwards left the
+    // first page at the service's default size (GitHub #185).
+    std::optional<uint32_t> max_page_size;
+    if (input.named_parameters.find("max_page_size") != input.named_parameters.end()) {
+      max_page_size = ValidateMaxPageSizeParameter(input.named_parameters["max_page_size"]);
+    }
+
     // Single probe to determine content type and version
-    auto probe_result = ODataClientFactory::ProbeUrl(url, auth_params);
+    auto probe_result = ODataClientFactory::ProbeUrl(url, auth_params, max_page_size);
 
   // Create appropriate bind data based on probe result with fallback heuristic
   duckdb::unique_ptr<ODataReadBindData> bind_data;

--- a/src/odata_read_functions.cpp
+++ b/src/odata_read_functions.cpp
@@ -257,6 +257,16 @@ ODataReadBind(ClientContext &context, TableFunctionBindInput &input,
   ODataReadBindHelpers::SetupSchemaFromProbeResult(
       probe_result, bind_data.get(), return_types, names);
 
+  // A service root lists entity sets rather than reading one, and the block below - which
+  // is where max_page_size is applied to the client - is skipped for it. The preference
+  // still rides the probe request (it is passed to ProbeUrl above), but nothing would
+  // carry it onto any later request, so apply it here too rather than accepting the
+  // parameter and quietly ignoring it (GitHub #185).
+  if (probe_result.is_service_root && max_page_size.has_value() &&
+      bind_data->GetODataClient() != nullptr) {
+    bind_data->GetODataClient()->SetMaxPageSize(max_page_size.value());
+  }
+
   // Handle named parameters and URL expand clause (only for entity-set mode)
   if (!probe_result.is_service_root) {
     // Process named parameters (top, skip, expand)

--- a/src/odata_read_pushdown.cpp
+++ b/src/odata_read_pushdown.cpp
@@ -174,6 +174,7 @@ void ODataReadBindData::UpdateUrlFromPredicatePushdown() {
 
     // Store the current OData version before creating new client
     auto current_version = odata_client->GetODataVersion();
+  const auto current_max_page_size = odata_client->GetMaxPageSize();
   // Datasphere's dual-URL state. CloneForScan carries these, and this rebuild used to
   // throw them away one statement later on every projecting or filtered query - which is
   // why a SELECT * test could not reproduce the loss: SELECT * takes the early return
@@ -186,6 +187,9 @@ void ODataReadBindData::UpdateUrlFromPredicatePushdown() {
   odata_client = std::make_shared<ODataEntitySetClient>(
       http_client, updated_url, auth_params);
 
+  if (current_max_page_size.has_value()) {
+    odata_client->SetMaxPageSize(current_max_page_size.value());
+  }
   if (!current_metadata_context.empty()) {
     odata_client->SetMetadataContextUrl(current_metadata_context);
   }

--- a/src/odata_read_scan_state.cpp
+++ b/src/odata_read_scan_state.cpp
@@ -436,6 +436,9 @@ duckdb::unique_ptr<ODataReadBindData> ODataReadBindData::CloneForScan() const {
     // follow that page's next link without re-fetching it, while keeping the cursor
     // private. Deliberately NOT odata_client->current_response: after one execution that
     // is the LAST page, and resuming from it would return nothing.
+    if (const auto page_size = odata_client->GetMaxPageSize()) {
+      scan_client->SetMaxPageSize(page_size.value());
+    }
     // Datasphere's dual-URL shape: FromEntitySetRoot stores the @odata.context metadata
     // URL and the entity-set name from its fragment at bind time, gated on
     // IsDatasphereUrl. A clone that adopts page one never runs the code that derives them

--- a/src/odp_odata_read_functions.cpp
+++ b/src/odp_odata_read_functions.cpp
@@ -46,7 +46,10 @@ duckdb::unique_ptr<duckdb::FunctionData> OdpODataReadBind(duckdb::ClientContext 
             import_delta_token = kv.second.ToString();
             ERPL_TRACE_DEBUG("ODP_ODATA_READ_BIND", "Import delta token: " + import_delta_token);
         } else if (kv.first == "max_page_size") {
-            max_page_size = kv.second.GetValue<uint32_t>();
+            // Shared with odata_read: a bare GetValue<uint32_t> let max_page_size=0 through
+            // and put `Prefer: odata.maxpagesize=0` on the wire, turning a bad argument into
+            // a service-side failure (GitHub #185).
+            max_page_size = ValidateMaxPageSizeParameter(kv.second);
             ERPL_TRACE_DEBUG("ODP_ODATA_READ_BIND", "Max page size: " + std::to_string(max_page_size.value()));
         }
     }
@@ -226,7 +229,9 @@ duckdb::TableFunctionSet CreateOdpODataReadFunction() {
     odp_read_function.named_parameters["secret"] = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
     odp_read_function.named_parameters["force_full_load"] = duckdb::LogicalType(duckdb::LogicalTypeId::BOOLEAN);
     odp_read_function.named_parameters["import_delta_token"] = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
-    odp_read_function.named_parameters["max_page_size"] = duckdb::LogicalType(duckdb::LogicalTypeId::UINTEGER);
+    // UBIGINT to match odata_read; the shared validator range-checks it down to 32 bits
+    // and reports an out-of-range value as an argument error rather than silently wrapping.
+    odp_read_function.named_parameters["max_page_size"] = duckdb::LogicalType(duckdb::LogicalTypeId::UBIGINT);
     
     function_set.AddFunction(odp_read_function);
     

--- a/test/cpp/test_odata_max_page_size.cpp
+++ b/test/cpp/test_odata_max_page_size.cpp
@@ -1,0 +1,236 @@
+// GitHub #161 left odata_read with a hard ceiling of 10000 server-driven pages and no way
+// for a caller to do anything about it. The error text tells them to "ask the service for
+// larger pages", which is sound advice with no supported way to follow it: OData says a
+// client asks with `Prefer: odata.maxpagesize=N`, and odata_read had no such parameter.
+// odp_odata_read has had one all along (odp_http_request_factory.cpp), so the asymmetry
+// was accidental rather than deliberate.
+
+#include "catch.hpp"
+#include "duckdb.hpp"
+
+#include "odata_test_server.hpp"
+#include "odata_client.hpp"
+
+#include <string>
+
+using erpl_web::test_support::CannedResponse;
+using erpl_web::test_support::MakeV4Page;
+using erpl_web::test_support::ODataTestServer;
+using erpl_web::test_support::RecordedRequest;
+
+namespace {
+
+// See CLAUDE.md: a bare DuckDB(nullptr) crashes in DEBUG builds shortly after the first
+// query unless jemalloc's background threads own arena management.
+class TestDatabase {
+public:
+    TestDatabase()
+    {
+        config.SetOption("allocator_background_threads", duckdb::Value::BOOLEAN(true));
+        database = duckdb::make_uniq<duckdb::DuckDB>(nullptr, &config);
+        connection = duckdb::make_uniq<duckdb::Connection>(*database);
+    }
+
+    duckdb::Connection &Con() const { return *connection; }
+
+private:
+    duckdb::DBConfig config;
+    duckdb::unique_ptr<duckdb::DuckDB> database;
+    duckdb::unique_ptr<duckdb::Connection> connection;
+};
+
+const char *const AIRLINE_AA = R"({"AirlineCode":"AA","Name":"American Airlines"})";
+const char *const AIRLINE_FM = R"({"AirlineCode":"FM","Name":"Shanghai Airline"})";
+
+}  // namespace
+
+TEST_CASE("odata_read asks the service for a page size with Prefer", "[odata_maxpagesize]") {
+    ODataTestServer server;
+    const std::string entity_url = server.Url("/mps/Airlines");
+    const std::string context = server.Url("/mps/$metadata") + "#Airlines";
+
+    server.ServeMetadataFixture("/mps/$metadata", "edm_trippin.xml");
+    server.OnPath("/mps/Airlines",
+                  CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA, AIRLINE_FM})));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto result = con.Query("SELECT COUNT(*) FROM odata_read('" + entity_url +
+                            "', max_page_size=5000)");
+    INFO((result->HasError() ? result->GetError() : std::string()));
+    REQUIRE_FALSE(result->HasError());
+    REQUIRE(result->GetValue(0, 0).GetValue<int64_t>() == 2);
+
+    bool asked = false;
+    for (const auto &request : server.RequestsFor("/mps/Airlines")) {
+        INFO("Prefer: " << request.Header("Prefer"));
+        if (request.Header("Prefer").find("odata.maxpagesize=5000") != std::string::npos) {
+            asked = true;
+        }
+    }
+    INFO("no request to the entity set carried Prefer: odata.maxpagesize=5000");
+    REQUIRE(asked);
+}
+
+// Without the parameter nothing changes: a Prefer header the caller did not ask for can
+// make a service page differently than it otherwise would.
+TEST_CASE("odata_read sends no page-size preference unless asked", "[odata_maxpagesize]") {
+    ODataTestServer server;
+    const std::string entity_url = server.Url("/nomps/Airlines");
+    const std::string context = server.Url("/nomps/$metadata") + "#Airlines";
+
+    server.ServeMetadataFixture("/nomps/$metadata", "edm_trippin.xml");
+    server.OnPath("/nomps/Airlines",
+                  CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA, AIRLINE_FM})));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    REQUIRE_FALSE(con.Query("SELECT COUNT(*) FROM odata_read('" + entity_url + "')")->HasError());
+
+    for (const auto &request : server.RequestsFor("/nomps/Airlines")) {
+        INFO("Prefer: " << request.Header("Prefer"));
+        REQUIRE(request.Header("Prefer").find("odata.maxpagesize") == std::string::npos);
+    }
+}
+
+// A page size of zero is not "no preference" - it is a request the service cannot honour,
+// and sending it would be worse than rejecting it here where the caller can see why.
+TEST_CASE("odata_read rejects a page size of zero", "[odata_maxpagesize]") {
+    ODataTestServer server;
+    const std::string entity_url = server.Url("/zeromps/Airlines");
+    const std::string context = server.Url("/zeromps/$metadata") + "#Airlines";
+
+    server.ServeMetadataFixture("/zeromps/$metadata", "edm_trippin.xml");
+    server.OnPath("/zeromps/Airlines",
+                  CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA})));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto result =
+        con.Query("SELECT COUNT(*) FROM odata_read('" + entity_url + "', max_page_size=0)");
+    REQUIRE(result->HasError());
+    INFO(result->GetError());
+    REQUIRE(result->GetError().find("max_page_size") != std::string::npos);
+    // A bad argument is the caller's, not a broken invariant of ours: an INTERNAL error
+    // here would invalidate the whole database instance.
+    REQUIRE(result->GetErrorObject().Type() != duckdb::ExceptionType::INTERNAL);
+}
+
+// The ceiling's own error message tells the caller to ask for larger pages. It has to name
+// the parameter that does that, or the advice is unactionable - which is the whole reason
+// this parameter exists. Driving the real ceiling would need 10000 round trips, so the
+// message is built by a named function and that function is what is asserted.
+TEST_CASE("the page-ceiling error names the parameter that raises the page size",
+          "[odata_maxpagesize]") {
+    const auto message = erpl_web::BuildPageLimitExceededMessage(
+        erpl_web::ODataClient<erpl_web::ODataEntitySetResponse>::MAX_PAGE_REQUESTS,
+        "https://service.example/Entity?$skiptoken=9999");
+
+    INFO(message);
+    REQUIRE(message.find("10000") != std::string::npos);
+    REQUIRE(message.find("max_page_size") != std::string::npos);
+    REQUIRE(message.find("https://service.example/Entity?$skiptoken=9999") != std::string::npos);
+}
+
+// A client is re-minted in two places mid-query: CloneForScan gives each execution a
+// private pagination cursor, and predicate pushdown rebuilds it whenever it changes the
+// URL. A setting not copied at both sites is silently lost - which is how this parameter
+// was first written, and the reason the first test above failed before the fix. A filter
+// forces the pushdown path specifically.
+TEST_CASE("the page-size preference survives a client rebuilt by predicate pushdown",
+          "[odata_maxpagesize]") {
+    ODataTestServer server;
+    const std::string entity_url = server.Url("/mpspush/Airlines");
+    const std::string context = server.Url("/mpspush/$metadata") + "#Airlines";
+
+    server.ServeMetadataFixture("/mpspush/$metadata", "edm_trippin.xml");
+    server.OnPath("/mpspush/Airlines",
+                  CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA})));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto result = con.Query("SELECT Name FROM odata_read('" + entity_url +
+                            "', max_page_size=250) WHERE AirlineCode = 'AA'");
+    INFO((result->HasError() ? result->GetError() : std::string()));
+    REQUIRE_FALSE(result->HasError());
+
+    // Only requests that actually carry the pushed-down filter go through the rebuilt
+    // client, so those are the ones that prove the setting travelled.
+    bool rebuilt_client_asked = false;
+    bool rebuilt_client_forgot = false;
+    for (const auto &request : server.RequestsFor("/mpspush/Airlines")) {
+        if (request.DecodedQueryParam("$filter").empty()) {
+            continue;
+        }
+        INFO("filtered request Prefer: " << request.Header("Prefer"));
+        if (request.Header("Prefer").find("odata.maxpagesize=250") != std::string::npos) {
+            rebuilt_client_asked = true;
+        } else {
+            rebuilt_client_forgot = true;
+        }
+    }
+    INFO("no filtered request was made, so the pushdown path was never exercised");
+    REQUIRE(rebuilt_client_asked);
+    REQUIRE_FALSE(rebuilt_client_forgot);
+}
+
+// The same across executions of a bound plan, which is the CloneForScan site.
+TEST_CASE("the page-size preference survives re-execution of a bound plan",
+          "[odata_maxpagesize]") {
+    ODataTestServer server;
+    const std::string entity_url = server.Url("/mpsreexec/Airlines");
+    const std::string context = server.Url("/mpsreexec/$metadata") + "#Airlines";
+
+    server.ServeMetadataFixture("/mpsreexec/$metadata", "edm_trippin.xml");
+    // Two pages on purpose. With a single page the first execution issues no request at
+    // all - the bind-time probe already paid for page one and CloneForScan adopts it - so
+    // there would be nothing on the wire to assert against.
+    server.OnMatch(
+        [](const RecordedRequest &request) {
+            return request.path == "/mpsreexec/Airlines" &&
+                   request.QueryParam("$skiptoken") == "2";
+        },
+        CannedResponse::Json(MakeV4Page(context, {AIRLINE_FM})));
+    server.OnPath("/mpsreexec/Airlines",
+                  CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA},
+                                                  entity_url + "?$format=json&$skiptoken=2")));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    REQUIRE_FALSE(con.Query("PREPARE p AS SELECT * FROM odata_read('" + entity_url +
+                            "', max_page_size=750)")
+                      ->HasError());
+
+    for (int execution = 1; execution <= 3; execution++) {
+        INFO("execution " << execution);
+        server.ClearRequests();
+        auto result = con.Query("EXECUTE p");
+        INFO((result->HasError() ? result->GetError() : std::string()));
+        REQUIRE_FALSE(result->HasError());
+
+        // The next-link page is fetched through the per-execution client, so it is the
+        // one that proves the setting survived the clone.
+        bool asked = false;
+        for (const auto &request : server.RequestsFor("/mpsreexec/Airlines")) {
+            if (request.QueryParam("$skiptoken") != "2") {
+                continue;
+            }
+            INFO("page-2 Prefer: " << request.Header("Prefer"));
+            if (request.Header("Prefer").find("odata.maxpagesize=750") != std::string::npos) {
+                asked = true;
+            }
+        }
+        INFO("this execution fetched no next-link page, so nothing was proven");
+        REQUIRE(asked);
+    }
+}

--- a/test/cpp/test_odata_max_page_size.cpp
+++ b/test/cpp/test_odata_max_page_size.cpp
@@ -283,3 +283,27 @@ TEST_CASE("odata_read sends the page-size preference on the very first request",
     REQUIRE(requests.front().Header("Prefer").find("odata.maxpagesize=1000") !=
             std::string::npos);
 }
+
+// Raised by an agent-crew review (F12). NULL is a distinct caller mistake from zero and
+// deserves its own message: reporting "must be greater than 0" for a NULL misdescribes
+// what the caller actually wrote.
+TEST_CASE("odata_read rejects a NULL page size with its own message", "[odata_maxpagesize]") {
+    ODataTestServer server;
+    const std::string entity_url = server.Url("/nullmps/Airlines");
+    const std::string context = server.Url("/nullmps/$metadata") + "#Airlines";
+
+    server.ServeMetadataFixture("/nullmps/$metadata", "edm_trippin.xml");
+    server.OnPath("/nullmps/Airlines", CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA})));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto result =
+        con.Query("SELECT COUNT(*) FROM odata_read('" + entity_url + "', max_page_size=NULL)");
+    REQUIRE(result->HasError());
+    INFO(result->GetError());
+    REQUIRE(result->GetError().find("NULL") != std::string::npos);
+    // A caller mistake, not a broken invariant of ours.
+    REQUIRE(result->GetErrorObject().Type() != duckdb::ExceptionType::INTERNAL);
+}

--- a/test/cpp/test_odata_max_page_size.cpp
+++ b/test/cpp/test_odata_max_page_size.cpp
@@ -91,7 +91,14 @@ TEST_CASE("odata_read sends no page-size preference unless asked", "[odata_maxpa
 
     REQUIRE_FALSE(con.Query("SELECT COUNT(*) FROM odata_read('" + entity_url + "')")->HasError());
 
-    for (const auto &request : server.RequestsFor("/nomps/Airlines")) {
+    // Without this the loop below asserts nothing whenever the entity set was never
+    // requested at all - which is every way this test could break other than the one it
+    // is meant to catch.
+    const auto requests = server.RequestsFor("/nomps/Airlines");
+    INFO("the entity set was never requested, so the loop below proves nothing");
+    REQUIRE_FALSE(requests.empty());
+
+    for (const auto &request : requests) {
         INFO("Prefer: " << request.Header("Prefer"));
         REQUIRE(request.Header("Prefer").find("odata.maxpagesize") == std::string::npos);
     }

--- a/test/cpp/test_odata_max_page_size.cpp
+++ b/test/cpp/test_odata_max_page_size.cpp
@@ -234,3 +234,45 @@ TEST_CASE("the page-size preference survives re-execution of a bound plan",
         REQUIRE(asked);
     }
 }
+
+// GitHub #185 / crew F3. ODataReadBind probes the URL before ProcessNamedParameters runs,
+// and FromProbeResult buffers the probe body as page one. With no projection and no filter
+// the URL never changes, so UpdateUrlFromPredicatePushdown takes its early return, the
+// buffered page survives and PrefetchFirstPage is skipped. The result: the headline shape
+// for this feature - a large unprojected extraction - sent page one with NO Prefer header
+// and got the service's default page size; only page two onwards carried the preference.
+//
+// Every other test in this file uses COUNT(*) or a projection, which changes the URL and
+// forces a refetch, so none of them could see it.
+TEST_CASE("odata_read sends the page-size preference on the very first request",
+          "[odata_maxpagesize]") {
+    ODataTestServer server;
+    const std::string entity_url = server.Url("/mpsfirst/Airlines");
+    const std::string context = server.Url("/mpsfirst/$metadata") + "#Airlines";
+
+    server.ServeMetadataFixture("/mpsfirst/$metadata", "edm_trippin.xml");
+    // Deliberately a SINGLE page: with no next link there is no second request that could
+    // carry the header and rescue the assertion.
+    server.OnPath("/mpsfirst/Airlines",
+                  CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA, AIRLINE_FM})));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    // SELECT * with an ORDER BY keeps every column live, so no $select is emitted and the
+    // URL is unchanged - the exact shape that skips the refetch.
+    auto result = con.Query("SELECT * FROM odata_read('" + entity_url +
+                            "', max_page_size=1000) ORDER BY AirlineCode");
+    INFO((result->HasError() ? result->GetError() : std::string()));
+    REQUIRE_FALSE(result->HasError());
+    REQUIRE(result->RowCount() == 2);
+
+    const auto requests = server.RequestsFor("/mpsfirst/Airlines");
+    INFO("no request at all reached the entity set");
+    REQUIRE_FALSE(requests.empty());
+
+    INFO("first request Prefer: [" << requests.front().Header("Prefer") << "]");
+    REQUIRE(requests.front().Header("Prefer").find("odata.maxpagesize=1000") !=
+            std::string::npos);
+}


### PR DESCRIPTION
Follow-up to #161.

#161 settled the server-driven paging ceiling at 10,000 pages, and the error it raises tells the caller to *"ask the service for larger pages"*. That was advice with no supported way to follow it: OData's mechanism is `Prefer: odata.maxpagesize=N`, and `odata_read` had no such parameter. `odp_odata_read` has had one all along (`odp_http_request_factory.cpp`), so the asymmetry was accidental rather than deliberate.

```sql
SELECT * FROM odata_read('https://example.com/svc/Orders', max_page_size = 5000);
```

### Omitting it still sends nothing

No `Prefer` header at all — which is deliberately *not* the same as sending a default. A `Prefer` header the caller never asked for can make a service page differently than it otherwise would.

### The part that actually had a bug

The setting has to be copied at **both** places a client is re-minted mid-query:

- `CloneForScan`, which gives each execution a private pagination cursor
- the predicate-pushdown rebuild, which happens whenever a filter changes the URL

My first version set it on the bind-data client only, and it was silently dropped on the way to the wire — the first test failed on exactly that. There is now a test for each site, and I verified both are non-vacuous by deleting the propagation and re-running: **3 of 6 fail** without it.

### Other decisions

- **Zero is rejected at bind time** rather than put on the wire — it is a preference no service can honour. As `InvalidInputException`, not `InternalException`: a bad argument is the caller's, not a broken invariant of ours, and `ExceptionType::INTERNAL` invalidates the whole database instance.
- **The ceiling message moved into `BuildPageLimitExceededMessage`** so it can be asserted without driving 10,000 real round trips, and it now names the parameter. Testing it by actually hitting the ceiling would not be a unit test; asserting a placeholder would not be a test at all.
- The re-execution case uses a **two-page** fixture on purpose: with one page the first execution issues no request at all (the bind-time probe already paid for page one and `CloneForScan` adopts it), so there would be nothing on the wire to assert against.

### Verification

448 C++ cases / 2280 assertions green. Full SQL suite green. README documents the parameter, including that a service may ignore or cap it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791785076&installation_model_id=425457&pr_number=176&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F176&signature=a3d8e6b54762b556f11350429c43f83096167ce09a95927fead0f1697a0baa5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->