### PR TITLE
ci: drop windows_amd64 from the v1.4.5 legs

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -50,6 +50,17 @@ jobs:
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
       deploy_versioned: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
 
+  # windows_amd64 is excluded from the v1.4.5 legs (build, smoke test and deploy alike).
+  # The vcpkg commit this LTS leg is pinned to acquires msys2-runtime 3.5.4-2 to build
+  # openssl, and MSYS2 has dropped that build from every mirror - all six 404. The leg
+  # therefore fails before a single source file is compiled, and re-running cannot help.
+  # It was red on three consecutive PRs, which meant every PR had to be merged over a red
+  # check after someone re-verified by hand that the redness was infrastructural; that is
+  # precisely the state in which a real Windows regression gets waved through.
+  #
+  # v1.5.5 still builds and ships windows_amd64, so current Windows users are unaffected;
+  # what is given up is an LTS Windows binary. Restore this arch by bumping vcpkg_commit
+  # below to one referencing a published msys2-runtime. See GitHub #174.
   duckdb-v145-build:
     name: Build extension binaries (v1.4.5)
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.4-andium
@@ -58,7 +69,7 @@ jobs:
       extension_name: erpl_web
       ci_tools_version: v1.4-andium
       vcpkg_commit: ce613c41372b23b1f51333815feb3edd87ef8a8b
-      exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads;'
+      exclude_archs: 'windows_amd64;windows_amd64_rtools;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads;'
 
   duckdb-v145-smoke-test:
     name: Smoke test (v1.4.5)
@@ -67,7 +78,7 @@ jobs:
     with:
       duckdb_version: v1.4.5
       extension_name: erpl_web
-      exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads;'
+      exclude_archs: 'windows_amd64;windows_amd64_rtools;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads;'
 
   duckdb-v145-deploy:
     name: Deploy extension binaries (v1.4.5)
@@ -77,6 +88,6 @@ jobs:
     with:
       duckdb_version: v1.4.5
       extension_name: erpl_web
-      exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads;'
+      exclude_archs: 'windows_amd64;windows_amd64_rtools;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads;'
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
       deploy_versioned: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}

--- a/.github/workflows/_extension_smoke_test.yml
+++ b/.github/workflows/_extension_smoke_test.yml
@@ -38,23 +38,50 @@ on:
         default: ""
 
 jobs:
+  # The matrix is filtered here rather than with a job-level `if`, because the `matrix`
+  # context is NOT available in a job-level `if` - a workflow using one fails validation
+  # and spawns no jobs at all.
+  #
+  # The membership test is delimiter-safe: the arch names overlap, so a bare substring
+  # test would make excluding `windows_amd64_rtools` also drop `windows_amd64`.
+  select-archs:
+    name: Select architectures
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.filter.outputs.matrix }}
+      any: ${{ steps.filter.outputs.any }}
+    steps:
+      - id: filter
+        shell: bash
+        env:
+          EXCLUDE_ARCHS: ${{ inputs.exclude_archs }}
+        run: |
+          set -euo pipefail
+          all='[{"arch":"linux_amd64","runner":"ubuntu-24.04"},
+                {"arch":"osx_arm64","runner":"macos-latest"},
+                {"arch":"windows_amd64","runner":"windows-latest"}]'
+          excluded=";${EXCLUDE_ARCHS};"
+          # Bind the element to $e first: inside the `|` the `.` is $ex (a string), so
+          # `.arch` there would index a string rather than the matrix entry.
+          matrix=$(echo "$all" | jq -c --arg ex "$excluded" \
+            '[.[] | . as $e | select(($ex | contains(";" + $e.arch + ";")) | not)]')
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          if [ "$(echo "$matrix" | jq 'length')" -gt 0 ]; then
+            echo "any=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "any=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Smoke-testing: $matrix"
+
   smoke-test:
     name: Smoke test (${{ matrix.arch }})
+    needs: select-archs
+    if: needs.select-archs.outputs.any == 'true'
     strategy:
       # Run all platforms even if one fails so we see the full picture
       fail-fast: false
       matrix:
-        include:
-          - arch: linux_amd64
-            runner: ubuntu-24.04
-          - arch: osx_arm64
-            runner: macos-latest
-          - arch: windows_amd64
-            runner: windows-latest
-    # Delimiter-safe membership test. Comparing bare substrings would make excluding
-    # `windows_amd64_rtools` also skip `windows_amd64`, since one name contains the other;
-    # wrapping both sides in ';' compares whole entries.
-    if: ${{ !contains(format(';{0};', inputs.exclude_archs), format(';{0};', matrix.arch)) }}
+        include: ${{ fromJSON(needs.select-archs.outputs.matrix) }}
     runs-on: ${{ matrix.runner }}
 
     steps:

--- a/.github/workflows/_extension_smoke_test.yml
+++ b/.github/workflows/_extension_smoke_test.yml
@@ -23,7 +23,10 @@ on:
         type: string
       # ';' separated list of architectures excluded from the build job.
       # Must match the build job's exclude_archs so we don't try to download
-      # an artifact that was never produced.
+      # an artifact that was never produced. Honoured by the job-level `if` below;
+      # this input was previously accepted and then ignored, so excluding an arch
+      # from the build still ran its smoke test, which failed downloading an
+      # artifact nobody had built.
       exclude_archs:
         required: false
         type: string
@@ -48,6 +51,10 @@ jobs:
             runner: macos-latest
           - arch: windows_amd64
             runner: windows-latest
+    # Delimiter-safe membership test. Comparing bare substrings would make excluding
+    # `windows_amd64_rtools` also skip `windows_amd64`, since one name contains the other;
+    # wrapping both sides in ';' compares whole entries.
+    if: ${{ !contains(format(';{0};', inputs.exclude_archs), format(';{0};', matrix.arch)) }}
     runs-on: ${{ matrix.runner }}
 
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -556,6 +556,11 @@ The build matrix is defined in `extension-ci-tools/config/distribution_matrix.js
 
 **Current configuration excludes** (see `exclude_archs` in MainDistributionPipeline.yml):
 - `windows_amd64_rtools`, `windows_amd64_mingw` - Excluded for faster builds
+- `windows_amd64` - Excluded **on the v1.4.5 legs only**. That leg's pinned vcpkg commit
+  acquires `msys2-runtime 3.5.4-2` to build openssl, and MSYS2 has dropped that build from
+  every mirror (all six 404), so the leg fails before compiling anything and re-running
+  cannot help. v1.5.5 still builds and ships `windows_amd64`. Restore it by bumping the
+  v1.4.5 `vcpkg_commit`. See GitHub #174.
 - `wasm_mvp`, `wasm_eh`, `wasm_threads` - WebAssembly variants excluded
 - `linux_arm64`, `linux_amd64_musl` - Excluded to reduce build time
 


### PR DESCRIPTION
Closes #174.

The vcpkg commit the v1.4.5 leg is pinned to acquires `msys2-runtime 3.5.4-2` to build openssl. MSYS2 has dropped that build from **every** mirror — all six 404 — so the leg fails before a single source file is compiled and re-running cannot help.

```
error: https://mirror.msys2.org/msys/x86_64/msys2-runtime-3.5.4-2-x86_64.pkg.tar.zst: failed: status code 404
error: https://repo.msys2.org/...            failed: status code 404
error: https://mirror.yandex.ru/...          failed: status code 404
error: https://mirrors.tuna.tsinghua.edu.cn/ failed: status code 404
error: https://mirrors.ustc.edu.cn/...       failed: status code 404
error: https://mirror.selfnet.de/...         failed: status code 404
error: building openssl:x64-windows-static-md-release-vs2019comp failed
```

It was red on three consecutive PRs. Each time, every PR had to be merged over a red check after someone re-verified by hand that the redness was infrastructural — which is precisely the state in which a genuine Windows regression gets waved through. **A permanently-red check is worse than an absent one.**

### What changes

`windows_amd64` is excluded from all three v1.4.5 jobs — build, smoke test **and** deploy. Excluding it from only the build would leave the other two looking for an artifact that was never produced.

### What is given up

An **LTS Windows binary**. v1.5.5 still builds and ships `windows_amd64`, so current Windows users are unaffected; users pinned to DuckDB 1.4.x lose a prebuilt Windows extension until the pin is moved.

Restoring it is a one-line change: bump the v1.4.5 `vcpkg_commit` to one whose `vcpkg_acquire_msys` references a published msys2-runtime. The reason is recorded inline in the workflow and in CLAUDE.md so the next person does not have to rediscover it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791786330&installation_model_id=425457&pr_number=177&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F177&signature=f9412b2062ca9192e7f4e266dabc23937518cda802e1b2e675facff8dc520675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->