### PR TITLE
fix: give the Datasphere readers per-execution scan state (#75)

### DIFF
--- a/src/datasphere_read.cpp
+++ b/src/datasphere_read.cpp
@@ -200,7 +200,10 @@ static duckdb::unique_ptr<duckdb::GlobalTableFunctionState> DatasphereReadRelati
     scan_state->AddFilters(input.filters);
 
     // Input parameters live on the OData client, and CloneForScan mints a fresh one, so
-    // they have to be re-applied to the clone rather than to the bind data's client.
+    // they are re-applied to the clone here. They also survive the pushdown rebuild below,
+    // which now carries them explicitly - before that they came back only because
+    // PrefetchFirstPage re-applies them afterwards, which is an accident of ordering
+    // rather than a property of the re-mint.
     auto input_params = scan_state->GetInputParameters();
     if (!input_params.empty()) {
         auto odata_client = scan_state->GetODataClient();

--- a/src/datasphere_read.cpp
+++ b/src/datasphere_read.cpp
@@ -187,25 +187,33 @@ static duckdb::unique_ptr<duckdb::GlobalTableFunctionState> DatasphereReadRelati
     auto column_ids = input.column_ids;
 
     ERPL_TRACE_DEBUG("DATASPHERE_RELATIONAL_INIT", "Initializing with " + std::to_string(column_ids.size()) + " columns");
-    
-    // Activate columns and add filters
-    bind_data.ActivateColumns(column_ids);
-    bind_data.AddFilters(input.filters);
-    
-    // Ensure input parameters are still available in OData client
-    auto input_params = bind_data.GetInputParameters();
+
+    // Projection, filter pushdown and the first-page prefetch all mutate scan state, so
+    // they run against a private clone and the bind data stays exactly as bind left it.
+    // Scanning straight out of the bind data - which is what returning a bare
+    // GlobalTableFunctionState made ResolveScanState do - meant the second EXECUTE of a
+    // bound plan found the row buffer already drained and returned nothing, silently
+    // (GitHub #75).
+    auto scan_state = bind_data.CloneForScan();
+
+    scan_state->ActivateColumns(column_ids);
+    scan_state->AddFilters(input.filters);
+
+    // Input parameters live on the OData client, and CloneForScan mints a fresh one, so
+    // they have to be re-applied to the clone rather than to the bind data's client.
+    auto input_params = scan_state->GetInputParameters();
     if (!input_params.empty()) {
-        auto odata_client = bind_data.GetODataClient();
+        auto odata_client = scan_state->GetODataClient();
         if (odata_client) {
             odata_client->SetInputParameters(input_params);
             ERPL_TRACE_INFO("DATASPHERE_RELATIONAL_INIT", "Re-applied " + std::to_string(input_params.size()) + " input parameters");
         }
     }
-    
-    // Update URL with predicate pushdown
-    bind_data.UpdateUrlFromPredicatePushdown();
 
-    return duckdb::make_uniq<duckdb::GlobalTableFunctionState>();
+    scan_state->UpdateUrlFromPredicatePushdown();
+    scan_state->PrefetchFirstPage();
+
+    return duckdb::make_uniq<ODataReadGlobalState>(std::move(scan_state));
 }
 
 duckdb::TableFunctionSet CreateDatasphereReadRelationalFunction() {
@@ -236,13 +244,7 @@ duckdb::TableFunctionSet CreateDatasphereReadRelationalFunction() {
         DATAZOO_GUARD(ERPL_WEB_BANNER, ODataReadScan), DATAZOO_GUARD(ERPL_WEB_BANNER, DatasphereReadRelationalBind), DatasphereReadRelationalTableInitGlobalState);
     relational_function_3_params.filter_pushdown = true;
     relational_function_3_params.projection_pushdown = true;
-    relational_function_3_params.table_scan_progress = [](duckdb::ClientContext &context,
-                                                          const duckdb::FunctionData *bind_data,
-                                                          const duckdb::GlobalTableFunctionState *gstate) -> double {
-        if (!bind_data) return -1.0;
-        auto odata_bind = static_cast<const ODataReadBindData *>(bind_data);
-        return odata_bind ? odata_bind->GetProgressFraction() : -1.0;
-    };
+    relational_function_3_params.table_scan_progress = ODataReadTableProgress;
     relational_function_3_params.named_parameters["top"] = duckdb::LogicalType(duckdb::LogicalTypeId::UBIGINT);
     relational_function_3_params.named_parameters["skip"] = duckdb::LogicalType(duckdb::LogicalTypeId::UBIGINT);
     relational_function_3_params.named_parameters["params"] = duckdb::LogicalType::MAP(duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR), 
@@ -351,23 +353,26 @@ static duckdb::unique_ptr<duckdb::GlobalTableFunctionState> DatasphereReadAnalyt
     auto column_ids = input.column_ids;
 
     ERPL_TRACE_DEBUG("DATASPHERE_ANALYTICAL_INIT", "Initializing with " + std::to_string(column_ids.size()) + " columns");
-    
-    bind_data.ActivateColumns(column_ids);
-    bind_data.AddFilters(input.filters);
 
-    // Ensure input parameters are still available in OData client
-    auto input_params = bind_data.GetInputParameters();
+    // Private per-execution scan state; see the relational reader above (GitHub #75).
+    auto scan_state = bind_data.CloneForScan();
+
+    scan_state->ActivateColumns(column_ids);
+    scan_state->AddFilters(input.filters);
+
+    auto input_params = scan_state->GetInputParameters();
     if (!input_params.empty()) {
-        auto odata_client = bind_data.GetODataClient();
+        auto odata_client = scan_state->GetODataClient();
         if (odata_client) {
             odata_client->SetInputParameters(input_params);
             ERPL_TRACE_INFO("DATASPHERE_ANALYTICAL_INIT", "Re-applied " + std::to_string(input_params.size()) + " input parameters");
         }
     }
 
-    bind_data.UpdateUrlFromPredicatePushdown();
+    scan_state->UpdateUrlFromPredicatePushdown();
+    scan_state->PrefetchFirstPage();
 
-    return duckdb::make_uniq<duckdb::GlobalTableFunctionState>();
+    return duckdb::make_uniq<ODataReadGlobalState>(std::move(scan_state));
 }
 
 duckdb::TableFunctionSet CreateDatasphereReadAnalyticalFunction() {
@@ -400,13 +405,7 @@ duckdb::TableFunctionSet CreateDatasphereReadAnalyticalFunction() {
         DATAZOO_GUARD(ERPL_WEB_BANNER, ODataReadScan), DATAZOO_GUARD(ERPL_WEB_BANNER, DatasphereReadAnalyticalBind), DatasphereReadAnalyticalTableInitGlobalState);
     analytical_function_3_params.filter_pushdown = true;
     analytical_function_3_params.projection_pushdown = true;
-    analytical_function_3_params.table_scan_progress = [](duckdb::ClientContext &context,
-                                                          const duckdb::FunctionData *bind_data,
-                                                          const duckdb::GlobalTableFunctionState *gstate) -> double {
-        if (!bind_data) return -1.0;
-        auto odata_bind = static_cast<const ODataReadBindData *>(bind_data);
-        return odata_bind ? odata_bind->GetProgressFraction() : -1.0;
-    };
+    analytical_function_3_params.table_scan_progress = ODataReadTableProgress;
     analytical_function_3_params.named_parameters["top"] = duckdb::LogicalType(duckdb::LogicalTypeId::UBIGINT);
     analytical_function_3_params.named_parameters["skip"] = duckdb::LogicalType(duckdb::LogicalTypeId::UBIGINT);
     analytical_function_3_params.named_parameters["params"] = duckdb::LogicalType::MAP(duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR), 

--- a/src/include/odata_client.hpp
+++ b/src/include/odata_client.hpp
@@ -501,6 +501,12 @@ public:
     void SetEntitySetNameFromContextFragment(const std::string &context_or_fragment);
     // Explicitly set the current entity set name directly
     void SetEntitySetName(const std::string &entity_name) { current_entity_name_from_fragment = entity_name; }
+    // Read back so CloneForScan can carry it. Both this and the stored metadata context
+    // URL are set at bind time for Datasphere's dual-URL shape and are NOT re-derivable
+    // from a clone that adopts page one, because the derivation lives inside
+    // ODataEntitySetClient::Get() which such a clone never reaches (GitHub #186).
+    const std::string &GetEntitySetName() const { return current_entity_name_from_fragment; }
+    const std::string &StoredMetadataContextUrl() const { return metadata_context_url; }
 
     // Public access to entity type information for navigation property filtering
     EntityType GetCurrentEntityType();

--- a/src/include/odata_client.hpp
+++ b/src/include/odata_client.hpp
@@ -496,6 +496,10 @@ public:
     
     // Override to check if input parameters are present
     bool HasInputParameters() const override { return !input_parameters.empty(); }
+    // Read back so the client re-mint sites can carry them. They survive today only
+    // because PrefetchFirstPage re-applies them afterwards, which is an accident of
+    // ordering rather than a property of the re-mint (GitHub #186).
+    const std::map<std::string, std::string> &GetInputParameters() const { return input_parameters; }
 
     // Explicitly set the current entity set name from an @odata.context value or fragment
     void SetEntitySetNameFromContextFragment(const std::string &context_or_fragment);

--- a/src/odata_read_pushdown.cpp
+++ b/src/odata_read_pushdown.cpp
@@ -181,6 +181,7 @@ void ODataReadBindData::UpdateUrlFromPredicatePushdown() {
   // specifically to work around this same loss (GitHub #186).
   const auto current_metadata_context = odata_client->StoredMetadataContextUrl();
   const auto current_entity_set_name = odata_client->GetEntitySetName();
+  const auto current_input_parameters = odata_client->GetInputParameters();
 
   odata_client = std::make_shared<ODataEntitySetClient>(
       http_client, updated_url, auth_params);
@@ -190,6 +191,9 @@ void ODataReadBindData::UpdateUrlFromPredicatePushdown() {
   }
   if (!current_entity_set_name.empty()) {
     odata_client->SetEntitySetName(current_entity_set_name);
+  }
+  if (!current_input_parameters.empty()) {
+    odata_client->SetInputParameters(current_input_parameters);
   }
     
     // Preserve the OData version to avoid metadata fetching

--- a/src/odata_read_pushdown.cpp
+++ b/src/odata_read_pushdown.cpp
@@ -174,9 +174,23 @@ void ODataReadBindData::UpdateUrlFromPredicatePushdown() {
 
     // Store the current OData version before creating new client
     auto current_version = odata_client->GetODataVersion();
+  // Datasphere's dual-URL state. CloneForScan carries these, and this rebuild used to
+  // throw them away one statement later on every projecting or filtered query - which is
+  // why a SELECT * test could not reproduce the loss: SELECT * takes the early return
+  // above and never reaches here. business_central_catalog.cpp pre-warms caches
+  // specifically to work around this same loss (GitHub #186).
+  const auto current_metadata_context = odata_client->StoredMetadataContextUrl();
+  const auto current_entity_set_name = odata_client->GetEntitySetName();
 
   odata_client = std::make_shared<ODataEntitySetClient>(
       http_client, updated_url, auth_params);
+
+  if (!current_metadata_context.empty()) {
+    odata_client->SetMetadataContextUrl(current_metadata_context);
+  }
+  if (!current_entity_set_name.empty()) {
+    odata_client->SetEntitySetName(current_entity_set_name);
+  }
     
     // Preserve the OData version to avoid metadata fetching
     if (current_version != ODataVersion::UNKNOWN) {

--- a/src/odata_read_scan_state.cpp
+++ b/src/odata_read_scan_state.cpp
@@ -640,11 +640,14 @@ namespace {
 
 // Returns the object that owns the scan state for this execution.
 //
-// odata_read(), the ATTACHed odata_table_scan and the SAC readers use
-// ODataReadGlobalState, so each execution of a bound plan gets its own state.
-// The Datasphere readers reuse ODataReadScan with their own init-global
-// functions, which still return a bare GlobalTableFunctionState; those keep the
-// historical behaviour of scanning straight out of the bind data.
+// odata_read(), the ATTACHed odata_table_scan, the SAC readers and both
+// Datasphere readers all return ODataReadGlobalState, so each execution of a
+// bound plan gets its own state.
+//
+// The fallback to the bind data remains for any caller that still supplies a
+// bare GlobalTableFunctionState. It is not a safe default - it is the historical
+// behaviour that made the second EXECUTE of a bound plan return nothing - so a
+// new reader should return ODataReadGlobalState rather than rely on it.
 ODataReadBindData &ResolveScanState(const duckdb::FunctionData *bind_data,
                                     const GlobalTableFunctionState *global_state) {
   auto *odata_global = dynamic_cast<const ODataReadGlobalState *>(global_state);

--- a/src/odata_read_scan_state.cpp
+++ b/src/odata_read_scan_state.cpp
@@ -436,6 +436,18 @@ duckdb::unique_ptr<ODataReadBindData> ODataReadBindData::CloneForScan() const {
     // follow that page's next link without re-fetching it, while keeping the cursor
     // private. Deliberately NOT odata_client->current_response: after one execution that
     // is the LAST page, and resuming from it would return nothing.
+    // Datasphere's dual-URL shape: FromEntitySetRoot stores the @odata.context metadata
+    // URL and the entity-set name from its fragment at bind time, gated on
+    // IsDatasphereUrl. A clone that adopts page one never runs the code that derives them
+    // (it lives in ODataEntitySetClient::Get()), so without carrying them the clone
+    // resolves $metadata from the data URL and works from an empty entity-set name
+    // (GitHub #186).
+    if (!odata_client->StoredMetadataContextUrl().empty()) {
+      scan_client->SetMetadataContextUrl(odata_client->StoredMetadataContextUrl());
+    }
+    if (!odata_client->GetEntitySetName().empty()) {
+      scan_client->SetEntitySetName(odata_client->GetEntitySetName());
+    }
     if (first_page_response_ != nullptr) {
       scan_client->AdoptResponse(first_page_response_);
     }

--- a/test/cpp/test_datasphere_scan_reexecution.cpp
+++ b/test/cpp/test_datasphere_scan_reexecution.cpp
@@ -180,3 +180,76 @@ TEST_CASE("two datasphere_read_analytical scans of one call each see every row",
     REQUIRE_FALSE(result->HasError());
     REQUIRE(ScalarOf(result) == 16);
 }
+
+// Datasphere uses a dual-URL shape: the data lives at one URL and the @odata.context names
+// a DIFFERENT metadata URL. FromEntitySetRoot stores that context URL and the entity-set
+// name from its fragment at bind time, gated on IsDatasphereUrl.
+//
+// An agent-crew review flagged that CloneForScan did not copy either field and called it a
+// regression. It copies them now - a clone should be complete without depending on caller
+// ordering - but in fairness to the record: I could NOT construct a failing case. Two
+// attempts, one with metadata served only under the context path and one with the
+// entity-set name deliberately different from the data URL's last segment, both pass with
+// the copy removed. A clone that adopts page one never re-resolves metadata or the entity
+// type, so the fields are unobservable through SQL on today's paths.
+//
+// What this case therefore is: end-to-end cover for the dual-URL shape across re-execution,
+// which nothing else had. It is not a regression guard, and calling it one would be wrong.
+TEST_CASE("a Datasphere dual-URL asset re-executes correctly",
+          "[datasphere_reexec][dualurl]") {
+    ODataTestServer server;
+
+    // The path must contain "datasphere": ODataReadBindData::IsDatasphereUrl gates the
+    // dual-URL storage on that substring, so without it the shape under test never occurs.
+    const std::string data_prefix = "/datasphere/dwaas-core/api/v1/spaces/SP";
+    const std::string meta_prefix = "/datasphere/api/v1/dwc/consumption/relational/SP/ASSET";
+    // The data URL's last segment is the ASSET name, which is NOT the entity-set name in
+    // the EDM - that comes from the @odata.context fragment. Making them differ is what
+    // makes a lost fragment name observable; if the URL ended in /Airlines the fallback
+    // "derive the entity set from the URL" would land on the right answer and hide it.
+    const std::string entity_url = server.Url(data_prefix + "/MYASSET");
+    // The context deliberately points somewhere the data URL would never derive.
+    const std::string context = server.Url(meta_prefix + "/$metadata") + "#Airlines";
+
+    // Metadata is served ONLY under the context path. If the clone derives the metadata
+    // URL from the data URL instead, it asks for a document that does not exist.
+    server.ServeMetadataFixture(meta_prefix + "/$metadata", "edm_trippin.xml");
+
+    server.OnMatch(
+        [data_prefix](const RecordedRequest &request) {
+            return request.path == data_prefix + "/MYASSET" &&
+                   request.QueryParam("$skiptoken") == "2";
+        },
+        CannedResponse::Json(MakeV4Page(context, {AIRLINE_MU, AIRLINE_AF})));
+    server.OnPath(data_prefix + "/MYASSET",
+                  CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA, AIRLINE_FM},
+                                                  entity_url + "?$format=json&$skiptoken=2")));
+    server.OnPath("/oauth/token",
+                  CannedResponse::Json(
+                      R"({"access_token":"test-token","token_type":"Bearer","expires_in":3600})"));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+    CreateLoopbackSecret(con, "ds", server);
+
+    const std::string read =
+        "datasphere_read_relational('" + server.Url(data_prefix) + "', 'MYASSET', secret => 'ds')";
+
+    REQUIRE_FALSE(con.Query("PREPARE dual AS SELECT * FROM " + read)->HasError());
+
+    for (int execution = 1; execution <= 2; execution++) {
+        auto result = con.Query("EXECUTE dual");
+        INFO("execution " << execution);
+        INFO((result->HasError() ? result->GetError() : std::string()));
+        REQUIRE_FALSE(result->HasError());
+        REQUIRE(result->RowCount() == 4);
+    }
+
+    // Nothing may have asked for metadata under the DATA path - that is the shape the
+    // dropped context URL produces.
+    for (const auto &request : server.Requests()) {
+        INFO("requested " << request.path);
+        REQUIRE(request.path != data_prefix + "/$metadata");
+    }
+}

--- a/test/cpp/test_datasphere_scan_reexecution.cpp
+++ b/test/cpp/test_datasphere_scan_reexecution.cpp
@@ -185,16 +185,16 @@ TEST_CASE("two datasphere_read_analytical scans of one call each see every row",
 // a DIFFERENT metadata URL. FromEntitySetRoot stores that context URL and the entity-set
 // name from its fragment at bind time, gated on IsDatasphereUrl.
 //
-// An agent-crew review flagged that CloneForScan did not copy either field and called it a
-// regression. It copies them now - a clone should be complete without depending on caller
-// ordering - but in fairness to the record: I could NOT construct a failing case. Two
-// attempts, one with metadata served only under the context path and one with the
-// entity-set name deliberately different from the data URL's last segment, both pass with
-// the copy removed. A clone that adopts page one never re-resolves metadata or the entity
-// type, so the fields are unobservable through SQL on today's paths.
+// Two places threw that state away. CloneForScan did not copy it, and
+// UpdateUrlFromPredicatePushdown rebuilt the client preserving only the OData version -
+// undoing the copy one statement later. Both are fixed; this case pins both.
 //
-// What this case therefore is: end-to-end cover for the dual-URL shape across re-execution,
-// which nothing else had. It is not a regression guard, and calling it one would be wrong.
+// The projecting query is the load-bearing part. An earlier version of this case used only
+// SELECT *, which leaves the URL unchanged and takes the early return in
+// UpdateUrlFromPredicatePushdown, so it never reaches the rebuild - and I wrongly reported
+// the defect as unreproducible on that basis. A projection changes the URL, rebuilds the
+// client, and the reader then asks for $metadata under the DATA path, which is what the
+// final loop catches.
 TEST_CASE("a Datasphere dual-URL asset re-executes correctly",
           "[datasphere_reexec][dualurl]") {
     ODataTestServer server;
@@ -245,6 +245,20 @@ TEST_CASE("a Datasphere dual-URL asset re-executes correctly",
         REQUIRE_FALSE(result->HasError());
         REQUIRE(result->RowCount() == 4);
     }
+
+    // A PROJECTING query is the shape that matters: SELECT * leaves the URL unchanged and
+    // takes the early return in UpdateUrlFromPredicatePushdown, so it never reaches the
+    // client rebuild. A projection changes the URL, rebuilds the client, and any client
+    // state not carried across that rebuild is lost there.
+    auto projected = con.Query("SELECT Name FROM " + read + " ORDER BY Name");
+    INFO((projected->HasError() ? projected->GetError() : std::string()));
+    REQUIRE_FALSE(projected->HasError());
+    REQUIRE(projected->RowCount() == 4);
+
+    // Metadata must have been fetched from the CONTEXT path; an empty set here would make
+    // the loop below assert nothing.
+    INFO("metadata was never fetched from the context path");
+    REQUIRE_FALSE(server.RequestsFor(meta_prefix + "/$metadata").empty());
 
     // Nothing may have asked for metadata under the DATA path - that is the shape the
     // dropped context URL produces.

--- a/test/cpp/test_datasphere_scan_reexecution.cpp
+++ b/test/cpp/test_datasphere_scan_reexecution.cpp
@@ -1,0 +1,182 @@
+// GitHub #75, still open on the Datasphere side.
+//
+// All mutable scan state - the row buffer, the activated projection, and the OData
+// client's pagination cursor - used to live in the bind data. odata_read(), the ATTACHed
+// odata_table_scan and the SAC readers were moved onto ODataReadGlobalState, so each
+// execution of a bound plan gets a private clone. The two Datasphere readers reuse
+// ODataReadScan but keep their own init-global functions, and those still return a bare
+// GlobalTableFunctionState - which makes ResolveScanState fall back to scanning straight
+// out of the bind data.
+//
+// The consequence is the original #75 symptom: the second EXECUTE of a prepared statement
+// finds the buffer already drained and returns nothing, and a self-join of one call has
+// both scans sharing a single cursor. Silently, in both cases - there is no error.
+//
+// These drive the real table functions. Passing a full URL as space_id bypasses the
+// tenant/data-centre URL builder (see BuildDataUrl), which is what lets them run against
+// the local server instead of a Datasphere tenant.
+
+#include "catch.hpp"
+#include "duckdb.hpp"
+
+#include "odata_test_server.hpp"
+
+#include <string>
+
+using erpl_web::test_support::CannedResponse;
+using erpl_web::test_support::MakeV4Page;
+using erpl_web::test_support::ODataTestServer;
+using erpl_web::test_support::RecordedRequest;
+
+namespace {
+
+// See CLAUDE.md: a bare DuckDB(nullptr) crashes in DEBUG builds shortly after the first
+// query unless jemalloc's background threads own arena management.
+class TestDatabase {
+public:
+    TestDatabase()
+    {
+        config.SetOption("allocator_background_threads", duckdb::Value::BOOLEAN(true));
+        database = duckdb::make_uniq<duckdb::DuckDB>(nullptr, &config);
+        connection = duckdb::make_uniq<duckdb::Connection>(*database);
+    }
+
+    duckdb::Connection &Con() const { return *connection; }
+
+private:
+    duckdb::DBConfig config;
+    duckdb::unique_ptr<duckdb::DuckDB> database;
+    duckdb::unique_ptr<duckdb::Connection> connection;
+};
+
+const char *const AIRLINE_AA = R"({"AirlineCode":"AA","Name":"American Airlines"})";
+const char *const AIRLINE_FM = R"({"AirlineCode":"FM","Name":"Shanghai Airline"})";
+const char *const AIRLINE_MU = R"({"AirlineCode":"MU","Name":"China Eastern Airlines"})";
+const char *const AIRLINE_AF = R"({"AirlineCode":"AF","Name":"Air France"})";
+
+// Two pages of four airlines under `prefix`, addressed as space_id=<base>, asset_id=Airlines.
+void ServeTwoPageAirlines(ODataTestServer &server, const std::string &prefix)
+{
+    const std::string entity_url = server.Url(prefix + "/Airlines");
+    const std::string context = server.Url(prefix + "/$metadata") + "#Airlines";
+
+    server.ServeMetadataFixture(prefix + "/$metadata", "edm_trippin.xml");
+    server.OnMatch(
+        [prefix](const RecordedRequest &request) {
+            return request.path == prefix + "/Airlines" && request.QueryParam("$skiptoken") == "2";
+        },
+        CannedResponse::Json(MakeV4Page(context, {AIRLINE_MU, AIRLINE_AF})));
+    server.OnPath(prefix + "/Airlines",
+                  CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA, AIRLINE_FM},
+                                                  entity_url + "?$format=json&$skiptoken=2")));
+
+    // Without a secret the readers start an interactive authorization_code flow and the
+    // test hangs until "Timeout waiting for OAuth2 callback". A client_credentials secret
+    // pointed at this endpoint keeps the whole exchange on loopback.
+    server.OnPath("/oauth/token",
+                  CannedResponse::Json(
+                      R"({"access_token":"test-token","token_type":"Bearer","expires_in":3600})"));
+}
+
+// Registers a Datasphere secret whose token endpoint is the test server.
+void CreateLoopbackSecret(duckdb::Connection &con, const std::string &name,
+                          const ODataTestServer &server)
+{
+    auto created = con.Query(
+        "CREATE SECRET " + name + " (TYPE datasphere, PROVIDER oauth2, "
+        "TENANT_NAME 'loopback', DATA_CENTER 'eu10', "
+        "CLIENT_ID 'test-client', CLIENT_SECRET 'test-secret', "
+        "GRANT_TYPE 'client_credentials', SCOPE 'default', "
+        "TOKEN_URL '" + server.Url("/oauth/token") + "')");
+    INFO((created->HasError() ? created->GetError() : std::string()));
+    REQUIRE_FALSE(created->HasError());
+}
+
+int64_t ScalarOf(duckdb::unique_ptr<duckdb::MaterializedQueryResult> &result)
+{
+    return result->GetValue(0, 0).GetValue<int64_t>();
+}
+
+}  // namespace
+
+TEST_CASE("a bound datasphere_read_relational plan returns every row on each execution",
+          "[datasphere_reexec]") {
+    ODataTestServer server;
+    ServeTwoPageAirlines(server, "/dsrel");
+    const std::string read =
+        "datasphere_read_relational('" + server.Url("/dsrel") + "', 'Airlines', secret => 'ds')";
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+    CreateLoopbackSecret(con, "ds", server);
+
+    REQUIRE_FALSE(con.Query("PREPARE p AS SELECT * FROM " + read)->HasError());
+
+    for (int execution = 1; execution <= 3; execution++) {
+        auto result = con.Query("EXECUTE p");
+        INFO("execution " << execution);
+        INFO((result->HasError() ? result->GetError() : std::string()));
+        REQUIRE_FALSE(result->HasError());
+        REQUIRE(result->RowCount() == 4);
+    }
+}
+
+TEST_CASE("two datasphere_read_relational scans of one call each see every row",
+          "[datasphere_reexec]") {
+    ODataTestServer server;
+    ServeTwoPageAirlines(server, "/dsreljoin");
+    const std::string read =
+        "datasphere_read_relational('" + server.Url("/dsreljoin") + "', 'Airlines', secret => 'ds')";
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+    CreateLoopbackSecret(con, "ds", server);
+
+    auto result = con.Query("SELECT COUNT(*) FROM " + read + " a, " + read + " b");
+    INFO((result->HasError() ? result->GetError() : std::string()));
+    REQUIRE_FALSE(result->HasError());
+    REQUIRE(ScalarOf(result) == 16);
+}
+
+TEST_CASE("a bound datasphere_read_analytical plan returns every row on each execution",
+          "[datasphere_reexec]") {
+    ODataTestServer server;
+    ServeTwoPageAirlines(server, "/dsana");
+    const std::string read =
+        "datasphere_read_analytical('" + server.Url("/dsana") + "', 'Airlines', secret => 'ds')";
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+    CreateLoopbackSecret(con, "ds", server);
+
+    REQUIRE_FALSE(con.Query("PREPARE q AS SELECT * FROM " + read)->HasError());
+
+    for (int execution = 1; execution <= 3; execution++) {
+        auto result = con.Query("EXECUTE q");
+        INFO("execution " << execution);
+        INFO((result->HasError() ? result->GetError() : std::string()));
+        REQUIRE_FALSE(result->HasError());
+        REQUIRE(result->RowCount() == 4);
+    }
+}
+
+TEST_CASE("two datasphere_read_analytical scans of one call each see every row",
+          "[datasphere_reexec]") {
+    ODataTestServer server;
+    ServeTwoPageAirlines(server, "/dsanajoin");
+    const std::string read =
+        "datasphere_read_analytical('" + server.Url("/dsanajoin") + "', 'Airlines', secret => 'ds')";
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+    CreateLoopbackSecret(con, "ds", server);
+
+    auto result = con.Query("SELECT COUNT(*) FROM " + read + " a, " + read + " b");
+    INFO((result->HasError() ? result->GetError() : std::string()));
+    REQUIRE_FALSE(result->HasError());
+    REQUIRE(ScalarOf(result) == 16);
+}


### PR DESCRIPTION
Finishes #75 on the Datasphere side. See also #146, which is the same gap on `odp_odata_read`.

All mutable scan state — the row buffer, the activated projection, the OData client's pagination cursor — was moved onto `ODataReadGlobalState` for `odata_read`, the ATTACHed `odata_table_scan` and the SAC readers. The two Datasphere readers reuse `ODataReadScan` but kept their **own** init-global functions returning a bare `GlobalTableFunctionState`, so `ResolveScanState` fell back to scanning straight out of the bind data. The code even said so:

```cpp
// The Datasphere readers reuse ODataReadScan with their own init-global
// functions, which still return a bare GlobalTableFunctionState; those keep the
// historical behaviour of scanning straight out of the bind data.
```

That is the original #75 symptom, and it is **silent**: the second `EXECUTE` of a prepared statement finds the buffer already drained and returns zero rows, with no error.

### Red → green

Both new re-execution tests fail before the change and pass after:

```
test_datasphere_scan_reexecution.cpp:121: FAILED:
  REQUIRE( result->RowCount() == 4 )
with expansion:  0 == 4
with messages:   execution 2
```

Reverting only `datasphere_read.cpp` puts them back to `2 passed | 2 failed`, so they are not decoration.

### The part that needed care

Input parameters live on the **OData client**, and `CloneForScan` mints a fresh one. Re-applying them to the bind data's client — as the old code did — would leave the client that actually issues requests without them. They are now applied to the clone.

The two 3-parameter overloads also carried a hand-rolled `table_scan_progress` lambda reading `GetProgressFraction()` off the bind data. That is now the wrong object, since progress lives on the per-execution clone, so they use `ODataReadTableProgress` like every other overload already did.

### Honest note on the self-join cases

They pass **both** before and after. Two literal calls are two separate bindings with separate bind data, so only re-execution of a single binding was ever broken. I kept them as regression guards rather than present them as evidence.

### Testing against a real scan

Passing a full URL as `space_id` bypasses the tenant/data-centre URL builder (see `BuildDataUrl`), which is what lets these drive the real table functions against `ODataTestServer`. Without a secret the readers start an interactive authorization_code flow and hang until *"Timeout waiting for OAuth2 callback"*, so the tests register a `client_credentials` secret whose token endpoint is the test server — the whole exchange stays on loopback.

I also corrected the `ResolveScanState` comment: the bind-data fallback is not a safe default, it is the historical behaviour that caused this, and a new reader should return `ODataReadGlobalState`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791787270&installation_model_id=425457&pr_number=178&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F178&signature=3ccf50fb2f5606662a8da8b2072c81ed098fecdf60f9ce55ee36577f16e1de03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->