### PR TITLE
fix: give odp_odata_read per-execution scan state (#146)

### DIFF
--- a/src/include/odp_odata_read_bind_data.hpp
+++ b/src/include/odp_odata_read_bind_data.hpp
@@ -163,6 +163,21 @@ public:
     void Initialize();
 
     /**
+     * @brief Build a private copy of this bind data for one execution of a bound plan.
+     *
+     * All mutable scan state - the inner ODataReadBindData's row buffer and pagination
+     * cursor, the audit id, the staged delta token - lives on the instance, so sharing one
+     * between executions makes the second EXECUTE of a prepared statement find the buffer
+     * already drained and return nothing (GitHub #146, the #75 class).
+     *
+     * The clone re-runs Initialize(), which re-resolves the SAME subscription rather than
+     * creating a second one: (service_url, entity_set_name) is unique in the repository and
+     * CreateSubscription returns the existing id for an active row. The audit id and the
+     * delta-token staging slot start empty, which is what they must be for a new execution.
+     */
+    duckdb::unique_ptr<OdpODataReadBindData> CloneForScan() const;
+
+    /**
      * @brief Called when the scan is finished, however it finished.
      *
      * Commits a staged delta token. The scan can end WITHOUT a final zero-row

--- a/src/odp_odata_read_bind_data.cpp
+++ b/src/odp_odata_read_bind_data.cpp
@@ -50,6 +50,28 @@ OdpODataReadBindData::OdpODataReadBindData(duckdb::ClientContext& context,
     ValidateEntitySetUrl();
 }
 
+duckdb::unique_ptr<OdpODataReadBindData> OdpODataReadBindData::CloneForScan() const {
+    ERPL_TRACE_DEBUG("ODP_BIND_DATA", "Cloning ODP bind data for a new execution");
+
+    auto clone = duckdb::make_uniq<OdpODataReadBindData>(
+        context_, entity_set_url_, secret_name_, force_full_load_, import_delta_token_,
+        max_page_size_);
+
+    if (initialized_) {
+        clone->Initialize();
+    }
+
+    // Column activation is held on the wrapper rather than the inner bind data (GitHub
+    // #58): the inner instance is replaced wholesale on every page, and only the wrapper
+    // remembers the selection well enough to re-apply it to the replacement. A clone that
+    // did not carry it would run page 2 onwards in all-columns mode.
+    if (!active_column_ids_.empty()) {
+        clone->ActivateColumns(active_column_ids_);
+    }
+
+    return clone;
+}
+
 // ============================================================================
 // Core DuckDB Table Function Interface (Delegated)
 // ============================================================================

--- a/src/odp_odata_read_bind_data.cpp
+++ b/src/odp_odata_read_bind_data.cpp
@@ -53,9 +53,18 @@ OdpODataReadBindData::OdpODataReadBindData(duckdb::ClientContext& context,
 duckdb::unique_ptr<OdpODataReadBindData> OdpODataReadBindData::CloneForScan() const {
     ERPL_TRACE_DEBUG("ODP_BIND_DATA", "Cloning ODP bind data for a new execution");
 
+    // force_full_load and import_delta_token are ONE-SHOT bind options, and are
+    // deliberately not forwarded to the clone.
+    //
+    // Bind has already applied them: force_full_load reset the subscription, and
+    // import_delta_token was written to it. Replaying them per execution would mean a
+    // prepared statement re-imports the same token on every EXECUTE, so execution 2 could
+    // never advance past the token execution 1 consumed - the subscription would be pinned
+    // forever at the imported position. The clone instead resolves the subscription bind
+    // left behind, which is exactly the state those options produced (GitHub #188).
     auto clone = duckdb::make_uniq<OdpODataReadBindData>(
-        context_, entity_set_url_, secret_name_, force_full_load_, import_delta_token_,
-        max_page_size_);
+        context_, entity_set_url_, secret_name_, /*force_full_load=*/false,
+        /*import_delta_token=*/std::string(), max_page_size_);
 
     if (initialized_) {
         clone->Initialize();
@@ -68,6 +77,11 @@ duckdb::unique_ptr<OdpODataReadBindData> OdpODataReadBindData::CloneForScan() co
     if (!active_column_ids_.empty()) {
         clone->ActivateColumns(active_column_ids_);
     }
+
+    // Result modifiers (pushed LIMIT / ORDER BY) are deliberately not carried, because
+    // AddResultModifiers is intentionally never called on either bind data - see the note
+    // at odata_read_functions.hpp. If that path is ever wired up, modifier state has to be
+    // copied here too.
 
     return clone;
 }

--- a/src/odp_odata_read_functions.cpp
+++ b/src/odp_odata_read_functions.cpp
@@ -86,38 +86,9 @@ duckdb::unique_ptr<duckdb::FunctionData> OdpODataReadBind(duckdb::ClientContext 
     }
 }
 
-namespace {
-
-// Owns the private scan state for one execution of a bound plan (GitHub #146).
-class OdpODataReadGlobalState : public duckdb::GlobalTableFunctionState {
-public:
-    explicit OdpODataReadGlobalState(duckdb::unique_ptr<OdpODataReadBindData> scan_state)
-        : scan_state(std::move(scan_state)) {}
-
-    OdpODataReadBindData &Scan() { return *scan_state; }
-
-private:
-    duckdb::unique_ptr<OdpODataReadBindData> scan_state;
-};
-
-// Returns the object that owns the scan state for this execution, falling back to the
-// bind data for any caller that still supplies a bare GlobalTableFunctionState. That
-// fallback is not a safe default - it is the historical behaviour that made the second
-// EXECUTE of a bound plan return nothing.
-OdpODataReadBindData &ResolveOdpScanState(const duckdb::FunctionData *bind_data,
-                                          const duckdb::GlobalTableFunctionState *global_state) {
-    auto *odp_global = dynamic_cast<const OdpODataReadGlobalState *>(global_state);
-    if (odp_global != nullptr) {
-        return const_cast<OdpODataReadGlobalState *>(odp_global)->Scan();
-    }
-    return bind_data->CastNoConst<OdpODataReadBindData>();
-}
-
-} // namespace
-
 void OdpODataReadScan(duckdb::ClientContext &context, duckdb::TableFunctionInput &data, duckdb::DataChunk &output) {
-    auto &bind_data = ResolveOdpScanState(data.bind_data.get(), data.global_state.get());
-
+    auto &bind_data = data.bind_data->CastNoConst<OdpODataReadBindData>();
+    
     ERPL_TRACE_DEBUG("ODP_ODATA_READ_SCAN", "Starting ODP scan operation");
     
     try {
@@ -159,16 +130,11 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> OdpODataReadInitGlobalState
     // the re-application in FetchAndLoadNextPage was a no-op and page 2 onwards ran in
     // all-columns mode - which, as the comment there notes, can write out of bounds into a
     // projected chunk. See GitHub #58.
-    // Every execution gets a private clone: the row buffer, the pagination cursor, the
-    // audit id and the delta-token staging slot all live on the instance, so sharing one
-    // made the second EXECUTE of a bound plan return nothing (GitHub #146).
-    auto scan_state = bind_data.CloneForScan();
-
-    scan_state->ActivateColumns(column_ids);
+    bind_data.ActivateColumns(column_ids);
 
     // Filters are deliberately not pushed down for ODP; see the filter_pushdown comment at
     // the function registration below.
-    scan_state->GetODataBindData().UpdateUrlFromPredicatePushdown();
+    bind_data.GetODataBindData().UpdateUrlFromPredicatePushdown();
 
     // Do NOT call PrefetchFirstPage() here. The ODP first fetch must be orchestrator-owned:
     // it is the only path that applies the required Prefer: odata.track-changes /
@@ -177,15 +143,14 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> OdpODataReadInitGlobalState
     // here carries none of those headers, so SAP ODP ignores max_page_size and returns the whole
     // entity set in one response, exceeding the 30 s HTTP read timeout. See GitHub #47.
 
-    return duckdb::make_uniq<OdpODataReadGlobalState>(std::move(scan_state));
+    return duckdb::make_uniq<duckdb::GlobalTableFunctionState>();
 }
 
 double OdpODataReadProgress(duckdb::ClientContext &context, const duckdb::FunctionData *func_data,
-                           const duckdb::GlobalTableFunctionState *global_state) {
-    // Progress lives on the per-execution clone, so it has to be read from there rather
-    // than from the bind data (GitHub #146).
-    auto &bind_data = ResolveOdpScanState(func_data, global_state);
-    return bind_data.GetODataBindData().GetProgressFraction();
+                           const duckdb::GlobalTableFunctionState *) {
+    auto &bind_data = func_data->CastNoConst<OdpODataReadBindData>();
+    auto& odata_bind_data = bind_data.GetODataBindData();
+    return odata_bind_data.GetProgressFraction();
 }
 
 // ============================================================================

--- a/src/odp_odata_read_functions.cpp
+++ b/src/odp_odata_read_functions.cpp
@@ -86,9 +86,38 @@ duckdb::unique_ptr<duckdb::FunctionData> OdpODataReadBind(duckdb::ClientContext 
     }
 }
 
+namespace {
+
+// Owns the private scan state for one execution of a bound plan (GitHub #146).
+class OdpODataReadGlobalState : public duckdb::GlobalTableFunctionState {
+public:
+    explicit OdpODataReadGlobalState(duckdb::unique_ptr<OdpODataReadBindData> scan_state)
+        : scan_state(std::move(scan_state)) {}
+
+    OdpODataReadBindData &Scan() { return *scan_state; }
+
+private:
+    duckdb::unique_ptr<OdpODataReadBindData> scan_state;
+};
+
+// Returns the object that owns the scan state for this execution, falling back to the
+// bind data for any caller that still supplies a bare GlobalTableFunctionState. That
+// fallback is not a safe default - it is the historical behaviour that made the second
+// EXECUTE of a bound plan return nothing.
+OdpODataReadBindData &ResolveOdpScanState(const duckdb::FunctionData *bind_data,
+                                          const duckdb::GlobalTableFunctionState *global_state) {
+    auto *odp_global = dynamic_cast<const OdpODataReadGlobalState *>(global_state);
+    if (odp_global != nullptr) {
+        return const_cast<OdpODataReadGlobalState *>(odp_global)->Scan();
+    }
+    return bind_data->CastNoConst<OdpODataReadBindData>();
+}
+
+} // namespace
+
 void OdpODataReadScan(duckdb::ClientContext &context, duckdb::TableFunctionInput &data, duckdb::DataChunk &output) {
-    auto &bind_data = data.bind_data->CastNoConst<OdpODataReadBindData>();
-    
+    auto &bind_data = ResolveOdpScanState(data.bind_data.get(), data.global_state.get());
+
     ERPL_TRACE_DEBUG("ODP_ODATA_READ_SCAN", "Starting ODP scan operation");
     
     try {
@@ -130,11 +159,16 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> OdpODataReadInitGlobalState
     // the re-application in FetchAndLoadNextPage was a no-op and page 2 onwards ran in
     // all-columns mode - which, as the comment there notes, can write out of bounds into a
     // projected chunk. See GitHub #58.
-    bind_data.ActivateColumns(column_ids);
+    // Every execution gets a private clone: the row buffer, the pagination cursor, the
+    // audit id and the delta-token staging slot all live on the instance, so sharing one
+    // made the second EXECUTE of a bound plan return nothing (GitHub #146).
+    auto scan_state = bind_data.CloneForScan();
+
+    scan_state->ActivateColumns(column_ids);
 
     // Filters are deliberately not pushed down for ODP; see the filter_pushdown comment at
     // the function registration below.
-    bind_data.GetODataBindData().UpdateUrlFromPredicatePushdown();
+    scan_state->GetODataBindData().UpdateUrlFromPredicatePushdown();
 
     // Do NOT call PrefetchFirstPage() here. The ODP first fetch must be orchestrator-owned:
     // it is the only path that applies the required Prefer: odata.track-changes /
@@ -143,14 +177,15 @@ duckdb::unique_ptr<duckdb::GlobalTableFunctionState> OdpODataReadInitGlobalState
     // here carries none of those headers, so SAP ODP ignores max_page_size and returns the whole
     // entity set in one response, exceeding the 30 s HTTP read timeout. See GitHub #47.
 
-    return duckdb::make_uniq<duckdb::GlobalTableFunctionState>();
+    return duckdb::make_uniq<OdpODataReadGlobalState>(std::move(scan_state));
 }
 
 double OdpODataReadProgress(duckdb::ClientContext &context, const duckdb::FunctionData *func_data,
-                           const duckdb::GlobalTableFunctionState *) {
-    auto &bind_data = func_data->CastNoConst<OdpODataReadBindData>();
-    auto& odata_bind_data = bind_data.GetODataBindData();
-    return odata_bind_data.GetProgressFraction();
+                           const duckdb::GlobalTableFunctionState *global_state) {
+    // Progress lives on the per-execution clone, so it has to be read from there rather
+    // than from the bind data (GitHub #146).
+    auto &bind_data = ResolveOdpScanState(func_data, global_state);
+    return bind_data.GetODataBindData().GetProgressFraction();
 }
 
 // ============================================================================

--- a/test/cpp/test_odp_scan_reexecution.cpp
+++ b/test/cpp/test_odp_scan_reexecution.cpp
@@ -26,13 +26,26 @@
 
 #include <sstream>
 #include <string>
+#include <vector>
 
 using erpl_web::test_support::CannedResponse;
+using erpl_web::test_support::MakeOdpDeltaPage;
 using erpl_web::test_support::ODataTestServer;
+using erpl_web::test_support::RecordedRequest;
 
 namespace {
 
 // An OData v2 ODP page, the shape the ODP reader parses.
+std::vector<std::string> MakeOdpRows(std::size_t row_count)
+{
+    std::vector<std::string> rows;
+    rows.reserve(row_count);
+    for (std::size_t i = 0; i < row_count; i++) {
+        rows.push_back(R"({"D_NW_DIV":")" + std::to_string(i) + R"(","ODQ_CHANGEMODE":"C"})");
+    }
+    return rows;
+}
+
 std::string MakeOdpPage(std::size_t row_count)
 {
     std::ostringstream out;
@@ -59,7 +72,18 @@ void ServeOdpEntitySet(ODataTestServer &server, const std::string &path, std::si
 
 }  // namespace
 
-TEST_CASE("a bound odp_odata_read plan returns every row on each execution",
+// This fixture issues NO delta token and no Preference-Applied, so the subscription stays
+// in initial-load phase and every execution is a full load. That is a real shape, not a
+// convenience: an ABAP-CDS extractor without changeDataCapture reports supports_delta = ' '
+// and never yields a delta link, which is exactly why the live delta test is gated on a
+// separate, delta-capable service. What is asserted here is therefore "a non-delta-capable
+// ODP re-extracts in full on every execution" - true of a real service of that kind.
+//
+// The delta-capable shape is pinned by the case below. An earlier version of this file had
+// only this case and asserted the full row count on every execution as though that were
+// universal; against a delta-capable service execution 2 is a delta fetch and returns the
+// changes, usually none. Raised by an agent-crew review (F6).
+TEST_CASE("a bound odp_odata_read plan re-extracts in full when the service has no delta",
           "[odp_reexec]") {
     constexpr std::size_t ROW_COUNT = 120;
     const std::string path = "/sap/opu/odata/sap/Z_TEST_SRV/FactsOf0D_NW_C01";
@@ -93,3 +117,62 @@ TEST_CASE("a bound odp_odata_read plan returns every row on each execution",
 // defect filed as GitHub #179, confirmed by reverting every ODP source change here and
 // re-running. A projecting case cannot pass while that stands, and folding the two
 // together would hide one behind the other. It belongs with the fix for #179.
+
+// The delta-capable counterpart: execution 1 is the initial load and commits the token,
+// execution 2 must resume from it rather than re-extracting. Without per-execution scan
+// state this could not be observed at all - the second EXECUTE returned nothing because
+// the buffer was drained, which looks identical to "the delta was empty".
+TEST_CASE("a bound odp_odata_read plan resumes from the committed delta token",
+          "[odp_reexec][delta]") {
+    constexpr std::size_t ROW_COUNT = 120;
+    const std::string path = "/sap/opu/odata/sap/Z_TEST_SRV/FactsOf0D_NW_C01";
+
+    ODataTestServer server;
+    server.ServeMetadataFixture("/sap/opu/odata/sap/Z_TEST_SRV/$metadata",
+                                "edm_sap_odp_bw_fact.xml");
+    server.ServeMetadataFixture(path + "/$metadata", "edm_sap_odp_bw_fact.xml");
+
+    const std::string delta_link =
+        server.Url(path) + "?!deltatoken=D20260912000000_000001000";
+
+    // A request carrying the delta token is the follow-up read; it reports no changes.
+    server.OnMatch(
+        [path](const RecordedRequest &request) {
+            return request.path == path && request.query.find("deltatoken") != std::string::npos;
+        },
+        CannedResponse::Json(R"({"d":{"results":[]}})"));
+
+    // Anything else is the initial load, which hands back a delta link plus
+    // Preference-Applied: odata.track-changes.
+    server.OnPath(path, MakeOdpDeltaPage(MakeOdpRows(ROW_COUNT), delta_link));
+
+    odp_test::TempDatabase db("odp_reexec_delta");
+    auto &con = db.Conn();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    const auto url = server.Url(path);
+    REQUIRE_FALSE(
+        con.Query("PREPARE p AS SELECT COUNT(*) FROM odp_odata_read('" + url + "')")
+            ->HasError());
+
+    auto initial = con.Query("EXECUTE p");
+    INFO((initial->HasError() ? initial->GetError() : std::string()));
+    REQUIRE_FALSE(initial->HasError());
+    REQUIRE(initial->GetValue(0, 0).GetValue<int64_t>() == static_cast<int64_t>(ROW_COUNT));
+
+    // Execution 2 must reach the service WITH the token - not re-extract, and not return
+    // nothing because a shared buffer was already drained.
+    auto delta = con.Query("EXECUTE p");
+    INFO((delta->HasError() ? delta->GetError() : std::string()));
+    REQUIRE_FALSE(delta->HasError());
+    REQUIRE(delta->GetValue(0, 0).GetValue<int64_t>() == 0);
+
+    bool token_reached_the_wire = false;
+    for (const auto &request : server.RequestsFor(path)) {
+        if (request.query.find("deltatoken") != std::string::npos) {
+            token_reached_the_wire = true;
+        }
+    }
+    INFO("no request carried a delta token, so execution 2 was not a delta fetch");
+    REQUIRE(token_reached_the_wire);
+}

--- a/test/cpp/test_odp_scan_reexecution.cpp
+++ b/test/cpp/test_odp_scan_reexecution.cpp
@@ -176,3 +176,72 @@ TEST_CASE("a bound odp_odata_read plan resumes from the committed delta token",
     INFO("no request carried a delta token, so execution 2 was not a delta fetch");
     REQUIRE(token_reached_the_wire);
 }
+
+// GitHub #188. force_full_load and import_delta_token are one-shot bind options. Forwarding
+// them to every clone meant a prepared statement re-applied them on each EXECUTE, so an
+// imported token was re-imported forever and the subscription could never advance past the
+// position execution 1 had already consumed.
+//
+// Raised by an agent-crew review (F9), which noted neither parameter appeared in this file
+// at all.
+TEST_CASE("an imported delta token is consumed once, not re-imported every execution",
+          "[odp_reexec][import]") {
+    const std::string path = "/sap/opu/odata/sap/Z_TEST_SRV/FactsOf0D_NW_C01";
+    const std::string imported = "D20260101000000_000000001";
+    const std::string advanced = "D20260202000000_000000002";
+
+    ODataTestServer server;
+    server.ServeMetadataFixture("/sap/opu/odata/sap/Z_TEST_SRV/$metadata",
+                                "edm_sap_odp_bw_fact.xml");
+    server.ServeMetadataFixture(path + "/$metadata", "edm_sap_odp_bw_fact.xml");
+
+    // A read carrying the ADVANCED token reports no changes; reaching this proves the
+    // subscription moved on from the imported one.
+    server.OnMatch(
+        [path, advanced](const RecordedRequest &request) {
+            return request.path == path && request.query.find(advanced) != std::string::npos;
+        },
+        CannedResponse::Json(R"({"d":{"results":[]}})"));
+
+    // A read carrying the IMPORTED token returns one change and hands back the advanced
+    // token, so a correct reader stores the new one.
+    server.OnMatch(
+        [path, imported](const RecordedRequest &request) {
+            return request.path == path && request.query.find(imported) != std::string::npos;
+        },
+        MakeOdpDeltaPage(MakeOdpRows(1), server.Url(path) + "?!deltatoken=" + advanced));
+
+    server.OnPath(path, MakeOdpDeltaPage(MakeOdpRows(5),
+                                         server.Url(path) + "?!deltatoken=" + imported));
+
+    odp_test::TempDatabase db("odp_import_once");
+    auto &con = db.Conn();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    const auto url = server.Url(path);
+    auto prep = con.Query("PREPARE imp AS SELECT COUNT(*) FROM odp_odata_read('" + url +
+                          "', import_delta_token => '" + imported + "')");
+    INFO((prep->HasError() ? prep->GetError() : std::string()));
+    REQUIRE_FALSE(prep->HasError());
+
+    auto first = con.Query("EXECUTE imp");
+    INFO((first->HasError() ? first->GetError() : std::string()));
+    REQUIRE_FALSE(first->HasError());
+    REQUIRE(first->GetValue(0, 0).GetValue<int64_t>() == 1);
+
+    // Execution 2 must resume from the ADVANCED token. If the clone re-imported the
+    // original, this would return 1 again, forever.
+    auto second = con.Query("EXECUTE imp");
+    INFO((second->HasError() ? second->GetError() : std::string()));
+    REQUIRE_FALSE(second->HasError());
+    REQUIRE(second->GetValue(0, 0).GetValue<int64_t>() == 0);
+
+    bool advanced_reached_the_wire = false;
+    for (const auto &request : server.RequestsFor(path)) {
+        if (request.query.find(advanced) != std::string::npos) {
+            advanced_reached_the_wire = true;
+        }
+    }
+    INFO("the advanced token never reached the wire, so the token never moved on");
+    REQUIRE(advanced_reached_the_wire);
+}

--- a/test/cpp/test_odp_scan_reexecution.cpp
+++ b/test/cpp/test_odp_scan_reexecution.cpp
@@ -1,0 +1,95 @@
+// GitHub #146: odp_odata_read has no per-execution scan state - the #75 class, still open
+// on the ODP side.
+//
+// odata_read, the ATTACHed odata_table_scan, the SAC readers and (as of #75's Datasphere
+// follow-up) both Datasphere readers hand each execution a private clone owned by a real
+// GlobalTableFunctionState. OdpODataReadInitGlobalState still returned a bare
+// GlobalTableFunctionState and OdpODataReadScan cast data.bind_data directly, so every
+// execution of a bound plan scanned the same object: the second EXECUTE found the row
+// buffer already drained and returned nothing, silently.
+//
+// A note on what is NOT tested here. The issue also asks for a self-join of one
+// odp_odata_read call. That shape cannot work against a real service and should not be
+// made to: an ODQ subscription admits one open extraction at a time, and SAP refuses the
+// second with "Could not open data access via extraction API RODPS_REPL_ODP_OPEN"
+// (RSODP_ODATA/013). That was established in #173, where the same shape in
+// odp_odata_read.test had to be rewritten as two sequential reads. Asserting that a
+// self-join succeeds against a canned server would assert something untrue of every real
+// service, so re-execution - which is sequential, and which real services do support - is
+// what is covered.
+
+#include "catch.hpp"
+#include "duckdb.hpp"
+
+#include "odata_test_server.hpp"
+#include "odp_test_db.hpp"
+
+#include <sstream>
+#include <string>
+
+using erpl_web::test_support::CannedResponse;
+using erpl_web::test_support::ODataTestServer;
+
+namespace {
+
+// An OData v2 ODP page, the shape the ODP reader parses.
+std::string MakeOdpPage(std::size_t row_count)
+{
+    std::ostringstream out;
+    out << R"({"d":{"results":[)";
+    for (std::size_t i = 0; i < row_count; i++) {
+        if (i > 0) {
+            out << ",";
+        }
+        // D_NW_DIV is a real column of edm_sap_odp_bw_fact.xml; the schema comes from
+        // the EDM, so a made-up name binds to nothing.
+        out << R"({"D_NW_DIV":")" << i << R"(","ODQ_CHANGEMODE":"C"})";
+    }
+    out << "]}}";
+    return out.str();
+}
+
+void ServeOdpEntitySet(ODataTestServer &server, const std::string &path, std::size_t rows)
+{
+    server.ServeMetadataFixture("/sap/opu/odata/sap/Z_TEST_SRV/$metadata",
+                                "edm_sap_odp_bw_fact.xml");
+    server.ServeMetadataFixture(path + "/$metadata", "edm_sap_odp_bw_fact.xml");
+    server.OnPath(path, CannedResponse::Json(MakeOdpPage(rows)));
+}
+
+}  // namespace
+
+TEST_CASE("a bound odp_odata_read plan returns every row on each execution",
+          "[odp_reexec]") {
+    constexpr std::size_t ROW_COUNT = 120;
+    const std::string path = "/sap/opu/odata/sap/Z_TEST_SRV/FactsOf0D_NW_C01";
+
+    ODataTestServer server;
+    ServeOdpEntitySet(server, path, ROW_COUNT);
+
+    // ODP delta state is refused an in-memory catalog on purpose (GitHub #92), so the
+    // state has to live in a real database file.
+    odp_test::TempDatabase db("odp_reexec");
+    auto &con = db.Conn();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    const auto url = server.Url(path);
+    REQUIRE_FALSE(
+        con.Query("PREPARE p AS SELECT COUNT(*) FROM odp_odata_read('" + url + "')")
+            ->HasError());
+
+    for (int execution = 1; execution <= 3; execution++) {
+        auto result = con.Query("EXECUTE p");
+        INFO("execution " << execution);
+        INFO((result->HasError() ? result->GetError() : std::string()));
+        REQUIRE_FALSE(result->HasError());
+        REQUIRE(result->GetValue(0, 0).GetValue<int64_t>() ==
+                static_cast<int64_t>(ROW_COUNT));
+    }
+}
+
+// The projecting re-execution case is deliberately absent. odp_odata_read returns NULL for
+// every explicitly projected column while SELECT * returns the values - a pre-existing
+// defect filed as GitHub #179, confirmed by reverting every ODP source change here and
+// re-running. A projecting case cannot pass while that stands, and folding the two
+// together would hide one behind the other. It belongs with the fix for #179.


### PR DESCRIPTION
Closes #146. With #178 (Datasphere) this clears the #75 class from the OData and SAP readers — `odp_odata_read` was the last of those still scanning out of its bind data.

**Correction to an earlier version of this description:** I first wrote that this "finishes the #75 class". It does not. Checking afterwards turned up six more table functions with the same defect — the Business Central and Dataverse readers keep a `finished` flag on their bind data, never reset it, and return `nullptr` as their global state. That is filed as **#182** and is not addressed here.

`OdpODataReadInitGlobalState` returned a bare `GlobalTableFunctionState` and `OdpODataReadScan` cast `data.bind_data` directly, so every execution of a bound plan scanned the same object. The second `EXECUTE` found the row buffer already drained and returned nothing — silently.

### Red → green

```
test_odp_scan_reexecution.cpp:86: FAILED:
  REQUIRE( result->GetValue(0, 0).GetValue<int64_t>() == ROW_COUNT )
with expansion:  0 == 120
with messages:   execution 3
```

Reverting only `odp_odata_read_functions.cpp` puts it back to red, so it is not decoration.

### What the clone had to get right

The issue warned this is not a mechanical copy of #75, and it was right to:

- **The subscription must not be duplicated.** It is not: `Initialize()` re-resolves the same row, because `(service_url, entity_set_name)` is unique in the repository and `CreateSubscription` returns the existing id for an active row. I checked this rather than assumed it.
- **The audit id and delta-token staging slot start empty**, which is what a new execution needs.
- **Column activation is carried across explicitly** — for ODP it lives on the wrapper, not the inner bind data (#58), because the inner instance is replaced wholesale on every page.
- **Progress** is read through the same resolver. It lives on the clone now, so reading it off the bind data would report the wrong scan.

### Two shapes deliberately not covered

**A self-join of one `odp_odata_read` call.** The issue asks for it; it cannot work against a real service and should not be made to. An ODQ subscription admits one open extraction at a time, and SAP refuses the second with `RSODP_ODATA/013` — which is exactly what forced the rewrite of `odp_odata_read.test` in #173. Asserting success against a canned server would assert something untrue of every real service.

**A projecting re-execution case.** It cannot pass yet: `odp_odata_read` returns `NULL` for every explicitly projected column while `SELECT *` returns the values. Pre-existing, confirmed by reverting every ODP source change here, filed as **#179**. Folding the two together would have hidden one behind the other.

### Verification

440 C++ cases / 2222 assertions green. Live SAP tier against A4H green (12 passed, 2 skipped) — worth having here, since this touches real subscription and delta-token state rather than just row plumbing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791788394&installation_model_id=425457&pr_number=180&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F180&signature=ab0ab330f43cfa84672cf80fe84f75fc885215b7f44ef79a39a0bac6dbbbaa7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
