### PR TITLE
fix: project the column the query asked for in odp_odata_read (#179)

### DIFF
--- a/src/include/odp_odata_read_bind_data.hpp
+++ b/src/include/odp_odata_read_bind_data.hpp
@@ -313,11 +313,6 @@ private:
     void ProcessRequestResult(const OdpRequestOrchestrator::OdpRequestResult& result,
                              const std::string& operation_type);
 
-    /**
-     * @brief Update the underlying OData client with new URL/token
-     * @param url New URL to use for requests
-     */
-    void UpdateODataClient(const std::string& url);
 
     /**
      * @brief Update OData client with pre-fetched response content

--- a/src/include/odp_odata_read_functions.hpp
+++ b/src/include/odp_odata_read_functions.hpp
@@ -68,7 +68,7 @@ double OdpODataReadProgress(duckdb::ClientContext &context, const duckdb::Functi
  *   - secret (VARCHAR): DuckDB secret name for authentication
  *   - force_full_load (BOOLEAN): Force full reload instead of delta
  *   - import_delta_token (VARCHAR): Import existing delta token
- *   - max_page_size (UINTEGER): Override default page size
+ *   - max_page_size (UBIGINT): Override default page size (validated, must be > 0)
  * 
  * @return TableFunctionSet for registration with DuckDB
  */

--- a/src/odp_odata_read_bind_data.cpp
+++ b/src/odp_odata_read_bind_data.cpp
@@ -604,7 +604,17 @@ void OdpODataReadBindData::UpdateODataClientWithResponse(const std::string& url,
         if (!odata_bind_data_) {
             throw duckdb::InternalException("Failed to update OData client with response");
         }
-        
+
+        // The replacement carries no column selection, so it has to be re-applied here -
+        // at the single place the instance is replaced - rather than at each call site.
+        // FetchAndLoadNextPage did re-apply it; HandleInitialLoad and HandleDeltaFetch did
+        // not, so the FIRST page of every scan ran in all-columns mode and an explicitly
+        // projected column came back NULL for every row, with the row count still correct
+        // (GitHub #179).
+        if (!active_column_ids_.empty()) {
+            odata_bind_data_->ActivateColumns(active_column_ids_);
+        }
+
         ERPL_TRACE_DEBUG("ODP_BIND_DATA", "OData client updated successfully with pre-fetched response");
         
     } catch (const std::exception& e) {
@@ -785,12 +795,10 @@ void OdpODataReadBindData::FetchAndLoadNextPage() {
     // Use entity_set_url_ as the canonical URL; the actual content comes from the fetched page.
     UpdateODataClientWithResponse(entity_set_url_, next_result.response->RawContent());
 
-    // Re-apply column projection: UpdateODataClientWithResponse creates a fresh
-    // ODataReadBindData that has no column selection. Without this, the new instance
-    // falls back to "all columns" mode and can write out-of-bounds into a projected chunk.
-    if (!active_column_ids_.empty()) {
-        odata_bind_data_->ActivateColumns(active_column_ids_);
-    }
+    // Column projection is re-applied inside UpdateODataClientWithResponse itself, so it
+    // covers this call and the two in HandleInitialLoad / HandleDeltaFetch alike. It used
+    // to be re-applied only here, which is why only page two onwards was ever projected
+    // correctly (GitHub #179).
 
     ERPL_TRACE_INFO("ODP_BIND_DATA", pending_next_url_.empty()
         ? "Last ODP page loaded into odata_bind_data_"

--- a/src/odp_odata_read_bind_data.cpp
+++ b/src/odp_odata_read_bind_data.cpp
@@ -564,25 +564,6 @@ void OdpODataReadBindData::CommitStagedDeltaToken() {
     staged_operation_type_.clear();
 }
 
-void OdpODataReadBindData::UpdateODataClient(const std::string& url) {
-    ERPL_TRACE_DEBUG("ODP_BIND_DATA", "Updating OData client with URL: " + url);
-    
-    try {
-        // Recreate the OData bind data with the new URL
-        odata_bind_data_ = ODataReadBindData::FromEntitySetRoot(url, auth_params_);
-        
-        if (!odata_bind_data_) {
-            throw duckdb::InternalException("Failed to update OData client");
-        }
-        
-        ERPL_TRACE_DEBUG("ODP_BIND_DATA", "OData client updated successfully");
-        
-    } catch (const std::exception& e) {
-        ERPL_TRACE_ERROR("ODP_BIND_DATA", "Failed to update OData client: " + std::string(e.what()));
-        throw;
-    }
-}
-
 void OdpODataReadBindData::UpdateODataClientWithResponse(const std::string& url, const std::string& response_content) {
     ERPL_TRACE_DEBUG("ODP_BIND_DATA", "Updating OData client with pre-fetched response for URL: " + url);
     

--- a/test/cpp/test_odp_projection.cpp
+++ b/test/cpp/test_odp_projection.cpp
@@ -90,6 +90,9 @@ TEST_CASE("odp_odata_read projects the column the query asked for", "[odp_projec
                                 "') LIMIT 3");
         INFO((result->HasError() ? result->GetError() : std::string()));
         REQUIRE_FALSE(result->HasError());
+        // Without a row-count assertion the loop below asserts nothing on an empty result -
+        // which is exactly the drained-buffer shape these tests exist to catch.
+        REQUIRE(result->RowCount() == 3);
         for (duckdb::idx_t row = 0; row < result->RowCount(); row++) {
             INFO("row " << row << " = " << result->GetValue(0, row).ToString());
             REQUIRE(result->GetValue(0, row).ToString() == "C");
@@ -117,6 +120,7 @@ TEST_CASE("odp_odata_read projects the column the query asked for", "[odp_projec
                                 "') LIMIT 3");
         INFO((result->HasError() ? result->GetError() : std::string()));
         REQUIRE_FALSE(result->HasError());
+        REQUIRE(result->RowCount() == 3);
         for (duckdb::idx_t row = 0; row < result->RowCount(); row++) {
             INFO("row " << row << ": ODQ_CHANGEMODE=" << result->GetValue(0, row).ToString()
                         << " CALMONTH=" << result->GetValue(1, row).ToString());
@@ -131,6 +135,7 @@ TEST_CASE("odp_odata_read projects the column the query asked for", "[odp_projec
                                 url + "')) LIMIT 3");
         INFO((result->HasError() ? result->GetError() : std::string()));
         REQUIRE_FALSE(result->HasError());
+        REQUIRE(result->RowCount() == 3);
         for (duckdb::idx_t row = 0; row < result->RowCount(); row++) {
             REQUIRE(result->GetValue(0, row).ToString() == "CM" + std::to_string(row));
             REQUIRE(result->GetValue(1, row).ToString() == "DV" + std::to_string(row));

--- a/test/cpp/test_odp_projection.cpp
+++ b/test/cpp/test_odp_projection.cpp
@@ -1,0 +1,139 @@
+// GitHub #179: odp_odata_read returns NULL for every explicitly projected column, while
+// SELECT * returns the values. No error, no warning, and the row count is correct - so an
+// aggregate over a named column returns a confidently wrong answer, and COUNT(*) agreeing
+// with reality while COUNT(col) reads 0 is a disagreement nobody checks for.
+//
+// Cause: UpdateODataClientWithResponse replaces odata_bind_data_ wholesale with a fresh
+// instance that carries no column selection. FetchAndLoadNextPage re-applies the
+// selection afterwards and says why; HandleInitialLoad and HandleDeltaFetch call the same
+// replacement and do not. So the FIRST page of every scan runs in all-columns mode, and
+// only page two onwards was ever correct.
+
+#include "catch.hpp"
+#include "duckdb.hpp"
+
+#include "odata_test_server.hpp"
+#include "odp_test_db.hpp"
+
+#include <sstream>
+#include <string>
+
+using erpl_web::test_support::CannedResponse;
+using erpl_web::test_support::ODataTestServer;
+
+namespace {
+
+// D_NW_DIV and ODQ_CHANGEMODE are real properties of edm_sap_odp_bw_fact.xml; the schema
+// comes from the EDM, so an invented name binds to nothing.
+std::string MakeOdpPage(std::size_t row_count)
+{
+    std::ostringstream out;
+    out << R"({"d":{"results":[)";
+    for (std::size_t i = 0; i < row_count; i++) {
+        if (i > 0) {
+            out << ",";
+        }
+        out << R"({"CALMONTH":"CM)" << i << R"(","D_NW_DIV":"DV)" << i
+            << R"(","ODQ_CHANGEMODE":"C"})";
+    }
+    out << "]}}";
+    return out.str();
+}
+
+const char *const ODP_PATH = "/sap/opu/odata/sap/Z_TEST_SRV/FactsOf0D_NW_C01";
+
+void ServeOdpEntitySet(ODataTestServer &server, std::size_t rows)
+{
+    server.ServeMetadataFixture("/sap/opu/odata/sap/Z_TEST_SRV/$metadata",
+                                "edm_sap_odp_bw_fact.xml");
+    server.ServeMetadataFixture(std::string(ODP_PATH) + "/$metadata",
+                                "edm_sap_odp_bw_fact.xml");
+    server.OnPath(ODP_PATH, CannedResponse::Json(MakeOdpPage(rows)));
+}
+
+}  // namespace
+
+TEST_CASE("odp_odata_read projects the column the query asked for", "[odp_projection]") {
+    constexpr std::size_t ROW_COUNT = 90;
+
+    ODataTestServer server;
+    ServeOdpEntitySet(server, ROW_COUNT);
+
+    // ODP state is refused an in-memory catalog on purpose (GitHub #92).
+    odp_test::TempDatabase db("odp_projection");
+    auto &con = db.Conn();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+    const auto url = server.Url(ODP_PATH);
+
+    // Every assertion here is on VALUES, not on nullness. The defect does not produce
+    // NULLs when the payload carries the schema's leading properties - it produces the
+    // WRONG column's data under the requested name, with the right row count and the right
+    // type. A "not null" assertion passes straight through it, which is how it survived:
+    // against the live A4H service, SELECT ItemName returned ItemId's values and looked
+    // entirely plausible. CALMONTH is schema column 0 and D_NW_DIV is not, so the two are
+    // told apart by their distinct value prefixes.
+    SECTION("a single projected column carries its own values") {
+        auto result = con.Query("SELECT D_NW_DIV FROM odp_odata_read('" + url + "') LIMIT 3");
+        INFO((result->HasError() ? result->GetError() : std::string()));
+        REQUIRE_FALSE(result->HasError());
+        REQUIRE(result->RowCount() == 3);
+        for (duckdb::idx_t row = 0; row < result->RowCount(); row++) {
+            const auto value = result->GetValue(0, row).ToString();
+            INFO("row " << row << " D_NW_DIV = " << value
+                        << " (CM* would mean CALMONTH's data arrived instead)");
+            REQUIRE(value == "DV" + std::to_string(row));
+        }
+    }
+
+    SECTION("a projected column that is not first in the schema is not shifted") {
+        auto result = con.Query("SELECT ODQ_CHANGEMODE FROM odp_odata_read('" + url +
+                                "') LIMIT 3");
+        INFO((result->HasError() ? result->GetError() : std::string()));
+        REQUIRE_FALSE(result->HasError());
+        for (duckdb::idx_t row = 0; row < result->RowCount(); row++) {
+            INFO("row " << row << " = " << result->GetValue(0, row).ToString());
+            REQUIRE(result->GetValue(0, row).ToString() == "C");
+        }
+    }
+
+    SECTION("two projected columns each carry their own values") {
+        auto result = con.Query("SELECT D_NW_DIV, ODQ_CHANGEMODE FROM odp_odata_read('" + url +
+                                "') LIMIT 3");
+        INFO((result->HasError() ? result->GetError() : std::string()));
+        REQUIRE_FALSE(result->HasError());
+        REQUIRE(result->RowCount() == 3);
+        for (duckdb::idx_t row = 0; row < result->RowCount(); row++) {
+            INFO("row " << row << ": D_NW_DIV=" << result->GetValue(0, row).ToString()
+                        << " ODQ_CHANGEMODE=" << result->GetValue(1, row).ToString());
+            REQUIRE(result->GetValue(0, row).ToString() == "DV" + std::to_string(row));
+            REQUIRE(result->GetValue(1, row).ToString() == "C");
+        }
+    }
+
+    // Reversing the order relative to the schema catches a fix that merely re-maps by
+    // position rather than by name.
+    SECTION("projected columns in non-schema order keep their own values") {
+        auto result = con.Query("SELECT ODQ_CHANGEMODE, CALMONTH FROM odp_odata_read('" + url +
+                                "') LIMIT 3");
+        INFO((result->HasError() ? result->GetError() : std::string()));
+        REQUIRE_FALSE(result->HasError());
+        for (duckdb::idx_t row = 0; row < result->RowCount(); row++) {
+            INFO("row " << row << ": ODQ_CHANGEMODE=" << result->GetValue(0, row).ToString()
+                        << " CALMONTH=" << result->GetValue(1, row).ToString());
+            REQUIRE(result->GetValue(0, row).ToString() == "C");
+            REQUIRE(result->GetValue(1, row).ToString() == "CM" + std::to_string(row));
+        }
+    }
+
+    // The unprojected path was always correct, and is the only reason this stayed hidden.
+    SECTION("SELECT * is unaffected") {
+        auto result = con.Query("SELECT CALMONTH, D_NW_DIV FROM (SELECT * FROM odp_odata_read('" +
+                                url + "')) LIMIT 3");
+        INFO((result->HasError() ? result->GetError() : std::string()));
+        REQUIRE_FALSE(result->HasError());
+        for (duckdb::idx_t row = 0; row < result->RowCount(); row++) {
+            REQUIRE(result->GetValue(0, row).ToString() == "CM" + std::to_string(row));
+            REQUIRE(result->GetValue(1, row).ToString() == "DV" + std::to_string(row));
+        }
+    }
+}

--- a/test/cpp/test_odp_scan_reexecution.cpp
+++ b/test/cpp/test_odp_scan_reexecution.cpp
@@ -112,11 +112,40 @@ TEST_CASE("a bound odp_odata_read plan re-extracts in full when the service has 
     }
 }
 
-// The projecting re-execution case is deliberately absent. odp_odata_read returns NULL for
-// every explicitly projected column while SELECT * returns the values - a pre-existing
-// defect filed as GitHub #179, confirmed by reverting every ODP source change here and
-// re-running. A projecting case cannot pass while that stands, and folding the two
-// together would hide one behind the other. It belongs with the fix for #179.
+// The projecting shape needs its own case: for ODP the column selection is held on the
+// wrapper rather than the inner bind data (GitHub #58), so a clone that failed to carry it
+// would run in all-columns mode. This case only became possible once #179 was fixed -
+// before that an explicitly projected column came back NULL for every row, regardless of
+// re-execution, so it would have failed for a reason unrelated to scan state.
+TEST_CASE("a bound projecting odp_odata_read plan returns every row on each execution",
+          "[odp_reexec]") {
+    // D_NW_DIV is Edm.String in edm_sap_odp_bw_fact.xml and the values are distinct per
+    // row, so COUNT(DISTINCT) equals the row count.
+    constexpr std::size_t ROW_COUNT = 90;
+    const std::string path = "/sap/opu/odata/sap/Z_TEST_SRV/FactsOf0D_NW_C01";
+
+    ODataTestServer server;
+    ServeOdpEntitySet(server, path, ROW_COUNT);
+
+    odp_test::TempDatabase db("odp_reexec_proj");
+    auto &con = db.Conn();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    const auto url = server.Url(path);
+    auto prep = con.Query(
+        "PREPARE q AS SELECT COUNT(DISTINCT D_NW_DIV) FROM odp_odata_read('" + url + "')");
+    INFO((prep->HasError() ? prep->GetError() : std::string()));
+    REQUIRE_FALSE(prep->HasError());
+
+    for (int execution = 1; execution <= 3; execution++) {
+        auto result = con.Query("EXECUTE q");
+        INFO("execution " << execution);
+        INFO((result->HasError() ? result->GetError() : std::string()));
+        REQUIRE_FALSE(result->HasError());
+        REQUIRE(result->GetValue(0, 0).GetValue<int64_t>() ==
+                static_cast<int64_t>(ROW_COUNT));
+    }
+}
 
 // The delta-capable counterpart: execution 1 is the initial load and commits the token,
 // execution 2 must resume from it rather than re-extracting. Without per-execution scan


### PR DESCRIPTION
Closes #179. **Merge #180 first.** The branch sits on top of #180's commit because both touch `odp_odata_read_bind_data.cpp`; the base here is now `main`, so until #180 lands this PR shows both commits and afterwards the diff collapses to the projection fix alone. They are unrelated defects — a re-execution returning nothing, and a projection returning another column's data — and are kept as separate commits so each rationale stays attached to its own change.

`odp_odata_read` returns **another column's data** under the name you asked for. No error, no NULLs, correct row count, correct type — and `COUNT(*)` agrees with `COUNT(col)`, so the obvious sanity check cannot see it.

```
SELECT D_NW_DIV           -> [CM0][CM1][CM2]        <- CALMONTH's values
SELECT CALMONTH, D_NW_DIV -> [CM0/NULL][CM1/NULL]   <- slot 0 right by luck, slot 1 shifted off the end
```

**Confirmed against the live A4H service:**

```
pre-fix   SELECT ItemName -> ITEM1, ITEM2, ITEM3           (these are ItemId's values)
post-fix  SELECT ItemName -> Seed item 1, Seed item 2, …
```

### Cause

`UpdateODataClientWithResponse` replaces `odata_bind_data_` with a fresh instance carrying no column selection. `FetchAndLoadNextPage` re-applies the selection afterwards and explains why; `HandleInitialLoad` and `HandleDeltaFetch` call the same replacement and do not. So the **first page** of every scan runs in all-columns mode and emits by schema position instead of by projection. Only page two onwards was ever right.

Re-applying inside `UpdateODataClientWithResponse` — the single place the instance is replaced — covers all three call sites instead of one, and removes the duplicated re-application.

### Two corrections to my own earlier reporting

I got this wrong twice before getting it right, and the issue has been updated accordingly:

1. I first filed it as *"returns NULL for projected columns"*. NULL is only what you see when the shifted-in column happens to be absent from the payload.
2. I then reported the live service as **unaffected**, because `SELECT ItemName` returned `ITEM1, ITEM2, ITEM3` and I recognised those as real data. They are `ItemId`'s values — the schema is `ITEMID, ITEMNAME, …`, and `ItemName` actually holds `Seed item N`. Plausible-looking wrong data is the whole hazard here.

### Testing

The tests assert **values**, never nullness — a not-null assertion passes straight through this defect, which is exactly how it survived my first pass. One case projects in **non-schema order** (`ODQ_CHANGEMODE, CALMONTH`) so that a fix which merely re-maps by position rather than by name would still fail.

Without the fix: `"CM0" == "DV0"` — the wrong-column shape, directly.

### Verification

438 C++ cases / 2240 assertions green. Live SAP tier against A4H green (12 passed, 2 skipped), plus the manual live before/after above. Also unblocks the projecting re-execution case #146 had to leave out, which is added here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791790189&installation_model_id=425457&pr_number=181&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F181&signature=ed0d59301a376fb987abc5d18a29d97d28108f8b75beb85d0df099eca176713c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
