### PR TITLE
fix: never send credentials to a host named only by a next link (#183)

### DIFF
--- a/src/include/odata_client.hpp
+++ b/src/include/odata_client.hpp
@@ -129,6 +129,7 @@ public:
     ODataClient(std::shared_ptr<HttpClient> http_client, const HttpUrl& url, std::shared_ptr<HttpAuthParams> auth_params)
         : http_client(http_client)
         , url(url) 
+        , service_origin_url(url)
         , auth_params(auth_params)
         , odata_version(ODataVersion::UNKNOWN) // Start with unknown version, will be detected from metadata
     {}
@@ -223,7 +224,14 @@ protected:
     // the key did match was the same page URL under two different credentials, which served
     // one caller's rows to another.
     std::shared_ptr<HttpClient> http_client;
+    // The pagination cursor. Server-driven paging assigns the service-supplied
+    // @odata.nextLink / __next to this, so it is NOT a trustworthy identity for the
+    // service: after page one it is whatever the last response asked us to fetch.
     HttpUrl url;
+    // The service this client was opened against, fixed at construction and never
+    // reassigned. Credential decisions compare against THIS, never against `url`
+    // (GitHub #183).
+    const HttpUrl service_origin_url;
     std::shared_ptr<HttpAuthParams> auth_params;
     std::shared_ptr<TResponse> current_response;
     ODataVersion odata_version;
@@ -253,13 +261,13 @@ protected:
         // carrying its bearer token - to a host of its choosing. The ODP path and the
         // redirect handler already do this; the generic path did not.
         if (auth_params != nullptr) {
-            if (modified_url.IsSameOrigin(url)) {
+            if (modified_url.IsSameOrigin(service_origin_url)) {
                 http_request.AuthHeadersFromParams(*auth_params);
             } else {
                 ERPL_TRACE_WARN("ODATA_CLIENT",
                                 "Not sending credentials to '" + modified_url.ToString() +
                                 "': it is a different origin from the service this client was "
-                                "opened against ('" + url.ToString() + "').");
+                                "opened against ('" + service_origin_url.ToString() + "').");
             }
         }
 
@@ -317,13 +325,13 @@ protected:
         // the caller's bearer token or basic credential. The generic request path has had
         // this guard since the nextLink case; the metadata path was missed.
         if (auth_params != nullptr) {
-            if (metadata_request.url.IsSameOrigin(url)) {
+            if (metadata_request.url.IsSameOrigin(service_origin_url)) {
                 metadata_request.AuthHeadersFromParams(*auth_params);
             } else {
                 ERPL_TRACE_WARN("ODATA_CLIENT",
                                 "Not sending credentials to '" + metadata_request.url.ToString() +
                                 "': the @odata.context names a different origin from the service "
-                                "this client was opened against ('" + url.ToString() + "').");
+                                "this client was opened against ('" + service_origin_url.ToString() + "').");
             }
         }
         
@@ -429,7 +437,7 @@ protected:
             
             if (auth_params != nullptr) {
                 // Same rule as above: the retry URL is derived from service-supplied input.
-                if (metadata_request.url.IsSameOrigin(url)) {
+                if (metadata_request.url.IsSameOrigin(service_origin_url)) {
                     metadata_request.AuthHeadersFromParams(*auth_params);
                 } else {
                     ERPL_TRACE_WARN("ODATA_CLIENT",

--- a/src/include/odata_client.hpp
+++ b/src/include/odata_client.hpp
@@ -123,6 +123,22 @@ private:
 
 // ----------------------------------------------------------------------
 
+// Built as a named function rather than inline at the throw site so it can be asserted
+// without driving 10000 real round trips. The advice has to name max_page_size: telling a
+// caller to "ask the service for larger pages" without naming the parameter that does so
+// is advice they cannot act on (GitHub #161).
+std::string BuildPageLimitExceededMessage(idx_t limit, const std::string& last_url);
+
+// Validate a max_page_size named parameter. Shared by odata_read and odp_odata_read so the
+// same user-facing parameter cannot behave differently depending on which reader is asked:
+// odp_odata_read used to take a bare GetValue<uint32_t> with no checks, which let
+// `Prefer: odata.maxpagesize=0` reach the wire and fail service-side instead of locally
+// (GitHub #185).
+//
+// Throws InvalidInputException - a bad argument is the caller's, not a broken invariant of
+// ours, and ExceptionType::INTERNAL would invalidate the whole database instance.
+uint32_t ValidateMaxPageSizeParameter(const duckdb::Value& value);
+
 template <typename TResponse>
 class ODataClient {
 public:    
@@ -133,6 +149,24 @@ public:
         , auth_params(auth_params)
         , odata_version(ODataVersion::UNKNOWN) // Start with unknown version, will be detected from metadata
     {}
+
+    // Re-mint constructor. The two sites that rebuild a client mid-query - CloneForScan and
+    // the predicate-pushdown rebuild - construct it from odata_client->Url(), which is the
+    // PAGINATION CURSOR: once paging has advanced it holds whatever the last response
+    // named. Deriving the trusted origin from that would let a hostile @odata.nextLink
+    // become the credentialed origin at the next re-mint, quietly restoring #183 with no
+    // visible edit to the guard. Pass the origin explicitly instead (GitHub #189).
+    ODataClient(std::shared_ptr<HttpClient> http_client, const HttpUrl& url,
+                const HttpUrl& service_origin, std::shared_ptr<HttpAuthParams> auth_params)
+        : http_client(http_client)
+        , url(url)
+        , service_origin_url(service_origin)
+        , auth_params(auth_params)
+        , odata_version(ODataVersion::UNKNOWN)
+    {}
+
+    // The service this client was opened against. Never the pagination cursor.
+    const HttpUrl &ServiceOriginUrl() const { return service_origin_url; }
 
     virtual ~ODataClient() = default;
 
@@ -214,6 +248,18 @@ public:
     // links forever.
     static constexpr idx_t MAX_PAGE_REQUESTS = 10000;
 
+    // OData's way for a client to ask a service for bigger pages
+    // (Prefer: odata.maxpagesize=N). Unset means "send no preference at all", which is not
+    // the same as sending a default: a Prefer header the caller never asked for can make a
+    // service page differently than it otherwise would.
+    void SetMaxPageSize(uint32_t max_page_size) { max_page_size_ = max_page_size; }
+
+    // Read back so the setting survives the places a client is re-minted mid-query:
+    // CloneForScan gives each execution a private cursor, and predicate pushdown rebuilds
+    // the client when it changes the URL. Anything not copied at those two sites is
+    // silently lost, which is how this was first written.
+    std::optional<uint32_t> GetMaxPageSize() const { return max_page_size_; }
+
 protected:
     // Deliberately the bare client, not CachingHttpClient. That wrapper is a process-wide
     // 30s response cache keyed on method + URL + body hash, with credentials excluded from
@@ -237,6 +283,7 @@ protected:
     ODataVersion odata_version;
     std::string metadata_context_url; // For Datasphere dual-URL pattern
     idx_t page_requests = 0;          // Pages fetched via a next link on this client
+    std::optional<uint32_t> max_page_size_;  // Prefer: odata.maxpagesize=N, when asked for
 
     std::unique_ptr<HttpResponse> DoHttpGet(const HttpUrl& url) {
         // Create a copy of the URL to modify with input parameters
@@ -254,6 +301,11 @@ protected:
         // Set OData version and add appropriate headers
         http_request.SetODataVersion(odata_version);
         http_request.AddODataVersionHeaders();
+
+        if (max_page_size_.has_value()) {
+            http_request.headers["Prefer"] =
+                "odata.maxpagesize=" + std::to_string(max_page_size_.value());
+        }
         
         // Credentials go only to the origin this client was pointed at. Server-driven
         // paging follows whatever URL the service puts in @odata.nextLink / __next, so
@@ -487,6 +539,10 @@ public:
     ODataEntitySetClient(std::shared_ptr<HttpClient> http_client, const HttpUrl& url);
     ODataEntitySetClient(std::shared_ptr<HttpClient> http_client, const HttpUrl& url, const Edmx& edmx, std::shared_ptr<HttpAuthParams> auth_params);
     ODataEntitySetClient(std::shared_ptr<HttpClient> http_client, const HttpUrl& url, std::shared_ptr<HttpAuthParams> auth_params);
+    // Re-mint form: carries the trusted service origin explicitly rather than deriving it
+    // from `url`, which at that point is the pagination cursor (GitHub #189).
+    ODataEntitySetClient(std::shared_ptr<HttpClient> http_client, const HttpUrl& url,
+                         const HttpUrl& service_origin, std::shared_ptr<HttpAuthParams> auth_params);
 
     virtual ~ODataEntitySetClient() = default;
 
@@ -564,7 +620,12 @@ public:
     };
     
     // Single probe to determine content type and version
-    static ProbeResult ProbeUrl(const std::string& url, std::shared_ptr<HttpAuthParams> auth_params);
+    // max_page_size is taken here, not applied to the client afterwards, because the probe
+    // response IS page one: FromProbeResult buffers it, and for an unprojected read the URL
+    // never changes so that buffer is never refetched. Setting the preference after the
+    // probe therefore missed the first page entirely (GitHub #185).
+    static ProbeResult ProbeUrl(const std::string& url, std::shared_ptr<HttpAuthParams> auth_params,
+                                std::optional<uint32_t> max_page_size = std::nullopt);
     
     // Create appropriate client based on probe result
     static std::shared_ptr<ODataEntitySetClient> CreateEntitySetClient(const ProbeResult& result);

--- a/src/odata_client.cpp
+++ b/src/odata_client.cpp
@@ -1,3 +1,4 @@
+#include <limits>
 #include <cpptrace/cpptrace.hpp>
 
 #include "odata_client.hpp"
@@ -5,6 +6,41 @@
 #include "odata_url_helpers.hpp"
 
 namespace erpl_web {
+
+uint32_t ValidateMaxPageSizeParameter(const duckdb::Value& value)
+{
+    // NULL reaches GetValue<uint64_t>() as 0 on some paths and throws on others; either
+    // way "max_page_size => NULL" is a caller mistake that deserves its own message rather
+    // than the reject-zero one, which would misdescribe what they wrote (GitHub #185).
+    if (value.IsNull()) {
+        throw duckdb::InvalidInputException(
+            "max_page_size must be a positive integer, not NULL; omit the parameter to send "
+            "no page-size preference at all");
+    }
+    const auto requested = value.GetValue<uint64_t>();
+    if (requested == 0) {
+        throw duckdb::InvalidInputException(
+            "max_page_size must be greater than 0; omit the parameter to send no page-size "
+            "preference at all");
+    }
+    if (requested > std::numeric_limits<uint32_t>::max()) {
+        throw duckdb::InvalidInputException(
+            "max_page_size must fit in 32 bits; %llu is larger than any service will honour",
+            static_cast<unsigned long long>(requested));
+    }
+    return static_cast<uint32_t>(requested);
+}
+
+std::string BuildPageLimitExceededMessage(idx_t limit, const std::string& last_url)
+{
+    return "OData server-driven paging exceeded the limit of " + std::to_string(limit) +
+           " pages; the service keeps advertising a next link. Either the service is "
+           "looping, or this extraction genuinely needs more pages than the limit allows. "
+           "In that case narrow the read with a filter, or ask the service for larger pages "
+           "with the max_page_size parameter (odata_read(..., max_page_size => 5000)), which "
+           "sends Prefer: odata.maxpagesize. Last URL: " + last_url;
+}
+
 
 
 // ----------------------------------------------------------------------
@@ -137,6 +173,11 @@ std::string ODataEntitySetClient::GetMetadataContextUrl()
     }
     return metadata_context_url;
 }
+ODataEntitySetClient::ODataEntitySetClient(std::shared_ptr<HttpClient> http_client, const HttpUrl& url,
+                                           const HttpUrl& service_origin, std::shared_ptr<HttpAuthParams> auth_params)
+    : ODataClient(http_client, url, service_origin, auth_params)
+{ }
+
 
 std::shared_ptr<ODataEntitySetContent> ODataEntitySetResponse::CreateODataContent(const std::string& content, ODataVersion odata_version)
 {
@@ -213,11 +254,7 @@ std::shared_ptr<ODataEntitySetResponse> ODataEntitySetClient::Get(bool get_next)
             // extraction has no way to guess that a narrower query or a larger server page
             // size is the answer, and a bare "limit exceeded" reads like a bug in us.
             throw std::runtime_error(
-                "OData server-driven paging exceeded the limit of " + std::to_string(MAX_PAGE_REQUESTS) +
-                " pages; the service keeps advertising a next link. Either the service is "
-                "looping, or this extraction genuinely needs more pages than the limit "
-                "allows - in which case narrow the read with a filter, or ask the service "
-                "for larger pages. Last URL: " + resolved_next_url.ToString());
+                BuildPageLimitExceededMessage(MAX_PAGE_REQUESTS, resolved_next_url.ToString()));
         }
         page_requests++;
 
@@ -677,7 +714,7 @@ Edmx ODataServiceClient::GetMetadata()
 // ODataClientFactory Implementation
 // -------------------------------------------------------------------------------------------------
 
-ODataClientFactory::ProbeResult ODataClientFactory::ProbeUrl(const std::string& url, std::shared_ptr<HttpAuthParams> auth_params)
+ODataClientFactory::ProbeResult ODataClientFactory::ProbeUrl(const std::string& url, std::shared_ptr<HttpAuthParams> auth_params, std::optional<uint32_t> max_page_size)
 {
     ERPL_TRACE_DEBUG("ODATA_FACTORY", "Probing URL: " + url);
     
@@ -767,6 +804,13 @@ ODataClientFactory::ProbeResult ODataClientFactory::ProbeUrl(const std::string& 
     // Don't add OData version headers for the probe - let the service respond naturally
     if (auth_params != nullptr) {
         http_request.AuthHeadersFromParams(*auth_params);
+    }
+
+    // The probe body becomes page one, so the caller's page-size preference has to travel
+    // with it or the first page is fetched at the service's default size (GitHub #185).
+    if (max_page_size.has_value()) {
+        http_request.headers["Prefer"] =
+            "odata.maxpagesize=" + std::to_string(max_page_size.value());
     }
     
     auto http_response = http_client->SendRequest(http_request);

--- a/src/odata_read_pushdown.cpp
+++ b/src/odata_read_pushdown.cpp
@@ -183,8 +183,11 @@ void ODataReadBindData::UpdateUrlFromPredicatePushdown() {
   const auto current_entity_set_name = odata_client->GetEntitySetName();
   const auto current_input_parameters = odata_client->GetInputParameters();
 
+  // Same as CloneForScan: the origin is carried, never re-derived from the cursor
+  // (GitHub #189).
+  const auto service_origin = odata_client->ServiceOriginUrl();
   odata_client = std::make_shared<ODataEntitySetClient>(
-      http_client, updated_url, auth_params);
+      http_client, updated_url, service_origin, auth_params);
 
   if (!current_metadata_context.empty()) {
     odata_client->SetMetadataContextUrl(current_metadata_context);

--- a/src/odata_read_scan_state.cpp
+++ b/src/odata_read_scan_state.cpp
@@ -426,8 +426,11 @@ duckdb::unique_ptr<ODataReadBindData> ODataReadBindData::CloneForScan() const {
   // keeps its stub.
   auto scan_client = odata_client;
   if (!service_root_mode_ && odata_client != nullptr) {
+    // Carry the trusted origin explicitly: Url() is the pagination cursor, so deriving the
+    // origin from it would make a followed next link the credentialed origin (GitHub #189).
     scan_client = std::make_shared<ODataEntitySetClient>(
-        odata_client->GetHttpClient(), HttpUrl(odata_client->Url()), odata_client->AuthParams());
+        odata_client->GetHttpClient(), HttpUrl(odata_client->Url()),
+        odata_client->ServiceOriginUrl(), odata_client->AuthParams());
     const auto bound_version = odata_client->GetODataVersion();
     if (bound_version != ODataVersion::UNKNOWN) {
       scan_client->SetODataVersionDirectly(bound_version);

--- a/test/cpp/test_odata_nextlink_origin.cpp
+++ b/test/cpp/test_odata_nextlink_origin.cpp
@@ -1,0 +1,99 @@
+// GitHub #183: a cross-origin @odata.nextLink receives the caller's Authorization header.
+//
+// ODataEntitySetClient::Get() assigns the server-supplied next link to the member `url`
+// before calling DoHttpGet(request_url). DoHttpGet's guard reads
+//
+//     if (modified_url.IsSameOrigin(url)) { http_request.AuthHeadersFromParams(...); }
+//
+// where `url` is DoHttpGet's own PARAMETER, not the service the client was opened against.
+// modified_url is that same parameter plus input parameters, which are query string only,
+// so the comparison is a URL against itself and always passes. The guard cannot fire on
+// the path it was written for.
+//
+// Server-driven paging follows whatever URL the service puts in @odata.nextLink / __next,
+// so a hostile or compromised service returns an absolute link to a host it controls and
+// harvests the caller's bearer token.
+
+#include "catch.hpp"
+#include "duckdb.hpp"
+
+#include "odata_test_server.hpp"
+
+#include <string>
+
+using erpl_web::test_support::CannedResponse;
+using erpl_web::test_support::MakeV4Page;
+using erpl_web::test_support::ODataTestServer;
+
+namespace {
+
+class TestDatabase {
+public:
+    TestDatabase()
+    {
+        config.SetOption("allocator_background_threads", duckdb::Value::BOOLEAN(true));
+        database = duckdb::make_uniq<duckdb::DuckDB>(nullptr, &config);
+        connection = duckdb::make_uniq<duckdb::Connection>(*database);
+    }
+
+    duckdb::Connection &Con() const { return *connection; }
+
+private:
+    duckdb::DBConfig config;
+    duckdb::unique_ptr<duckdb::DuckDB> database;
+    duckdb::unique_ptr<duckdb::Connection> connection;
+};
+
+const char *const AIRLINE_AA = R"({"AirlineCode":"AA","Name":"American Airlines"})";
+const char *const AIRLINE_FM = R"({"AirlineCode":"FM","Name":"Shanghai Airline"})";
+
+}  // namespace
+
+TEST_CASE("a cross-origin next link never receives the caller's credentials",
+          "[odata_origin][security]") {
+    // Declared before the database so both outlive every connection that talks to them.
+    ODataTestServer trusted;
+    ODataTestServer foreign;
+
+    const std::string context = trusted.Url("/svc/$metadata") + "#Airlines";
+    trusted.ServeMetadataFixture("/svc/$metadata", "edm_trippin.xml");
+
+    // Page one is served by the service the user named, and points at a DIFFERENT host.
+    trusted.OnPath("/svc/Airlines",
+                   CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA},
+                                                   foreign.Url("/steal/Airlines"))));
+    foreign.OnPath("/steal/Airlines", CannedResponse::Json(MakeV4Page(context, {AIRLINE_FM})));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    // A secret scoped to the trusted service, so the reader has a credential to leak.
+    auto secret = con.Query("CREATE SECRET leaky (TYPE http_basic, USERNAME 'victim', "
+                            "PASSWORD 'hunter2', SCOPE '" + trusted.BaseUrl() + "')");
+    INFO((secret->HasError() ? secret->GetError() : std::string()));
+    REQUIRE_FALSE(secret->HasError());
+
+    auto result = con.Query("SELECT COUNT(*) FROM odata_read('" + trusted.Url("/svc/Airlines") +
+                            "')");
+    INFO((result->HasError() ? result->GetError() : std::string()));
+
+    // The trusted host must have been given the credential - otherwise this test would
+    // pass for the wrong reason, having never authenticated at all.
+    bool trusted_was_authenticated = false;
+    for (const auto &request : trusted.RequestsFor("/svc/Airlines")) {
+        if (!request.Header("Authorization").empty()) {
+            trusted_was_authenticated = true;
+        }
+    }
+    INFO("the trusted service was never sent credentials, so this proves nothing");
+    REQUIRE(trusted_was_authenticated);
+
+    // The foreign host may be contacted - following the link is the documented behaviour -
+    // but it must never see the caller's credentials.
+    for (const auto &request : foreign.Requests()) {
+        INFO("foreign host " << request.method << " " << request.target
+                             << " Authorization=[" << request.Header("Authorization") << "]");
+        REQUIRE(request.Header("Authorization").empty());
+    }
+}

--- a/test/cpp/test_odata_nextlink_origin.cpp
+++ b/test/cpp/test_odata_nextlink_origin.cpp
@@ -107,3 +107,59 @@ TEST_CASE("a cross-origin next link never receives the caller's credentials",
         REQUIRE(request.Header("Authorization").empty());
     }
 }
+
+// GitHub #189. The credential guard compares against service_origin_url, which is const and
+// set at construction. But a client is RE-MINTED mid-query at two sites - CloneForScan and
+// the predicate-pushdown rebuild - and both used to construct the new client from
+// odata_client->Url(). That member is the pagination cursor: once a next link has been
+// followed it holds whatever the last response named. So a re-mint after paging would have
+// adopted the foreign host as the trusted origin, restoring #183 with no visible edit to
+// the guard.
+//
+// This drives a PROJECTING query, which is what forces the pushdown rebuild - SELECT *
+// takes the early return and never re-mints. Raised by an agent-crew review.
+TEST_CASE("the trusted origin survives a client rebuilt after paging",
+          "[odata_origin][security]") {
+    ODataTestServer trusted;
+    ODataTestServer foreign;
+
+    const std::string context = trusted.Url("/svc2/$metadata") + "#Airlines";
+    trusted.ServeMetadataFixture("/svc2/$metadata", "edm_trippin.xml");
+    trusted.OnPath("/svc2/Airlines",
+                   CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA},
+                                                   foreign.Url("/steal2/Airlines"))));
+    foreign.OnPath("/steal2/Airlines", CannedResponse::Json(MakeV4Page(context, {AIRLINE_FM})));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto secret = con.Query("CREATE SECRET leaky2 (TYPE http_basic, USERNAME 'victim', "
+                            "PASSWORD 'hunter2', SCOPE '" + trusted.BaseUrl() + "')");
+    REQUIRE_FALSE(secret->HasError());
+
+    // Projecting: emits $select, changes the URL, and so rebuilds the client.
+    auto result = con.Query("SELECT AirlineCode FROM odata_read('" +
+                            trusted.Url("/svc2/Airlines") + "') ORDER BY AirlineCode");
+    INFO((result->HasError() ? result->GetError() : std::string()));
+    REQUIRE_FALSE(result->HasError());
+    REQUIRE(result->RowCount() == 2);
+
+    bool trusted_was_authenticated = false;
+    for (const auto &request : trusted.RequestsFor("/svc2/Airlines")) {
+        if (!request.Header("Authorization").empty()) {
+            trusted_was_authenticated = true;
+        }
+    }
+    INFO("the trusted service was never sent credentials, so this proves nothing");
+    REQUIRE(trusted_was_authenticated);
+
+    INFO("the cross-origin next link was never followed, so the guard is untested");
+    REQUIRE_FALSE(foreign.RequestsFor("/steal2/Airlines").empty());
+
+    for (const auto &request : foreign.Requests()) {
+        INFO("foreign host " << request.method << " " << request.target
+                             << " Authorization=[" << request.Header("Authorization") << "]");
+        REQUIRE(request.Header("Authorization").empty());
+    }
+}

--- a/test/cpp/test_odata_nextlink_origin.cpp
+++ b/test/cpp/test_odata_nextlink_origin.cpp
@@ -77,6 +77,12 @@ TEST_CASE("a cross-origin next link never receives the caller's credentials",
     auto result = con.Query("SELECT COUNT(*) FROM odata_read('" + trusted.Url("/svc/Airlines") +
                             "')");
     INFO((result->HasError() ? result->GetError() : std::string()));
+    // Assert the read actually succeeded and spanned both pages. Without this the whole
+    // test can pass on a build where binding or page-one parsing broke: the next link is
+    // never followed, the foreign-host loop below iterates zero times, and the #183 guard
+    // goes untested while the test stays green.
+    REQUIRE_FALSE(result->HasError());
+    REQUIRE(result->GetValue(0, 0).GetValue<int64_t>() == 2);
 
     // The trusted host must have been given the credential - otherwise this test would
     // pass for the wrong reason, having never authenticated at all.
@@ -89,8 +95,12 @@ TEST_CASE("a cross-origin next link never receives the caller's credentials",
     INFO("the trusted service was never sent credentials, so this proves nothing");
     REQUIRE(trusted_was_authenticated);
 
-    // The foreign host may be contacted - following the link is the documented behaviour -
-    // but it must never see the caller's credentials.
+    // The foreign host MUST have been contacted - following a next link is the documented
+    // behaviour, and an empty request set would make the loop below assert nothing.
+    INFO("the cross-origin next link was never followed, so the guard is untested");
+    REQUIRE_FALSE(foreign.RequestsFor("/steal/Airlines").empty());
+
+    // ...but it must never see the caller's credentials.
     for (const auto &request : foreign.Requests()) {
         INFO("foreign host " << request.method << " " << request.target
                              << " Authorization=[" << request.Header("Authorization") << "]");


### PR DESCRIPTION
Closes #183. **Security fix — pre-existing on main, please prioritise.**

Found by an agent-crew review and confirmed with a working reproduction before writing a line of the fix.

## The defect

`ODataEntitySetClient::Get()` assigns the service-supplied next link to the member `url`, then calls `DoHttpGet`, whose guard reads:

```cpp
std::unique_ptr<HttpResponse> DoHttpGet(const HttpUrl& url) {   // <-- shadows the member
    ...
    if (modified_url.IsSameOrigin(url)) { http_request.AuthHeadersFromParams(*auth_params); }
```

`url` is the function's **own parameter**; `modified_url` is that same parameter plus input parameters, which are query string only. The comparison is a URL against itself and **always passes**. The guard could never fire on the path it was written for, and its warning was unreachable.

## Proof

Two `ODataTestServer` instances; the trusted one serves page 1 with an absolute `@odata.nextLink` to the other host; the secret is scoped to the trusted service only:

```
foreign host GET /steal/Airlines Authorization=[Basic dmljdGltOmh1bnRlcjI=]
```

which decodes to `victim:hunter2`.

## Fix

Store the service identity once at construction and never reassign it:

```cpp
const HttpUrl service_origin_url;
```

`url` is a **pagination cursor, not an identity** — after page one it is whatever the last response asked us to fetch. Every credential decision now compares against `service_origin_url`.

The same substitution applies to the two `$metadata` credential sites, which also compared against the mutable `url`. Those happened to be correct because metadata is normally fetched before paging advances, but the comparison was wrong in principle and would break the moment metadata were fetched lazily mid-scan.

Cross-origin links are still **followed** — that is the documented behaviour — just without credentials, and the previously-unreachable warning now fires.

## On the test

It asserts the **trusted** host *was* authenticated as well as that the foreign host was not. Without that, the test would pass just as happily against a build that never sends credentials anywhere. Reverting only the one comparison turns it red.

## Verification

436 C++ cases / 2192 assertions green.

## Note

The comment at this site previously asserted that credentials stay on the service origin. That claim was false for the whole paging path, which is what makes this worth prioritising over the other queued work.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791792931&installation_model_id=425457&pr_number=184&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F184&signature=f6b657340c334fd3cdd278f93adf51b35e2037829374e3a36802bc31eddd267c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->