### PR TITLE
fix: give bc_read and crm_read per-execution scan state (#182)

### DIFF
--- a/src/business_central_client.cpp
+++ b/src/business_central_client.cpp
@@ -21,10 +21,43 @@ std::string BusinessCentralUrlBuilder::BuildApiUrl(const std::string &tenant_id,
     // behaviour cannot be tested at all - which is how it kept a per-execution-state
     // defect nobody could reproduce (GitHub #182). DatasphereReadRelational has had the
     // same escape hatch on space_id for as long as it has existed.
-    if (environment.rfind("http://", 0) == 0 || environment.rfind("https://", 0) == 0) {
+    const bool is_https = environment.rfind("https://", 0) == 0;
+    const bool is_http = environment.rfind("http://", 0) == 0;
+    if (is_https || is_http) {
         std::string base = environment;
         while (!base.empty() && base.back() == '/') {
             base.pop_back();
+        }
+        // Plain http is accepted ONLY for loopback. This hatch exists so the reader can be
+        // pointed at a local test server; anywhere else it would put the OAuth bearer token
+        // on the wire in cleartext, and the same-origin guard would not object because the
+        // configured URL IS the origin. Before this hatch existed the scheme was hardcoded
+        // https, so allowing plain http generally would be a downgrade introduced by a
+        // testability change - which is not a trade worth making silently.
+        if (is_http) {
+            // The host must BE a loopback name, not merely start with one: a prefix test
+            // lets "localhost.evil.example" through.
+            const std::string after_scheme = base.substr(std::string("http://").size());
+            std::string host;
+            if (!after_scheme.empty() && after_scheme.front() == '[') {
+                // Bracketed IPv6: the port separator is the colon AFTER the ']', and the
+                // address itself is full of colons.
+                const auto close = after_scheme.find(']');
+                host = (close == std::string::npos) ? after_scheme
+                                                    : after_scheme.substr(0, close + 1);
+            } else {
+                const auto host_end = after_scheme.find_first_of(":/");
+                host = (host_end == std::string::npos) ? after_scheme
+                                                       : after_scheme.substr(0, host_end);
+            }
+            const bool loopback = host == "localhost" || host == "127.0.0.1" || host == "[::1]";
+            if (!loopback) {
+                throw duckdb::InvalidInputException(
+                    "Business Central 'environment' may only use plain http:// for a loopback "
+                    "address (localhost, 127.0.0.1 or [::1]); '%s' would send the OAuth bearer "
+                    "token unencrypted. Use https:// instead.",
+                    environment.c_str());
+            }
         }
         return base;
     }

--- a/src/business_central_client.cpp
+++ b/src/business_central_client.cpp
@@ -16,6 +16,18 @@ static std::string ValueToString(const duckdb::Value &value) {
 
 // URL Builder implementation
 std::string BusinessCentralUrlBuilder::BuildApiUrl(const std::string &tenant_id, const std::string &environment) {
+    // An `environment` that is already a URL is used as the API base verbatim. Without
+    // this the host is hardcoded, so bc_read cannot be pointed at a local server and its
+    // behaviour cannot be tested at all - which is how it kept a per-execution-state
+    // defect nobody could reproduce (GitHub #182). DatasphereReadRelational has had the
+    // same escape hatch on space_id for as long as it has existed.
+    if (environment.rfind("http://", 0) == 0 || environment.rfind("https://", 0) == 0) {
+        std::string base = environment;
+        while (!base.empty() && base.back() == '/') {
+            base.pop_back();
+        }
+        return base;
+    }
     return "https://api.businesscentral.dynamics.com/v2.0/" + tenant_id + "/" + environment + "/api/v2.0";
 }
 

--- a/src/business_central_client.cpp
+++ b/src/business_central_client.cpp
@@ -21,7 +21,11 @@ std::string BusinessCentralUrlBuilder::BuildApiUrl(const std::string &tenant_id,
     // behaviour cannot be tested at all - which is how it kept a per-execution-state
     // defect nobody could reproduce (GitHub #182). DatasphereReadRelational has had the
     // same escape hatch on space_id for as long as it has existed.
-    if (environment.rfind("https://", 0) == 0 || environment.rfind("http://", 0) == 0) {
+    // Shared predicate: the three hatches must agree on what counts as "already a URL",
+    // or the comment claiming one shared rule is false. A case-sensitive trigger also let
+    // an uppercase scheme skip the hatch entirely and get embedded into the real endpoint
+    // as an environment segment (GitHub #193).
+    if (LooksLikeAbsoluteHttpUrl(environment)) {
         std::string base = environment;
         while (!base.empty() && base.back() == '/') {
             base.pop_back();

--- a/src/business_central_client.cpp
+++ b/src/business_central_client.cpp
@@ -21,44 +21,14 @@ std::string BusinessCentralUrlBuilder::BuildApiUrl(const std::string &tenant_id,
     // behaviour cannot be tested at all - which is how it kept a per-execution-state
     // defect nobody could reproduce (GitHub #182). DatasphereReadRelational has had the
     // same escape hatch on space_id for as long as it has existed.
-    const bool is_https = environment.rfind("https://", 0) == 0;
-    const bool is_http = environment.rfind("http://", 0) == 0;
-    if (is_https || is_http) {
+    if (environment.rfind("https://", 0) == 0 || environment.rfind("http://", 0) == 0) {
         std::string base = environment;
         while (!base.empty() && base.back() == '/') {
             base.pop_back();
         }
-        // Plain http is accepted ONLY for loopback. This hatch exists so the reader can be
-        // pointed at a local test server; anywhere else it would put the OAuth bearer token
-        // on the wire in cleartext, and the same-origin guard would not object because the
-        // configured URL IS the origin. Before this hatch existed the scheme was hardcoded
-        // https, so allowing plain http generally would be a downgrade introduced by a
-        // testability change - which is not a trade worth making silently.
-        if (is_http) {
-            // The host must BE a loopback name, not merely start with one: a prefix test
-            // lets "localhost.evil.example" through.
-            const std::string after_scheme = base.substr(std::string("http://").size());
-            std::string host;
-            if (!after_scheme.empty() && after_scheme.front() == '[') {
-                // Bracketed IPv6: the port separator is the colon AFTER the ']', and the
-                // address itself is full of colons.
-                const auto close = after_scheme.find(']');
-                host = (close == std::string::npos) ? after_scheme
-                                                    : after_scheme.substr(0, close + 1);
-            } else {
-                const auto host_end = after_scheme.find_first_of(":/");
-                host = (host_end == std::string::npos) ? after_scheme
-                                                       : after_scheme.substr(0, host_end);
-            }
-            const bool loopback = host == "localhost" || host == "127.0.0.1" || host == "[::1]";
-            if (!loopback) {
-                throw duckdb::InvalidInputException(
-                    "Business Central 'environment' may only use plain http:// for a loopback "
-                    "address (localhost, 127.0.0.1 or [::1]); '%s' would send the OAuth bearer "
-                    "token unencrypted. Use https:// instead.",
-                    environment.c_str());
-            }
-        }
+        // Shared with Datasphere's space_id and Dataverse's environment_url hatches, so the
+        // loopback rule - and the IPv6 and prefix subtleties in it - has one implementation.
+        RequireSecureOrLoopbackUrl(base, "Business Central 'environment'");
         return base;
     }
     return "https://api.businesscentral.dynamics.com/v2.0/" + tenant_id + "/" + environment + "/api/v2.0";

--- a/src/business_central_functions.cpp
+++ b/src/business_central_functions.cpp
@@ -263,7 +263,23 @@ TableFunctionSet CreateBcDescribeFunction() {
 
 struct BcReadBindData : public TableFunctionData {
     std::unique_ptr<ODataReadBindData> odata_bind_data;
+};
+
+// Owns the scan state for ONE execution of a bound plan (GitHub #182).
+//
+// `finished` used to live on the bind data and was never reset, so the second EXECUTE of
+// a prepared statement returned zero rows deterministically and silently. Both it and the
+// row buffer now belong to the per-execution clone.
+class BcReadGlobalState : public GlobalTableFunctionState {
+public:
+    explicit BcReadGlobalState(std::unique_ptr<ODataReadBindData> scan_state)
+        : scan_state(std::move(scan_state)) {}
+
+    ODataReadBindData &Scan() { return *scan_state; }
     bool finished = false;
+
+private:
+    std::unique_ptr<ODataReadBindData> scan_state;
 };
 
 static unique_ptr<FunctionData> BcReadBind(
@@ -338,37 +354,42 @@ static unique_ptr<GlobalTableFunctionState> BcReadInitGlobalState(
 
     auto &bind_data = input.bind_data->CastNoConst<BcReadBindData>();
 
-    // Activate columns for projection pushdown
-    bind_data.odata_bind_data->ActivateColumns(input.column_ids);
+    // Projection, filter pushdown and the first-page prefetch all mutate scan state, so
+    // they run against a private clone; the bind data stays as bind left it. Returning
+    // nullptr here - with the scan reading the bind data directly - is what made a second
+    // EXECUTE return nothing (GitHub #182).
+    auto scan_state = bind_data.odata_bind_data->CloneForScan();
 
-    // Add filters for predicate pushdown
-    bind_data.odata_bind_data->AddFilters(input.filters);
+    scan_state->ActivateColumns(input.column_ids);
+    scan_state->AddFilters(input.filters);
+    scan_state->UpdateUrlFromPredicatePushdown();
+    scan_state->PrefetchFirstPage();
 
-    // Update URL with pushdown predicates
-    bind_data.odata_bind_data->UpdateUrlFromPredicatePushdown();
-
-    // Prefetch first page
-    bind_data.odata_bind_data->PrefetchFirstPage();
-
-    return nullptr;
+    return make_uniq<BcReadGlobalState>(std::move(scan_state));
 }
 
 static void BcReadScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
-    auto &bind_data = data.bind_data->CastNoConst<BcReadBindData>();
+    auto &gstate = data.global_state->Cast<BcReadGlobalState>();
 
-    if (bind_data.finished) {
+    if (gstate.finished) {
         return;
     }
 
-    auto rows_fetched = bind_data.odata_bind_data->FetchNextResult(output);
-    if (!bind_data.odata_bind_data->HasMoreResults() && rows_fetched == 0) {
-        bind_data.finished = true;
+    auto rows_fetched = gstate.Scan().FetchNextResult(output);
+    if (!gstate.Scan().HasMoreResults() && rows_fetched == 0) {
+        gstate.finished = true;
     }
 }
 
-static double BcReadProgress(ClientContext &context, const FunctionData *bind_data_p, const GlobalTableFunctionState *) {
-    auto &bind_data = bind_data_p->Cast<BcReadBindData>();
-    return bind_data.odata_bind_data->GetProgressFraction();
+static double BcReadProgress(ClientContext &context, const FunctionData *bind_data_p,
+                              const GlobalTableFunctionState *global_state) {
+    // Progress lives on the per-execution clone, so reading it off the bind data would
+    // report a scan that is no longer the one running (GitHub #182).
+    if (global_state == nullptr) {
+        return -1.0;
+    }
+    auto &gstate = const_cast<GlobalTableFunctionState *>(global_state)->Cast<BcReadGlobalState>();
+    return gstate.Scan().GetProgressFraction();
 }
 
 TableFunctionSet CreateBcReadFunction() {

--- a/src/datasphere_read.cpp
+++ b/src/datasphere_read.cpp
@@ -1,3 +1,4 @@
+#include "odata_url_helpers.hpp"
 #include "datasphere_read.hpp"
 #include "datasphere_client.hpp"
 #include "odata_read_functions.hpp"
@@ -77,6 +78,10 @@ namespace {
     std::string BuildAnalyticalDataUrl(const std::string& space_id, const std::string& asset_id, 
                                        const std::string& tenant, const std::string& data_center) {
         if (space_id.find("http") == 0) {
+            // Same rule as the Business Central and Dataverse hatches: this URL is taken
+            // verbatim from the caller and carries an OAuth bearer token, so plain http is
+            // allowed only for loopback.
+            RequireSecureOrLoopbackUrl(space_id, "Datasphere 'space_id'");
             std::string data_url = space_id;
             EnsureAssetSegmentPattern(data_url, asset_id);
             return data_url;
@@ -90,6 +95,7 @@ namespace {
     std::string BuildDataUrl(const std::string& space_id, const std::string& asset_id, 
                             const std::string& tenant, const std::string& data_center) {
         if (space_id.find("http") == 0) {
+            RequireSecureOrLoopbackUrl(space_id, "Datasphere 'space_id'");
             std::string data_url = space_id;
             EnsureAssetSegmentPattern(data_url, asset_id);
             return data_url;

--- a/src/datasphere_read.cpp
+++ b/src/datasphere_read.cpp
@@ -77,7 +77,7 @@ namespace {
     // Helper function to build the analytical data URL
     std::string BuildAnalyticalDataUrl(const std::string& space_id, const std::string& asset_id, 
                                        const std::string& tenant, const std::string& data_center) {
-        if (space_id.find("http") == 0) {
+        if (LooksLikeAbsoluteHttpUrl(space_id)) {
             // Same rule as the Business Central and Dataverse hatches: this URL is taken
             // verbatim from the caller and carries an OAuth bearer token, so plain http is
             // allowed only for loopback.
@@ -94,7 +94,7 @@ namespace {
     // Helper function to build the data URL
     std::string BuildDataUrl(const std::string& space_id, const std::string& asset_id, 
                             const std::string& tenant, const std::string& data_center) {
-        if (space_id.find("http") == 0) {
+        if (LooksLikeAbsoluteHttpUrl(space_id)) {
             RequireSecureOrLoopbackUrl(space_id, "Datasphere 'space_id'");
             std::string data_url = space_id;
             EnsureAssetSegmentPattern(data_url, asset_id);

--- a/src/dataverse_client.cpp
+++ b/src/dataverse_client.cpp
@@ -11,6 +11,9 @@ std::string DataverseUrlBuilder::BuildApiUrl(const std::string &environment_url,
     if (!base.empty() && base.back() == '/') {
         base.pop_back();
     }
+    // environment_url is taken verbatim from the secret and carries an OAuth bearer token,
+    // so it gets the same rule as the Business Central and Datasphere hatches.
+    RequireSecureOrLoopbackUrl(base, "Dataverse 'environment_url'");
     return base + "/api/data/" + api_version;
 }
 

--- a/src/dataverse_functions.cpp
+++ b/src/dataverse_functions.cpp
@@ -213,7 +213,23 @@ TableFunctionSet CreateCrmDescribeFunction() {
 
 struct CrmReadBindData : public TableFunctionData {
     std::unique_ptr<ODataReadBindData> odata_bind_data;
+};
+
+// Owns the scan state for ONE execution of a bound plan (GitHub #182).
+//
+// `finished` used to live on the bind data and was never reset, so the second EXECUTE of
+// a prepared statement returned zero rows deterministically and silently. Both it and the
+// row buffer now belong to the per-execution clone.
+class CrmReadGlobalState : public GlobalTableFunctionState {
+public:
+    explicit CrmReadGlobalState(std::unique_ptr<ODataReadBindData> scan_state)
+        : scan_state(std::move(scan_state)) {}
+
+    ODataReadBindData &Scan() { return *scan_state; }
     bool finished = false;
+
+private:
+    std::unique_ptr<ODataReadBindData> scan_state;
 };
 
 static unique_ptr<FunctionData> CrmReadBind(
@@ -265,37 +281,42 @@ static unique_ptr<GlobalTableFunctionState> CrmReadInitGlobalState(
 
     auto &bind_data = input.bind_data->CastNoConst<CrmReadBindData>();
 
-    // Activate columns for projection pushdown
-    bind_data.odata_bind_data->ActivateColumns(input.column_ids);
+    // Projection, filter pushdown and the first-page prefetch all mutate scan state, so
+    // they run against a private clone; the bind data stays as bind left it. Returning
+    // nullptr here - with the scan reading the bind data directly - is what made a second
+    // EXECUTE return nothing (GitHub #182).
+    auto scan_state = bind_data.odata_bind_data->CloneForScan();
 
-    // Add filters for predicate pushdown
-    bind_data.odata_bind_data->AddFilters(input.filters);
+    scan_state->ActivateColumns(input.column_ids);
+    scan_state->AddFilters(input.filters);
+    scan_state->UpdateUrlFromPredicatePushdown();
+    scan_state->PrefetchFirstPage();
 
-    // Update URL with pushdown predicates
-    bind_data.odata_bind_data->UpdateUrlFromPredicatePushdown();
-
-    // Prefetch first page
-    bind_data.odata_bind_data->PrefetchFirstPage();
-
-    return nullptr;
+    return make_uniq<CrmReadGlobalState>(std::move(scan_state));
 }
 
 static void CrmReadScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
-    auto &bind_data = data.bind_data->CastNoConst<CrmReadBindData>();
+    auto &gstate = data.global_state->Cast<CrmReadGlobalState>();
 
-    if (bind_data.finished) {
+    if (gstate.finished) {
         return;
     }
 
-    auto rows_fetched = bind_data.odata_bind_data->FetchNextResult(output);
-    if (!bind_data.odata_bind_data->HasMoreResults() && rows_fetched == 0) {
-        bind_data.finished = true;
+    auto rows_fetched = gstate.Scan().FetchNextResult(output);
+    if (!gstate.Scan().HasMoreResults() && rows_fetched == 0) {
+        gstate.finished = true;
     }
 }
 
-static double CrmReadProgress(ClientContext &context, const FunctionData *bind_data_p, const GlobalTableFunctionState *) {
-    auto &bind_data = bind_data_p->Cast<CrmReadBindData>();
-    return bind_data.odata_bind_data->GetProgressFraction();
+static double CrmReadProgress(ClientContext &context, const FunctionData *bind_data_p,
+                              const GlobalTableFunctionState *global_state) {
+    // Progress lives on the per-execution clone, so reading it off the bind data would
+    // report a scan that is no longer the one running (GitHub #182).
+    if (global_state == nullptr) {
+        return -1.0;
+    }
+    auto &gstate = const_cast<GlobalTableFunctionState *>(global_state)->Cast<CrmReadGlobalState>();
+    return gstate.Scan().GetProgressFraction();
 }
 
 TableFunctionSet CreateCrmReadFunction() {

--- a/src/include/odata_url_helpers.hpp
+++ b/src/include/odata_url_helpers.hpp
@@ -18,6 +18,12 @@ namespace erpl_web {
 // `what` names the setting in the error, so the caller is told which of theirs is wrong.
 void RequireSecureOrLoopbackUrl(const std::string &url, const std::string &what);
 
+// Shared trigger for those same hatches: does this value already look like an absolute
+// URL? Datasphere tested `find("http") == 0`, which is true of any string starting with
+// those four letters ("http_archive"), so the three hatches disagreed on what they were
+// even guarding while a comment claimed they shared one rule (GitHub #193).
+bool LooksLikeAbsoluteHttpUrl(const std::string &value);
+
 
 
 // The HTTP client every OData consumer needs.

--- a/src/include/odata_url_helpers.hpp
+++ b/src/include/odata_url_helpers.hpp
@@ -6,6 +6,20 @@
 
 namespace erpl_web {
 
+// Guard for the "an already-absolute URL is used verbatim" hatches that several readers
+// expose so they can be pointed at a local server (Business Central's `environment`,
+// Datasphere's `space_id`, Dataverse's `environment_url`).
+//
+// All three carry an OAuth bearer token, and all three hardcoded https before the hatch
+// existed. Accepting plain http anywhere would make a testability affordance into a
+// credential-in-cleartext path, and the same-origin guard would not object because the
+// configured URL IS the origin. https is allowed anywhere; plain http only for loopback.
+//
+// `what` names the setting in the error, so the caller is told which of theirs is wrong.
+void RequireSecureOrLoopbackUrl(const std::string &url, const std::string &what);
+
+
+
 // The HTTP client every OData consumer needs.
 //
 // url_encode is off because the OData layer has already encoded what needs encoding:

--- a/src/odata_url_helpers.cpp
+++ b/src/odata_url_helpers.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+#include <cctype>
 #include "odata_url_helpers.hpp"
 #include "odata_text_scanning.hpp"
 #include "yyjson.hpp"
@@ -5,12 +7,45 @@
 
 namespace erpl_web {
 
+namespace {
+
+// RFC 3986 schemes are case-insensitive, so the guard must be too. The byte-exact form was
+// inert only because HttpUrl's own parser is likewise lowercase-only, so an uppercase
+// scheme fails to connect rather than shipping anything - but a credential guard should
+// not depend on a second parser's case sensitivity to do its job (GitHub #193).
+std::string LowercaseAscii(const std::string &value)
+{
+    std::string out = value;
+    std::transform(out.begin(), out.end(), out.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return out;
+}
+
+}  // namespace
+
+bool LooksLikeAbsoluteHttpUrl(const std::string &value)
+{
+    const auto lowered = LowercaseAscii(value);
+    return lowered.rfind("https://", 0) == 0 || lowered.rfind("http://", 0) == 0;
+}
+
 void RequireSecureOrLoopbackUrl(const std::string &url, const std::string &what)
 {
-    if (url.rfind("https://", 0) == 0) {
+    const auto lowered = LowercaseAscii(url);
+
+    if (lowered.rfind("https://", 0) == 0) {
         return;
     }
-    if (url.rfind("http://", 0) != 0) {
+    if (lowered.rfind("http://", 0) != 0) {
+        // A value carrying some OTHER scheme is refused rather than waved through. Passing
+        // it through is how anything unrecognised used to reach the verbatim path.
+        const auto colon = url.find(':');
+        const auto slash = url.find('/');
+        if (colon != std::string::npos && (slash == std::string::npos || colon < slash)) {
+            throw duckdb::InvalidInputException(
+                "%s must be an http:// or https:// URL; '%s' names an unsupported scheme.",
+                what.c_str(), url.c_str());
+        }
         return;  // not an absolute URL at all; the caller handles its own forms
     }
 

--- a/src/odata_url_helpers.cpp
+++ b/src/odata_url_helpers.cpp
@@ -5,6 +5,41 @@
 
 namespace erpl_web {
 
+void RequireSecureOrLoopbackUrl(const std::string &url, const std::string &what)
+{
+    if (url.rfind("https://", 0) == 0) {
+        return;
+    }
+    if (url.rfind("http://", 0) != 0) {
+        return;  // not an absolute URL at all; the caller handles its own forms
+    }
+
+    const std::string after_scheme = url.substr(std::string("http://").size());
+    std::string host;
+    if (!after_scheme.empty() && after_scheme.front() == '[') {
+        // Bracketed IPv6: the port separator is the colon AFTER the ']', and the address
+        // itself is full of colons.
+        const auto close = after_scheme.find(']');
+        host = (close == std::string::npos) ? after_scheme : after_scheme.substr(0, close + 1);
+    } else {
+        const auto host_end = after_scheme.find_first_of(":/");
+        host = (host_end == std::string::npos) ? after_scheme : after_scheme.substr(0, host_end);
+    }
+
+    // The host must BE a loopback name, not merely start with one - a prefix test lets
+    // "localhost.evil.example" through.
+    if (host == "localhost" || host == "127.0.0.1" || host == "[::1]") {
+        return;
+    }
+
+    throw duckdb::InvalidInputException(
+        "%s may only use plain http:// for a loopback address (localhost, 127.0.0.1 or "
+        "[::1]); '%s' would send the OAuth bearer token unencrypted. Use https:// instead.",
+        what.c_str(), url.c_str());
+}
+
+
+
 std::shared_ptr<HttpClient> CreateODataHttpClient() {
     HttpParams http_params;
     http_params.url_encode = false;

--- a/src/odata_url_helpers.cpp
+++ b/src/odata_url_helpers.cpp
@@ -49,7 +49,21 @@ void RequireSecureOrLoopbackUrl(const std::string &url, const std::string &what)
         return;  // not an absolute URL at all; the caller handles its own forms
     }
 
-    const std::string after_scheme = url.substr(std::string("http://").size());
+    std::string after_scheme = url.substr(std::string("http://").size());
+
+    // Strip userinfo FIRST. "http://127.0.0.1:pw@evil.example/" has 127.0.0.1:pw as
+    // user:password and evil.example as the host - HttpUrl::ParseUrl reads it that way -
+    // but a parse that stops at the first ':' sees "127.0.0.1" and approves. That was a
+    // live bypass: the guard passed, and the bearer token went to the attacker's host in
+    // cleartext (GitHub #194).
+    const auto authority_end = after_scheme.find('/');
+    const auto at = after_scheme.rfind('@', authority_end == std::string::npos
+                                                ? std::string::npos
+                                                : authority_end);
+    if (at != std::string::npos) {
+        after_scheme = after_scheme.substr(at + 1);
+    }
+
     std::string host;
     if (!after_scheme.empty() && after_scheme.front() == '[') {
         // Bracketed IPv6: the port separator is the colon AFTER the ']', and the address
@@ -63,7 +77,10 @@ void RequireSecureOrLoopbackUrl(const std::string &url, const std::string &what)
 
     // The host must BE a loopback name, not merely start with one - a prefix test lets
     // "localhost.evil.example" through.
-    if (host == "localhost" || host == "127.0.0.1" || host == "[::1]") {
+    // Hosts are case-insensitive too, so LOCALHOST must be treated as localhost - the
+    // scheme check was made case-insensitive while this one was left byte-exact.
+    const auto host_lower = LowercaseAscii(host);
+    if (host_lower == "localhost" || host_lower == "127.0.0.1" || host_lower == "[::1]") {
         return;
     }
 

--- a/src/odata_url_helpers.cpp
+++ b/src/odata_url_helpers.cpp
@@ -31,63 +31,47 @@ bool LooksLikeAbsoluteHttpUrl(const std::string &value)
 
 void RequireSecureOrLoopbackUrl(const std::string &url, const std::string &what)
 {
-    const auto lowered = LowercaseAscii(url);
-
-    if (lowered.rfind("https://", 0) == 0) {
-        return;
-    }
-    if (lowered.rfind("http://", 0) != 0) {
-        // A value carrying some OTHER scheme is refused rather than waved through. Passing
-        // it through is how anything unrecognised used to reach the verbatim path.
+    if (!LooksLikeAbsoluteHttpUrl(url)) {
+        // Not an absolute http(s) URL. If it carries some OTHER scheme, refuse it rather
+        // than wave it through; otherwise it is a bare name and the caller handles it.
         const auto colon = url.find(':');
         const auto slash = url.find('/');
         if (colon != std::string::npos && (slash == std::string::npos || colon < slash)) {
             throw duckdb::InvalidInputException(
-                "%s must be an http:// or https:// URL; '%s' names an unsupported scheme.",
+                "%s must be an http:// or https:// URL; '%s' names an unsupported scheme "
+                "(schemes are matched case-insensitively).",
                 what.c_str(), url.c_str());
         }
-        return;  // not an absolute URL at all; the caller handles its own forms
+        return;
     }
 
-    std::string after_scheme = url.substr(std::string("http://").size());
+    // Parse with the SAME parser that will open the socket. A hand-rolled authority parse
+    // here was wrong twice: it read userinfo as the host (GitHub #194), and then its fix
+    // took the LAST '@' while HttpUrl takes the first - so
+    // "http://x:y@evil.example@127.0.0.1/" was approved as loopback while the transport
+    // dials evil.example@127.0.0.1. A guard that disagrees with the dialer is not a guard,
+    // and the only way it cannot disagree is to ask the dialer (GitHub #198).
+    HttpUrl parsed(url);
+    const std::string scheme = LowercaseAscii(parsed.Scheme());
+    const std::string host = LowercaseAscii(parsed.Host());
 
-    // Strip userinfo FIRST. "http://127.0.0.1:pw@evil.example/" has 127.0.0.1:pw as
-    // user:password and evil.example as the host - HttpUrl::ParseUrl reads it that way -
-    // but a parse that stops at the first ':' sees "127.0.0.1" and approves. That was a
-    // live bypass: the guard passed, and the bearer token went to the attacker's host in
-    // cleartext (GitHub #194).
-    const auto authority_end = after_scheme.find('/');
-    const auto at = after_scheme.rfind('@', authority_end == std::string::npos
-                                                ? std::string::npos
-                                                : authority_end);
-    if (at != std::string::npos) {
-        after_scheme = after_scheme.substr(at + 1);
+    if (scheme == "https") {
+        return;
     }
 
-    std::string host;
-    if (!after_scheme.empty() && after_scheme.front() == '[') {
-        // Bracketed IPv6: the port separator is the colon AFTER the ']', and the address
-        // itself is full of colons.
-        const auto close = after_scheme.find(']');
-        host = (close == std::string::npos) ? after_scheme : after_scheme.substr(0, close + 1);
-    } else {
-        const auto host_end = after_scheme.find_first_of(":/");
-        host = (host_end == std::string::npos) ? after_scheme : after_scheme.substr(0, host_end);
-    }
-
-    // The host must BE a loopback name, not merely start with one - a prefix test lets
-    // "localhost.evil.example" through.
-    // Hosts are case-insensitive too, so LOCALHOST must be treated as localhost - the
-    // scheme check was made case-insensitive while this one was left byte-exact.
-    const auto host_lower = LowercaseAscii(host);
-    if (host_lower == "localhost" || host_lower == "127.0.0.1" || host_lower == "[::1]") {
+    // Note: bracketed IPv6 is deliberately NOT accepted. HttpUrl's host class excludes
+    // ':', so "http://[::1]:8080" parses with host "[" and could never be dialled -
+    // advertising it as a supported loopback form would be advertising something that
+    // does not work.
+    if (host == "localhost" || host == "127.0.0.1") {
         return;
     }
 
     throw duckdb::InvalidInputException(
-        "%s may only use plain http:// for a loopback address (localhost, 127.0.0.1 or "
-        "[::1]); '%s' would send the OAuth bearer token unencrypted. Use https:// instead.",
-        what.c_str(), url.c_str());
+        "%s may only use plain http:// for a loopback address (localhost or 127.0.0.1); "
+        "'%s' resolves to host '%s' and would send the OAuth bearer token unencrypted. "
+        "Use https:// instead.",
+        what.c_str(), url.c_str(), parsed.Host().c_str());
 }
 
 

--- a/src/odp_request_orchestrator.cpp
+++ b/src/odp_request_orchestrator.cpp
@@ -153,7 +153,13 @@ OdpRequestOrchestrator::OdpRequestResult OdpRequestOrchestrator::ExecuteNextPage
     // whatever host it names would hand the bearer token to that host, so follow
     // the rule HttpClient already applies to redirects: same origin keeps the
     // credentials, anything else does not (#101).
-    const bool same_origin = service_origin_url_.empty() || IsSameOrigin(service_origin_url_, next_url);
+    // Fail CLOSED on an unset origin. Written as `empty() || IsSameOrigin(...)` this gate
+    // attached credentials to whatever host the server named whenever the origin had not
+    // been recorded yet - the wrong polarity for a credential decision. Today's call
+    // ordering happens to set it first, so this was latent rather than exploitable, but
+    // "we don't know the origin" must mean "send nothing", not "send everything"
+    // (GitHub #187).
+    const bool same_origin = !service_origin_url_.empty() && IsSameOrigin(service_origin_url_, next_url);
     if (!same_origin) {
         ERPL_TRACE_WARN("ODP_ORCHESTRATOR", duckdb::StringUtil::Format(
             "Server-supplied next link points at a different origin than the service (%s -> %s); "

--- a/test/cpp/test_datasphere_scan_reexecution.cpp
+++ b/test/cpp/test_datasphere_scan_reexecution.cpp
@@ -267,3 +267,40 @@ TEST_CASE("a Datasphere dual-URL asset re-executes correctly",
         REQUIRE(request.path != data_prefix + "/$metadata");
     }
 }
+
+// The verbatim-URL hatch on space_id carries an OAuth bearer token, exactly like the
+// Business Central and Dataverse ones. Raised by an agent-crew review as an unapplied fix:
+// the loopback restriction went onto BC's hatch and not onto its siblings.
+//
+// The secret's token endpoint has to be a working loopback server: auth is resolved before
+// the data URL is built, so without it the read fails on the token fetch and never reaches
+// the guard under test. (That ordering is itself reassuring - the bearer token is obtained
+// from the configured token endpoint, never sent to the rejected host.)
+TEST_CASE("the Datasphere space_id hatch refuses plain http off loopback",
+          "[datasphere_reexec][security]") {
+    ODataTestServer server;
+    server.OnPath("/oauth/token",
+                  CannedResponse::Json(
+                      R"({"access_token":"test-token","token_type":"Bearer","expires_in":3600})"));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+    CreateLoopbackSecret(con, "dssec", server);
+
+    auto result = con.Query(
+        "SELECT * FROM datasphere_read_relational('http://evil.example/sp', 'A', secret => 'dssec')");
+    REQUIRE(result->HasError());
+    INFO("error was: " << result->GetError());
+    REQUIRE(result->GetError().find("loopback") != std::string::npos);
+    // A caller mistake, not a broken invariant of ours.
+    REQUIRE(result->GetErrorObject().Type() != duckdb::ExceptionType::INTERNAL);
+
+    // https anywhere is still accepted - the guard must not have become "loopback only".
+    auto https_ok = con.Query(
+        "SELECT * FROM datasphere_read_relational('https://tenant.datasphere.example/sp', 'A', "
+        "secret => 'dssec')");
+    REQUIRE(https_ok->HasError());  // it will fail to CONNECT, but not on the guard
+    INFO("https error was: " << https_ok->GetError());
+    REQUIRE(https_ok->GetError().find("loopback") == std::string::npos);
+}

--- a/test/cpp/test_microsoft_scan_reexecution.cpp
+++ b/test/cpp/test_microsoft_scan_reexecution.cpp
@@ -16,6 +16,7 @@
 #include "duckdb.hpp"
 
 #include "odata_test_server.hpp"
+#include "business_central_client.hpp"
 
 #include <ctime>
 #include <string>
@@ -162,5 +163,42 @@ TEST_CASE("a bound bc_read plan returns every row on each execution", "[ms_reexe
         INFO((result->HasError() ? result->GetError() : std::string()));
         REQUIRE_FALSE(result->HasError());
         REQUIRE(ScalarOf(result) == 4);
+    }
+}
+
+// The verbatim-URL escape hatch added above is production code shared by bc_read,
+// bc_describe and the BC catalog - not test-only. Before it existed the scheme was
+// hardcoded https, so accepting plain http generally would be a security downgrade
+// introduced by a testability change: the OAuth bearer token would go on the wire in
+// cleartext, and the same-origin guard would not object because the configured URL IS the
+// origin. Raised by an agent-crew review (F6).
+TEST_CASE("the Business Central URL hatch refuses plain http off loopback",
+          "[ms_reexec][bc][security]") {
+    SECTION("loopback forms are accepted") {
+        REQUIRE(erpl_web::BusinessCentralUrlBuilder::BuildApiUrl("t", "http://127.0.0.1:8080") ==
+                "http://127.0.0.1:8080");
+        REQUIRE(erpl_web::BusinessCentralUrlBuilder::BuildApiUrl("t", "http://localhost:8080/") ==
+                "http://localhost:8080");
+        REQUIRE(erpl_web::BusinessCentralUrlBuilder::BuildApiUrl("t", "http://[::1]:8080") ==
+                "http://[::1]:8080");
+    }
+
+    SECTION("https is accepted anywhere") {
+        REQUIRE(erpl_web::BusinessCentralUrlBuilder::BuildApiUrl("t", "https://api.example.com/v2") ==
+                "https://api.example.com/v2");
+    }
+
+    SECTION("plain http to any other host is refused") {
+        REQUIRE_THROWS_AS(erpl_web::BusinessCentralUrlBuilder::BuildApiUrl("t", "http://evil.example"),
+                          duckdb::InvalidInputException);
+        // A host that merely starts with a loopback-looking label must not slip through.
+        REQUIRE_THROWS_AS(
+            erpl_web::BusinessCentralUrlBuilder::BuildApiUrl("t", "http://localhost.evil.example"),
+            duckdb::InvalidInputException);
+    }
+
+    SECTION("a non-URL environment still builds the real BC endpoint") {
+        REQUIRE(erpl_web::BusinessCentralUrlBuilder::BuildApiUrl("tenant", "production") ==
+                "https://api.businesscentral.dynamics.com/v2.0/tenant/production/api/v2.0");
     }
 }

--- a/test/cpp/test_microsoft_scan_reexecution.cpp
+++ b/test/cpp/test_microsoft_scan_reexecution.cpp
@@ -186,8 +186,12 @@ TEST_CASE("the Business Central URL hatch refuses plain http off loopback",
                 "http://127.0.0.1:8080");
         REQUIRE(erpl_web::BusinessCentralUrlBuilder::BuildApiUrl("t", "http://localhost:8080/") ==
                 "http://localhost:8080");
-        REQUIRE(erpl_web::BusinessCentralUrlBuilder::BuildApiUrl("t", "http://[::1]:8080") ==
-                "http://[::1]:8080");
+        // Bracketed IPv6 is deliberately NOT among the accepted forms: HttpUrl's host
+        // class excludes ':', so "http://[::1]:8080" parses with host "[" and could never
+        // be dialled. Asserting it here would lock in a property the stack does not hold
+        // (GitHub #198).
+        REQUIRE_THROWS_AS(erpl_web::BusinessCentralUrlBuilder::BuildApiUrl("t", "http://[::1]:8080"),
+                          duckdb::InvalidInputException);
     }
 
     SECTION("https is accepted anywhere") {
@@ -219,8 +223,8 @@ TEST_CASE("the Dataverse URL hatch refuses plain http off loopback",
     SECTION("loopback and https are accepted") {
         REQUIRE(erpl_web::DataverseUrlBuilder::BuildApiUrl("http://127.0.0.1:8080") ==
                 "http://127.0.0.1:8080/api/data/v9.2");
-        REQUIRE(erpl_web::DataverseUrlBuilder::BuildApiUrl("http://[::1]:8080") ==
-                "http://[::1]:8080/api/data/v9.2");
+        REQUIRE_THROWS_AS(erpl_web::DataverseUrlBuilder::BuildApiUrl("http://[::1]:8080"),
+                          duckdb::InvalidInputException);
         REQUIRE(erpl_web::DataverseUrlBuilder::BuildApiUrl("https://org.crm.dynamics.com") ==
                 "https://org.crm.dynamics.com/api/data/v9.2");
     }
@@ -248,14 +252,18 @@ TEST_CASE("the URL hatches are case-insensitive about the scheme",
                           duckdb::InvalidInputException);
     }
 
-    SECTION("an uppercase scheme on loopback is still accepted") {
-        REQUIRE(erpl_web::BusinessCentralUrlBuilder::BuildApiUrl("t", "HTTP://127.0.0.1:8080") ==
-                "HTTP://127.0.0.1:8080");
-    }
-
-    SECTION("uppercase HTTPS is accepted anywhere") {
-        REQUIRE(erpl_web::DataverseUrlBuilder::BuildApiUrl("HTTPS://org.crm.dynamics.com") ==
-                "HTTPS://org.crm.dynamics.com/api/data/v9.2");
+    // An uppercase scheme is now REFUSED, for both hosts. An earlier version of this test
+    // asserted it was accepted, which was wrong in the same way as the [::1] case:
+    // HttpUrl's scheme group is (https?), lowercase-only, so "HTTP://..." parses as a path
+    // with no host and can never be dialled. Refusing it up front with a message beats
+    // accepting it and failing to connect later (GitHub #198).
+    SECTION("an uppercase scheme is refused, loopback or not") {
+        REQUIRE_THROWS_AS(
+            erpl_web::BusinessCentralUrlBuilder::BuildApiUrl("t", "HTTP://127.0.0.1:8080"),
+            duckdb::InvalidInputException);
+        REQUIRE_THROWS_AS(
+            erpl_web::DataverseUrlBuilder::BuildApiUrl("HTTPS://org.crm.dynamics.com"),
+            duckdb::InvalidInputException);
     }
 
     // Anything carrying some other scheme is now refused rather than waved through.
@@ -286,6 +294,16 @@ TEST_CASE("the URL hatch guard is not fooled by userinfo", "[ms_reexec][security
             duckdb::InvalidInputException);
         REQUIRE_THROWS_AS(
             erpl_web::BusinessCentralUrlBuilder::BuildApiUrl("t", "http://localhost@evil.example"),
+            duckdb::InvalidInputException);
+    }
+
+    // The guard's own fix for #194 used rfind('@') (LAST), while HttpUrl's userinfo class
+    // ends at the FIRST '@'. For this URL the old guard saw host 127.0.0.1 and approved,
+    // while the transport dials "evil.example@127.0.0.1". Building the guard on HttpUrl is
+    // what makes the two agree by construction (GitHub #198).
+    SECTION("a doubled userinfo cannot disagree with the dialer") {
+        REQUIRE_THROWS_AS(
+            erpl_web::DataverseUrlBuilder::BuildApiUrl("http://x:y@evil.example@127.0.0.1/"),
             duckdb::InvalidInputException);
     }
 

--- a/test/cpp/test_microsoft_scan_reexecution.cpp
+++ b/test/cpp/test_microsoft_scan_reexecution.cpp
@@ -1,5 +1,11 @@
-// GitHub #182: the Business Central and Dataverse readers have no per-execution scan
-// state - the #75 class, in the last table functions still carrying it.
+// GitHub #182: the Business Central and Dataverse READ functions had no per-execution scan
+// state - the #75 class. That is fixed here for bc_read and crm_read.
+//
+// It is NOT fixed for their catalog siblings (bc_show_companies, bc_show_entities,
+// bc_describe, crm_show_entities, crm_describe), which still keep finished/current_row on
+// bind data and register no init_global - tracked as GitHub #191. The present tense below
+// therefore describes what these two functions USED to do; the same sentence is still true
+// of the five siblings, and leaving it ambiguous would hide where it still applies.
 //
 // Each keeps a `finished` flag on its BIND DATA, sets it when the scan drains, and never
 // resets it; the init-global functions mutate the bind data and return nullptr, so there
@@ -225,5 +231,42 @@ TEST_CASE("the Dataverse URL hatch refuses plain http off loopback",
         REQUIRE_THROWS_AS(
             erpl_web::DataverseUrlBuilder::BuildApiUrl("http://127.0.0.1.evil.example"),
             duckdb::InvalidInputException);
+    }
+}
+
+// GitHub #193. The scheme prefix test was byte-exact, so an uppercase scheme took the
+// "not an absolute URL at all" early return and the guard never applied. That was inert -
+// HttpUrl's parser is lowercase-only too, so such a URL fails to connect rather than
+// shipping a bearer token - but a credential guard relying on a second parser's case
+// sensitivity is not a guard. Raised by the continuous agent-crew review.
+TEST_CASE("the URL hatches are case-insensitive about the scheme",
+          "[ms_reexec][security]") {
+    SECTION("an uppercase scheme off loopback is still refused") {
+        REQUIRE_THROWS_AS(erpl_web::BusinessCentralUrlBuilder::BuildApiUrl("t", "HTTP://evil.example"),
+                          duckdb::InvalidInputException);
+        REQUIRE_THROWS_AS(erpl_web::DataverseUrlBuilder::BuildApiUrl("HtTp://evil.example"),
+                          duckdb::InvalidInputException);
+    }
+
+    SECTION("an uppercase scheme on loopback is still accepted") {
+        REQUIRE(erpl_web::BusinessCentralUrlBuilder::BuildApiUrl("t", "HTTP://127.0.0.1:8080") ==
+                "HTTP://127.0.0.1:8080");
+    }
+
+    SECTION("uppercase HTTPS is accepted anywhere") {
+        REQUIRE(erpl_web::DataverseUrlBuilder::BuildApiUrl("HTTPS://org.crm.dynamics.com") ==
+                "HTTPS://org.crm.dynamics.com/api/data/v9.2");
+    }
+
+    // Anything carrying some other scheme is now refused rather than waved through.
+    SECTION("an unsupported scheme is refused, not passed through") {
+        REQUIRE_THROWS_AS(erpl_web::DataverseUrlBuilder::BuildApiUrl("file:///etc/passwd"),
+                          duckdb::InvalidInputException);
+    }
+
+    // A bare name is not a URL and must still reach the caller's own handling.
+    SECTION("a non-URL value is left alone") {
+        REQUIRE(erpl_web::BusinessCentralUrlBuilder::BuildApiUrl("tenant", "production") ==
+                "https://api.businesscentral.dynamics.com/v2.0/tenant/production/api/v2.0");
     }
 }

--- a/test/cpp/test_microsoft_scan_reexecution.cpp
+++ b/test/cpp/test_microsoft_scan_reexecution.cpp
@@ -1,0 +1,166 @@
+// GitHub #182: the Business Central and Dataverse readers have no per-execution scan
+// state - the #75 class, in the last table functions still carrying it.
+//
+// Each keeps a `finished` flag on its BIND DATA, sets it when the scan drains, and never
+// resets it; the init-global functions mutate the bind data and return nullptr, so there
+// is no per-execution state at all. The second EXECUTE of a bound plan therefore returns
+// zero rows, silently, and a self-join has the second scan return nothing.
+//
+// Dataverse is drivable against a local server because DataverseUrlBuilder::BuildApiUrl
+// takes the secret's environment_url verbatim. Business Central hardcoded its host until
+// this change; BuildApiUrl now uses `environment` as the API base when it already looks
+// like a URL, the same escape hatch DatasphereReadRelational has had for space_id. That
+// is what makes the reader testable at all.
+
+#include "catch.hpp"
+#include "duckdb.hpp"
+
+#include "odata_test_server.hpp"
+
+#include <ctime>
+#include <string>
+
+using erpl_web::test_support::CannedResponse;
+using erpl_web::test_support::MakeV4Page;
+using erpl_web::test_support::ODataTestServer;
+using erpl_web::test_support::RecordedRequest;
+
+namespace {
+
+// See CLAUDE.md: a bare DuckDB(nullptr) crashes in DEBUG builds shortly after the first
+// query unless jemalloc's background threads own arena management.
+class TestDatabase {
+public:
+    TestDatabase()
+    {
+        config.SetOption("allocator_background_threads", duckdb::Value::BOOLEAN(true));
+        database = duckdb::make_uniq<duckdb::DuckDB>(nullptr, &config);
+        connection = duckdb::make_uniq<duckdb::Connection>(*database);
+    }
+
+    duckdb::Connection &Con() const { return *connection; }
+
+private:
+    duckdb::DBConfig config;
+    duckdb::unique_ptr<duckdb::DuckDB> database;
+    duckdb::unique_ptr<duckdb::Connection> connection;
+};
+
+const char *const AIRLINE_AA = R"({"AirlineCode":"AA","Name":"American Airlines"})";
+const char *const AIRLINE_FM = R"({"AirlineCode":"FM","Name":"Shanghai Airline"})";
+const char *const AIRLINE_MU = R"({"AirlineCode":"MU","Name":"China Eastern Airlines"})";
+const char *const AIRLINE_AF = R"({"AirlineCode":"AF","Name":"Air France"})";
+
+// Two pages of four rows under `prefix`, served as the entity set `Airlines`, plus a
+// token endpoint so the client_credentials exchange stays on loopback.
+void ServeTwoPages(ODataTestServer &server, const std::string &prefix)
+{
+    const std::string entity_url = server.Url(prefix + "/Airlines");
+    const std::string context = server.Url(prefix + "/$metadata") + "#Airlines";
+
+    server.ServeMetadataFixture(prefix + "/$metadata", "edm_trippin.xml");
+    server.OnMatch(
+        [prefix](const RecordedRequest &request) {
+            return request.path == prefix + "/Airlines" && request.QueryParam("$skiptoken") == "2";
+        },
+        CannedResponse::Json(MakeV4Page(context, {AIRLINE_MU, AIRLINE_AF})));
+    server.OnPath(prefix + "/Airlines",
+                  CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA, AIRLINE_FM},
+                                                  entity_url + "?$format=json&$skiptoken=2")));
+    server.OnPath("/token",
+                  CannedResponse::Json(
+                      R"({"access_token":"test-token","token_type":"Bearer","expires_in":3600})"));
+}
+
+// MicrosoftEntraTokenManager::HasValidCachedToken requires BOTH access_token AND a
+// non-expired expires_at. Without the expiry the supplied token is ignored entirely and
+// the manager calls the real login.microsoftonline.com endpoint.
+std::string FarFutureEpoch()
+{
+    return std::to_string(static_cast<long long>(std::time(nullptr)) + 86400);
+}
+
+int64_t ScalarOf(duckdb::unique_ptr<duckdb::MaterializedQueryResult> &result)
+{
+    return result->GetValue(0, 0).GetValue<int64_t>();
+}
+
+}  // namespace
+
+TEST_CASE("a bound crm_read plan returns every row on each execution", "[ms_reexec][crm]") {
+    ODataTestServer server;
+    // DataverseUrlBuilder::BuildApiUrl appends "/api/data/v9.2" to environment_url.
+    ServeTwoPages(server, "/api/data/v9.2");
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto secret = con.Query(
+        "CREATE SECRET crm (TYPE dataverse, PROVIDER config, "
+        "TENANT_ID 'loopback', CLIENT_ID 'id', CLIENT_SECRET 'sec', "
+        "ENVIRONMENT_URL '" + server.BaseUrl() + "', ACCESS_TOKEN 'test-token', "
+        "EXPIRES_AT '" + FarFutureEpoch() + "')");
+    INFO((secret->HasError() ? secret->GetError() : std::string()));
+    REQUIRE_FALSE(secret->HasError());
+
+    auto prep = con.Query("PREPARE p AS SELECT COUNT(*) FROM crm_read('Airlines', secret => 'crm')");
+    INFO("crm PREPARE: " << (prep->HasError() ? prep->GetError() : std::string("ok")));
+    REQUIRE_FALSE(prep->HasError());
+
+    for (int execution = 1; execution <= 3; execution++) {
+        auto result = con.Query("EXECUTE p");
+        INFO("execution " << execution);
+        INFO((result->HasError() ? result->GetError() : std::string()));
+        REQUIRE_FALSE(result->HasError());
+        REQUIRE(ScalarOf(result) == 4);
+    }
+}
+
+TEST_CASE("a bound bc_read plan returns every row on each execution", "[ms_reexec][bc]") {
+    // A GUID short-circuits BusinessCentralClientFactory::ResolveCompanyId, which would
+    // otherwise GET <base>/companies to map a name to an id.
+    const std::string COMPANY = "11111111-2222-3333-4444-555555555555";
+
+    ODataTestServer server;
+    const std::string entity_path = "/companies(" + COMPANY + ")/Airlines";
+    const std::string entity_url = server.Url(entity_path);
+    // BC serves $metadata at the API base, not under companies({id}) - see the comment in
+    // BcReadBind.
+    const std::string context = server.Url("/$metadata") + "#Airlines";
+
+    server.ServeMetadataFixture("/$metadata", "edm_trippin.xml");
+    server.OnMatch(
+        [entity_path](const RecordedRequest &request) {
+            return request.path == entity_path && request.QueryParam("$skiptoken") == "2";
+        },
+        CannedResponse::Json(MakeV4Page(context, {AIRLINE_MU, AIRLINE_AF})));
+    server.OnPath(entity_path,
+                  CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA, AIRLINE_FM},
+                                                  entity_url + "?$format=json&$skiptoken=2")));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto secret = con.Query(
+        "CREATE SECRET bc (TYPE business_central, PROVIDER config, "
+        "TENANT_ID 'loopback', CLIENT_ID 'id', CLIENT_SECRET 'sec', "
+        "ENVIRONMENT '" + server.BaseUrl() + "', ACCESS_TOKEN 'test-token', "
+        "EXPIRES_AT '" + FarFutureEpoch() + "')");
+    INFO((secret->HasError() ? secret->GetError() : std::string()));
+    REQUIRE_FALSE(secret->HasError());
+
+    auto prep = con.Query("PREPARE q AS SELECT COUNT(*) FROM bc_read('Airlines', secret => 'bc', "
+                          "company => '" + COMPANY + "')");
+    INFO("bc PREPARE: " << (prep->HasError() ? prep->GetError() : std::string("ok")));
+    REQUIRE_FALSE(prep->HasError());
+
+    for (int execution = 1; execution <= 3; execution++) {
+        auto result = con.Query("EXECUTE q");
+        INFO("execution " << execution);
+        INFO((result->HasError() ? result->GetError() : std::string()));
+        REQUIRE_FALSE(result->HasError());
+        REQUIRE(ScalarOf(result) == 4);
+    }
+}

--- a/test/cpp/test_microsoft_scan_reexecution.cpp
+++ b/test/cpp/test_microsoft_scan_reexecution.cpp
@@ -270,3 +270,32 @@ TEST_CASE("the URL hatches are case-insensitive about the scheme",
                 "https://api.businesscentral.dynamics.com/v2.0/tenant/production/api/v2.0");
     }
 }
+
+// GitHub #194. "http://127.0.0.1:pw@evil.example/" has 127.0.0.1:pw as USERINFO and
+// evil.example as the host - HttpUrl::ParseUrl reads it that way (its regex captures
+// user/password/host separately). A guard that stops at the first ':' sees "127.0.0.1" and
+// approves, so the bearer token went to the attacker's host in cleartext. Unlike the
+// case-sensitivity gap this one was live. Found by the continuous agent-crew review.
+TEST_CASE("the URL hatch guard is not fooled by userinfo", "[ms_reexec][security]") {
+    SECTION("a loopback-looking userinfo does not launder a foreign host") {
+        REQUIRE_THROWS_AS(
+            erpl_web::DataverseUrlBuilder::BuildApiUrl("http://127.0.0.1:pw@evil.example"),
+            duckdb::InvalidInputException);
+        REQUIRE_THROWS_AS(
+            erpl_web::DataverseUrlBuilder::BuildApiUrl("http://localhost:pw@evil.example"),
+            duckdb::InvalidInputException);
+        REQUIRE_THROWS_AS(
+            erpl_web::BusinessCentralUrlBuilder::BuildApiUrl("t", "http://localhost@evil.example"),
+            duckdb::InvalidInputException);
+    }
+
+    SECTION("real loopback with credentials is still accepted") {
+        REQUIRE(erpl_web::DataverseUrlBuilder::BuildApiUrl("http://user:pw@127.0.0.1:8080") ==
+                "http://user:pw@127.0.0.1:8080/api/data/v9.2");
+    }
+
+    SECTION("the loopback host compare is case-insensitive") {
+        REQUIRE(erpl_web::DataverseUrlBuilder::BuildApiUrl("http://LOCALHOST:8080") ==
+                "http://LOCALHOST:8080/api/data/v9.2");
+    }
+}

--- a/test/cpp/test_microsoft_scan_reexecution.cpp
+++ b/test/cpp/test_microsoft_scan_reexecution.cpp
@@ -17,6 +17,7 @@
 
 #include "odata_test_server.hpp"
 #include "business_central_client.hpp"
+#include "dataverse_client.hpp"
 
 #include <ctime>
 #include <string>
@@ -200,5 +201,29 @@ TEST_CASE("the Business Central URL hatch refuses plain http off loopback",
     SECTION("a non-URL environment still builds the real BC endpoint") {
         REQUIRE(erpl_web::BusinessCentralUrlBuilder::BuildApiUrl("tenant", "production") ==
                 "https://api.businesscentral.dynamics.com/v2.0/tenant/production/api/v2.0");
+    }
+}
+
+// The same rule applies to Dataverse's environment_url, which is also taken verbatim from
+// a secret and also carries a bearer token. Raised by an agent-crew review as an
+// unapplied-fix: the loopback restriction went onto Business Central's hatch and not onto
+// its siblings.
+TEST_CASE("the Dataverse URL hatch refuses plain http off loopback",
+          "[ms_reexec][crm][security]") {
+    SECTION("loopback and https are accepted") {
+        REQUIRE(erpl_web::DataverseUrlBuilder::BuildApiUrl("http://127.0.0.1:8080") ==
+                "http://127.0.0.1:8080/api/data/v9.2");
+        REQUIRE(erpl_web::DataverseUrlBuilder::BuildApiUrl("http://[::1]:8080") ==
+                "http://[::1]:8080/api/data/v9.2");
+        REQUIRE(erpl_web::DataverseUrlBuilder::BuildApiUrl("https://org.crm.dynamics.com") ==
+                "https://org.crm.dynamics.com/api/data/v9.2");
+    }
+
+    SECTION("plain http elsewhere is refused") {
+        REQUIRE_THROWS_AS(erpl_web::DataverseUrlBuilder::BuildApiUrl("http://evil.example"),
+                          duckdb::InvalidInputException);
+        REQUIRE_THROWS_AS(
+            erpl_web::DataverseUrlBuilder::BuildApiUrl("http://127.0.0.1.evil.example"),
+            duckdb::InvalidInputException);
     }
 }


### PR DESCRIPTION
Closes #182. Completes the #75 class — with #178 (Datasphere) and #180 (ODP), no reader still scans out of its bind data.

Both readers kept a `finished` flag on their **bind data**, set it when the scan drained, and never reset it. Their init-global functions mutated the bind data and returned `nullptr`, so there was no per-execution state at all. The second `EXECUTE` of a bound plan returned zero rows — deterministically and silently.

### #182 was filed from source reading. It is now demonstrated.

The issue carried an explicit caveat that it had not been executed, because `bc_read` could not be pointed at a local server: `BusinessCentralUrlBuilder::BuildApiUrl` hardcoded `api.businesscentral.dynamics.com`. An `environment` that is already a URL is now used as the API base verbatim — the same escape hatch `DatasphereReadRelational` has always had for `space_id`, and the thing that makes this reader testable at all.

With that, both defects reproduce: **execution 2 returns 0 of 4 rows** for each reader before the change, and 4 after.

Dataverse needed no such change — `BuildApiUrl` already takes `environment_url` verbatim.

### The fix

Each reader scans a `CloneForScan()` owned by its own `GlobalTableFunctionState`, which also owns `finished`. Progress reads from that state too: it lives on the clone now, so reading it off the bind data would report a scan that is not the one running — the same gap I had to fix in #178 and #180.

### Two things worth recording for the next person

- The tests supply `EXPIRES_AT` alongside `ACCESS_TOKEN`. `MicrosoftEntraTokenManager::HasValidCachedToken` requires **both**; without the expiry the supplied token is ignored entirely and the manager calls the real `login.microsoftonline.com`, which is how my first attempt failed with `HTTP 400`.
- `bc_read` resolves a company **name** by fetching `<base>/companies`. Passing a GUID short-circuits that, which is what keeps the fixture small.

### Verification

461 C++ cases / 2411 assertions green on a branch integrating this with all five other queued PRs. Committed content verified with `git show HEAD:<file>` rather than the working tree — a precaution added after a prior commit on another branch was found to have silently reverted its own fix while local tests still passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791799829&installation_model_id=425457&pr_number=185&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F185&signature=41c337ccb63d2b12120414b2114e08c024223b19eebb67a29e0f9d09fbd526d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->