### PR TITLE
fix: keep an authoritative metadata context URL when input parameters are present (#190)

### DIFF
--- a/src/include/odata_client.hpp
+++ b/src/include/odata_client.hpp
@@ -178,7 +178,13 @@ public:
     void DetectODataVersion();
     
     // Set metadata context URL directly (for Datasphere dual-URL pattern)
-    void SetMetadataContextUrl(const std::string& context_url) { metadata_context_url = context_url; }
+    // Records an AUTHORITATIVE context URL - the @odata.context the service itself
+    // returned, stored at bind time for Datasphere's dual-URL shape. Distinct from the
+    // memoised derivation below, which is only a cache (GitHub #190).
+    void SetMetadataContextUrl(const std::string& context_url) {
+        metadata_context_url = context_url;
+        metadata_context_url_is_authoritative = true;
+    }
     
     // Set OData version directly to skip metadata fetching
     void SetODataVersionDirectly(ODataVersion version) { odata_version = version; }
@@ -282,6 +288,10 @@ protected:
     std::shared_ptr<TResponse> current_response;
     ODataVersion odata_version;
     std::string metadata_context_url; // For Datasphere dual-URL pattern
+    // True when metadata_context_url came from the service's own @odata.context rather
+    // than from resolveMetadataUrl(). Only the derived form is a cache that input
+    // parameters can invalidate (GitHub #190).
+    bool metadata_context_url_is_authoritative = false;
     idx_t page_requests = 0;          // Pages fetched via a next link on this client
     std::optional<uint32_t> max_page_size_;  // Prefer: odata.maxpagesize=N, when asked for
 

--- a/src/odata_client.cpp
+++ b/src/odata_client.cpp
@@ -149,8 +149,16 @@ ODataEntitySetClient::ODataEntitySetClient(std::shared_ptr<HttpClient> http_clie
 
 std::string ODataEntitySetClient::GetMetadataContextUrl()
 {
-    if (!input_parameters.empty()) {
-        ERPL_TRACE_DEBUG("ODATA_CLIENT", "Input parameters present, clearing cached metadata URL");
+    // Input parameters can change what resolveMetadataUrl() would produce, so the MEMOISED
+    // derivation below is invalidated when they are present. An authoritative value - the
+    // @odata.context the service returned, stored at bind time - is not a cache and is not
+    // invalidated by them: it is what the service said its metadata lives at, regardless of
+    // which parameters the query passes.
+    //
+    // Clearing both was why the #186 carry was a no-op for exactly the parameterized
+    // Datasphere reads it was written for (GitHub #190).
+    if (!input_parameters.empty() && !metadata_context_url_is_authoritative) {
+        ERPL_TRACE_DEBUG("ODATA_CLIENT", "Input parameters present, clearing derived metadata URL");
         metadata_context_url.clear();
     }
 
@@ -170,6 +178,8 @@ std::string ODataEntitySetClient::GetMetadataContextUrl()
     if (metadata_context_url != final_url) {
         ERPL_TRACE_INFO("ODATA_CLIENT", "Resolved metadata URL: " + final_url);
         metadata_context_url = final_url;
+        // Derived, not authoritative: this one IS a cache.
+        metadata_context_url_is_authoritative = false;
     }
     return metadata_context_url;
 }

--- a/test/cpp/test_datasphere_scan_reexecution.cpp
+++ b/test/cpp/test_datasphere_scan_reexecution.cpp
@@ -224,6 +224,12 @@ TEST_CASE("a Datasphere dual-URL asset re-executes correctly",
     server.OnPath(data_prefix + "/MYASSET",
                   CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA, AIRLINE_FM},
                                                   entity_url + "?$format=json&$skiptoken=2")));
+
+    // Datasphere's parameterized shape: input parameters become a key predicate on the
+    // asset plus a /Set suffix.
+    server.OnPath(data_prefix + "/MYASSET(P_YEAR=2026)/Set",
+                  CannedResponse::Json(MakeV4Page(context, {AIRLINE_AA, AIRLINE_FM,
+                                                            AIRLINE_MU, AIRLINE_AF})));
     server.OnPath("/oauth/token",
                   CannedResponse::Json(
                       R"({"access_token":"test-token","token_type":"Bearer","expires_in":3600})"));
@@ -245,6 +251,18 @@ TEST_CASE("a Datasphere dual-URL asset re-executes correctly",
         REQUIRE_FALSE(result->HasError());
         REQUIRE(result->RowCount() == 4);
     }
+
+    // GitHub #190: with INPUT PARAMETERS present, GetMetadataContextUrl() used to clear the
+    // stored context URL unconditionally - treating the service's own @odata.context as a
+    // cache that parameters invalidate. That made the #186 carry a no-op for exactly the
+    // parameterized Datasphere reads it was written for. The parameters here are what
+    // triggers that path; without them this case cannot see the defect.
+    auto parameterized = con.Query(
+        "SELECT Name FROM datasphere_read_relational('" + server.Url(data_prefix) +
+        "', 'MYASSET', secret => 'ds', params => MAP{'P_YEAR': '2026'}) ORDER BY Name");
+    INFO((parameterized->HasError() ? parameterized->GetError() : std::string()));
+    REQUIRE_FALSE(parameterized->HasError());
+    REQUIRE(parameterized->RowCount() == 4);
 
     // A PROJECTING query is the shape that matters: SELECT * leaves the URL unchanged and
     // takes the early return in UpdateUrlFromPredicatePushdown, so it never reaches the


### PR DESCRIPTION
Closes #190.

`GetMetadataContextUrl()` cleared `metadata_context_url` whenever input parameters were set. That member serves **two** purposes:

1. the `@odata.context` the service itself returned, stored at bind time for Datasphere's dual-URL shape
2. a memoised cache of whatever `resolveMetadataUrl()` derived

Only the second is a cache that input parameters can invalidate. The first is what the service *said* its metadata lives at, and no parameter changes that.

Clearing both is why the #186 carry was a **no-op for exactly the parameterized Datasphere reads it was written for** — carried across both re-mint sites, then wiped on first use. That is why #186 shipped with a caveat comment and this issue rather than a claim of completeness.

### Fix

Track which of the two a stored value is (`metadata_context_url_is_authoritative`), and invalidate only the derived form.

### Test

The dual-URL case gains a **parameterized** query — `params => MAP{...}` — because that is the shape that reaches the clearing path. Without input parameters the case cannot see the defect at all, which is exactly why the original #186 test did not.

Red with the distinction removed, green with it.

Writing it also documented Datasphere's parameterized URL shape in the fixture: input parameters become a key predicate on the asset plus a `/Set` suffix (`…/MYASSET(P_YEAR=2026)/Set`).

457 C++ cases / 2370 assertions green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791819278&installation_model_id=425457&pr_number=197&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F197&signature=1923cc3aee511efb54b2ea081c405ead3329bd7fef694dcaaa1160ce553278b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->