### PR TITLE
fix: give the Business Central and Dataverse catalog functions per-execution scan state (#191)

### DIFF
--- a/src/business_central_functions.cpp
+++ b/src/business_central_functions.cpp
@@ -19,8 +19,27 @@ using namespace duckdb;
 
 struct BcShowCompaniesBindData : public TableFunctionData {
     std::unique_ptr<ODataReadBindData> odata_bind_data;
-    bool finished = false;
 };
+
+// Per-execution scan state (GitHub #191). `finished` lived on the bind data and was never
+// reset, so a second EXECUTE of a bound plan returned zero rows silently.
+class BcShowCompaniesGlobalState : public GlobalTableFunctionState {
+public:
+    explicit BcShowCompaniesGlobalState(std::unique_ptr<ODataReadBindData> scan_state)
+        : scan_state(std::move(scan_state)) {}
+
+    ODataReadBindData &Scan() { return *scan_state; }
+    bool finished = false;
+
+private:
+    std::unique_ptr<ODataReadBindData> scan_state;
+};
+
+static unique_ptr<GlobalTableFunctionState> BcShowCompaniesInitGlobalState(
+    ClientContext &context, TableFunctionInitInput &input) {
+    auto &bind_data = input.bind_data->CastNoConst<BcShowCompaniesBindData>();
+    return make_uniq<BcShowCompaniesGlobalState>(bind_data.odata_bind_data->CloneForScan());
+}
 
 static unique_ptr<FunctionData> BcShowCompaniesBind(
     ClientContext &context,
@@ -56,22 +75,22 @@ static unique_ptr<FunctionData> BcShowCompaniesBind(
 }
 
 static void BcShowCompaniesScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
-    auto &bind_data = data.bind_data->CastNoConst<BcShowCompaniesBindData>();
+    auto &gstate = data.global_state->Cast<BcShowCompaniesGlobalState>();
 
-    if (bind_data.finished) {
+    if (gstate.finished) {
         return;
     }
 
-    auto rows_fetched = bind_data.odata_bind_data->FetchNextResult(output);
-    if (!bind_data.odata_bind_data->HasMoreResults() && rows_fetched == 0) {
-        bind_data.finished = true;
+    auto rows_fetched = gstate.Scan().FetchNextResult(output);
+    if (!gstate.Scan().HasMoreResults() && rows_fetched == 0) {
+        gstate.finished = true;
     }
 }
 
 TableFunctionSet CreateBcShowCompaniesFunction() {
     TableFunctionSet set("bc_show_companies");
 
-    TableFunction func({}, DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowCompaniesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowCompaniesBind));
+    TableFunction func({}, DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowCompaniesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowCompaniesBind), BcShowCompaniesInitGlobalState);
     func.named_parameters["secret"] = LogicalType::VARCHAR;
 
     set.AddFunction(func);
@@ -84,8 +103,27 @@ TableFunctionSet CreateBcShowCompaniesFunction() {
 
 struct BcShowEntitiesBindData : public TableFunctionData {
     std::unique_ptr<ODataReadBindData> odata_bind_data;
-    bool finished = false;
 };
+
+// Per-execution scan state (GitHub #191). `finished` lived on the bind data and was never
+// reset, so a second EXECUTE of a bound plan returned zero rows silently.
+class BcShowEntitiesGlobalState : public GlobalTableFunctionState {
+public:
+    explicit BcShowEntitiesGlobalState(std::unique_ptr<ODataReadBindData> scan_state)
+        : scan_state(std::move(scan_state)) {}
+
+    ODataReadBindData &Scan() { return *scan_state; }
+    bool finished = false;
+
+private:
+    std::unique_ptr<ODataReadBindData> scan_state;
+};
+
+static unique_ptr<GlobalTableFunctionState> BcShowEntitiesInitGlobalState(
+    ClientContext &context, TableFunctionInitInput &input) {
+    auto &bind_data = input.bind_data->CastNoConst<BcShowEntitiesBindData>();
+    return make_uniq<BcShowEntitiesGlobalState>(bind_data.odata_bind_data->CloneForScan());
+}
 
 static unique_ptr<FunctionData> BcShowEntitiesBind(
     ClientContext &context,
@@ -121,22 +159,22 @@ static unique_ptr<FunctionData> BcShowEntitiesBind(
 }
 
 static void BcShowEntitiesScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
-    auto &bind_data = data.bind_data->CastNoConst<BcShowEntitiesBindData>();
+    auto &gstate = data.global_state->Cast<BcShowEntitiesGlobalState>();
 
-    if (bind_data.finished) {
+    if (gstate.finished) {
         return;
     }
 
-    auto rows_fetched = bind_data.odata_bind_data->FetchNextResult(output);
-    if (!bind_data.odata_bind_data->HasMoreResults() && rows_fetched == 0) {
-        bind_data.finished = true;
+    auto rows_fetched = gstate.Scan().FetchNextResult(output);
+    if (!gstate.Scan().HasMoreResults() && rows_fetched == 0) {
+        gstate.finished = true;
     }
 }
 
 TableFunctionSet CreateBcShowEntitiesFunction() {
     TableFunctionSet set("bc_show_entities");
 
-    TableFunction func({}, DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowEntitiesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowEntitiesBind));
+    TableFunction func({}, DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowEntitiesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowEntitiesBind), BcShowEntitiesInitGlobalState);
     func.named_parameters["secret"] = LogicalType::VARCHAR;
 
     set.AddFunction(func);
@@ -152,8 +190,20 @@ struct BcDescribeBindData : public TableFunctionData {
     std::vector<std::string> property_types;
     std::vector<bool> is_nullable;
     std::vector<bool> is_key;
+};
+
+// Per-execution row cursor (GitHub #191). It lived on the bind data and was never reset,
+// so a second EXECUTE of a bound plan resumed past the end and returned nothing. The
+// describe payload itself is immutable and stays shared.
+class BcDescribeGlobalState : public GlobalTableFunctionState {
+public:
     idx_t current_row = 0;
 };
+
+static unique_ptr<GlobalTableFunctionState> BcDescribeInitGlobalState(
+    ClientContext &context, TableFunctionInitInput &input) {
+    return make_uniq<BcDescribeGlobalState>();
+}
 
 static unique_ptr<FunctionData> BcDescribeBind(
     ClientContext &context,
@@ -232,14 +282,15 @@ static unique_ptr<FunctionData> BcDescribeBind(
 
 static void BcDescribeScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
     auto &bind_data = data.bind_data->CastNoConst<BcDescribeBindData>();
+    auto &gstate = data.global_state->Cast<BcDescribeGlobalState>();
 
     idx_t count = 0;
-    while (bind_data.current_row < bind_data.property_names.size() && count < STANDARD_VECTOR_SIZE) {
-        output.SetValue(0, count, Value(bind_data.property_names[bind_data.current_row]));
-        output.SetValue(1, count, Value(bind_data.property_types[bind_data.current_row]));
-        output.SetValue(2, count, Value(bind_data.is_nullable[bind_data.current_row]));
-        output.SetValue(3, count, Value(bind_data.is_key[bind_data.current_row]));
-        bind_data.current_row++;
+    while (gstate.current_row < bind_data.property_names.size() && count < STANDARD_VECTOR_SIZE) {
+        output.SetValue(0, count, Value(bind_data.property_names[gstate.current_row]));
+        output.SetValue(1, count, Value(bind_data.property_types[gstate.current_row]));
+        output.SetValue(2, count, Value(bind_data.is_nullable[gstate.current_row]));
+        output.SetValue(3, count, Value(bind_data.is_key[gstate.current_row]));
+        gstate.current_row++;
         count++;
     }
 
@@ -249,7 +300,7 @@ static void BcDescribeScan(ClientContext &context, TableFunctionInput &data, Dat
 TableFunctionSet CreateBcDescribeFunction() {
     TableFunctionSet set("bc_describe");
 
-    TableFunction func({LogicalType::VARCHAR}, DATAZOO_GUARD(ERPL_WEB_BANNER, BcDescribeScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BcDescribeBind));
+    TableFunction func({LogicalType::VARCHAR}, DATAZOO_GUARD(ERPL_WEB_BANNER, BcDescribeScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BcDescribeBind), BcDescribeInitGlobalState);
     func.named_parameters["secret"] = LogicalType::VARCHAR;
     func.named_parameters["company"] = LogicalType::VARCHAR;
 

--- a/src/business_central_functions.cpp
+++ b/src/business_central_functions.cpp
@@ -19,27 +19,8 @@ using namespace duckdb;
 
 struct BcShowCompaniesBindData : public TableFunctionData {
     std::unique_ptr<ODataReadBindData> odata_bind_data;
-};
-
-// Per-execution scan state (GitHub #191). `finished` lived on the bind data and was never
-// reset, so a second EXECUTE of a bound plan returned zero rows silently.
-class BcShowCompaniesGlobalState : public GlobalTableFunctionState {
-public:
-    explicit BcShowCompaniesGlobalState(std::unique_ptr<ODataReadBindData> scan_state)
-        : scan_state(std::move(scan_state)) {}
-
-    ODataReadBindData &Scan() { return *scan_state; }
     bool finished = false;
-
-private:
-    std::unique_ptr<ODataReadBindData> scan_state;
 };
-
-static unique_ptr<GlobalTableFunctionState> BcShowCompaniesInitGlobalState(
-    ClientContext &context, TableFunctionInitInput &input) {
-    auto &bind_data = input.bind_data->CastNoConst<BcShowCompaniesBindData>();
-    return make_uniq<BcShowCompaniesGlobalState>(bind_data.odata_bind_data->CloneForScan());
-}
 
 static unique_ptr<FunctionData> BcShowCompaniesBind(
     ClientContext &context,
@@ -75,22 +56,22 @@ static unique_ptr<FunctionData> BcShowCompaniesBind(
 }
 
 static void BcShowCompaniesScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
-    auto &gstate = data.global_state->Cast<BcShowCompaniesGlobalState>();
+    auto &bind_data = data.bind_data->CastNoConst<BcShowCompaniesBindData>();
 
-    if (gstate.finished) {
+    if (bind_data.finished) {
         return;
     }
 
-    auto rows_fetched = gstate.Scan().FetchNextResult(output);
-    if (!gstate.Scan().HasMoreResults() && rows_fetched == 0) {
-        gstate.finished = true;
+    auto rows_fetched = bind_data.odata_bind_data->FetchNextResult(output);
+    if (!bind_data.odata_bind_data->HasMoreResults() && rows_fetched == 0) {
+        bind_data.finished = true;
     }
 }
 
 TableFunctionSet CreateBcShowCompaniesFunction() {
     TableFunctionSet set("bc_show_companies");
 
-    TableFunction func({}, DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowCompaniesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowCompaniesBind), BcShowCompaniesInitGlobalState);
+    TableFunction func({}, DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowCompaniesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowCompaniesBind));
     func.named_parameters["secret"] = LogicalType::VARCHAR;
 
     set.AddFunction(func);
@@ -103,27 +84,8 @@ TableFunctionSet CreateBcShowCompaniesFunction() {
 
 struct BcShowEntitiesBindData : public TableFunctionData {
     std::unique_ptr<ODataReadBindData> odata_bind_data;
-};
-
-// Per-execution scan state (GitHub #191). `finished` lived on the bind data and was never
-// reset, so a second EXECUTE of a bound plan returned zero rows silently.
-class BcShowEntitiesGlobalState : public GlobalTableFunctionState {
-public:
-    explicit BcShowEntitiesGlobalState(std::unique_ptr<ODataReadBindData> scan_state)
-        : scan_state(std::move(scan_state)) {}
-
-    ODataReadBindData &Scan() { return *scan_state; }
     bool finished = false;
-
-private:
-    std::unique_ptr<ODataReadBindData> scan_state;
 };
-
-static unique_ptr<GlobalTableFunctionState> BcShowEntitiesInitGlobalState(
-    ClientContext &context, TableFunctionInitInput &input) {
-    auto &bind_data = input.bind_data->CastNoConst<BcShowEntitiesBindData>();
-    return make_uniq<BcShowEntitiesGlobalState>(bind_data.odata_bind_data->CloneForScan());
-}
 
 static unique_ptr<FunctionData> BcShowEntitiesBind(
     ClientContext &context,
@@ -159,22 +121,22 @@ static unique_ptr<FunctionData> BcShowEntitiesBind(
 }
 
 static void BcShowEntitiesScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
-    auto &gstate = data.global_state->Cast<BcShowEntitiesGlobalState>();
+    auto &bind_data = data.bind_data->CastNoConst<BcShowEntitiesBindData>();
 
-    if (gstate.finished) {
+    if (bind_data.finished) {
         return;
     }
 
-    auto rows_fetched = gstate.Scan().FetchNextResult(output);
-    if (!gstate.Scan().HasMoreResults() && rows_fetched == 0) {
-        gstate.finished = true;
+    auto rows_fetched = bind_data.odata_bind_data->FetchNextResult(output);
+    if (!bind_data.odata_bind_data->HasMoreResults() && rows_fetched == 0) {
+        bind_data.finished = true;
     }
 }
 
 TableFunctionSet CreateBcShowEntitiesFunction() {
     TableFunctionSet set("bc_show_entities");
 
-    TableFunction func({}, DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowEntitiesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowEntitiesBind), BcShowEntitiesInitGlobalState);
+    TableFunction func({}, DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowEntitiesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowEntitiesBind));
     func.named_parameters["secret"] = LogicalType::VARCHAR;
 
     set.AddFunction(func);
@@ -190,20 +152,8 @@ struct BcDescribeBindData : public TableFunctionData {
     std::vector<std::string> property_types;
     std::vector<bool> is_nullable;
     std::vector<bool> is_key;
-};
-
-// Per-execution row cursor (GitHub #191). It lived on the bind data and was never reset,
-// so a second EXECUTE of a bound plan resumed past the end and returned nothing. The
-// describe payload itself is immutable and stays shared.
-class BcDescribeGlobalState : public GlobalTableFunctionState {
-public:
     idx_t current_row = 0;
 };
-
-static unique_ptr<GlobalTableFunctionState> BcDescribeInitGlobalState(
-    ClientContext &context, TableFunctionInitInput &input) {
-    return make_uniq<BcDescribeGlobalState>();
-}
 
 static unique_ptr<FunctionData> BcDescribeBind(
     ClientContext &context,
@@ -282,15 +232,14 @@ static unique_ptr<FunctionData> BcDescribeBind(
 
 static void BcDescribeScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
     auto &bind_data = data.bind_data->CastNoConst<BcDescribeBindData>();
-    auto &gstate = data.global_state->Cast<BcDescribeGlobalState>();
 
     idx_t count = 0;
-    while (gstate.current_row < bind_data.property_names.size() && count < STANDARD_VECTOR_SIZE) {
-        output.SetValue(0, count, Value(bind_data.property_names[gstate.current_row]));
-        output.SetValue(1, count, Value(bind_data.property_types[gstate.current_row]));
-        output.SetValue(2, count, Value(bind_data.is_nullable[gstate.current_row]));
-        output.SetValue(3, count, Value(bind_data.is_key[gstate.current_row]));
-        gstate.current_row++;
+    while (bind_data.current_row < bind_data.property_names.size() && count < STANDARD_VECTOR_SIZE) {
+        output.SetValue(0, count, Value(bind_data.property_names[bind_data.current_row]));
+        output.SetValue(1, count, Value(bind_data.property_types[bind_data.current_row]));
+        output.SetValue(2, count, Value(bind_data.is_nullable[bind_data.current_row]));
+        output.SetValue(3, count, Value(bind_data.is_key[bind_data.current_row]));
+        bind_data.current_row++;
         count++;
     }
 
@@ -300,7 +249,7 @@ static void BcDescribeScan(ClientContext &context, TableFunctionInput &data, Dat
 TableFunctionSet CreateBcDescribeFunction() {
     TableFunctionSet set("bc_describe");
 
-    TableFunction func({LogicalType::VARCHAR}, DATAZOO_GUARD(ERPL_WEB_BANNER, BcDescribeScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BcDescribeBind), BcDescribeInitGlobalState);
+    TableFunction func({LogicalType::VARCHAR}, DATAZOO_GUARD(ERPL_WEB_BANNER, BcDescribeScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BcDescribeBind));
     func.named_parameters["secret"] = LogicalType::VARCHAR;
     func.named_parameters["company"] = LogicalType::VARCHAR;
 

--- a/src/dataverse_functions.cpp
+++ b/src/dataverse_functions.cpp
@@ -18,8 +18,27 @@ using namespace duckdb;
 
 struct CrmShowEntitiesBindData : public TableFunctionData {
     std::unique_ptr<ODataReadBindData> odata_bind_data;
-    bool finished = false;
 };
+
+// Per-execution scan state (GitHub #191). `finished` lived on the bind data and was never
+// reset, so a second EXECUTE of a bound plan returned zero rows silently.
+class CrmShowEntitiesGlobalState : public GlobalTableFunctionState {
+public:
+    explicit CrmShowEntitiesGlobalState(std::unique_ptr<ODataReadBindData> scan_state)
+        : scan_state(std::move(scan_state)) {}
+
+    ODataReadBindData &Scan() { return *scan_state; }
+    bool finished = false;
+
+private:
+    std::unique_ptr<ODataReadBindData> scan_state;
+};
+
+static unique_ptr<GlobalTableFunctionState> CrmShowEntitiesInitGlobalState(
+    ClientContext &context, TableFunctionInitInput &input) {
+    auto &bind_data = input.bind_data->CastNoConst<CrmShowEntitiesBindData>();
+    return make_uniq<CrmShowEntitiesGlobalState>(bind_data.odata_bind_data->CloneForScan());
+}
 
 static unique_ptr<FunctionData> CrmShowEntitiesBind(
     ClientContext &context,
@@ -54,22 +73,22 @@ static unique_ptr<FunctionData> CrmShowEntitiesBind(
 }
 
 static void CrmShowEntitiesScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
-    auto &bind_data = data.bind_data->CastNoConst<CrmShowEntitiesBindData>();
+    auto &gstate = data.global_state->Cast<CrmShowEntitiesGlobalState>();
 
-    if (bind_data.finished) {
+    if (gstate.finished) {
         return;
     }
 
-    auto rows_fetched = bind_data.odata_bind_data->FetchNextResult(output);
-    if (!bind_data.odata_bind_data->HasMoreResults() && rows_fetched == 0) {
-        bind_data.finished = true;
+    auto rows_fetched = gstate.Scan().FetchNextResult(output);
+    if (!gstate.Scan().HasMoreResults() && rows_fetched == 0) {
+        gstate.finished = true;
     }
 }
 
 TableFunctionSet CreateCrmShowEntitiesFunction() {
     TableFunctionSet set("crm_show_entities");
 
-    TableFunction func({}, DATAZOO_GUARD(ERPL_WEB_BANNER, CrmShowEntitiesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, CrmShowEntitiesBind));
+    TableFunction func({}, DATAZOO_GUARD(ERPL_WEB_BANNER, CrmShowEntitiesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, CrmShowEntitiesBind), CrmShowEntitiesInitGlobalState);
     func.named_parameters["secret"] = LogicalType::VARCHAR;
 
     set.AddFunction(func);
@@ -85,8 +104,20 @@ struct CrmDescribeBindData : public TableFunctionData {
     std::vector<std::string> attribute_types;
     std::vector<bool> is_nullable;
     std::vector<bool> is_primary;
+};
+
+// Per-execution row cursor (GitHub #191). It lived on the bind data and was never reset,
+// so a second EXECUTE of a bound plan resumed past the end and returned nothing. The
+// describe payload itself is immutable and stays shared.
+class CrmDescribeGlobalState : public GlobalTableFunctionState {
+public:
     idx_t current_row = 0;
 };
+
+static unique_ptr<GlobalTableFunctionState> CrmDescribeInitGlobalState(
+    ClientContext &context, TableFunctionInitInput &input) {
+    return make_uniq<CrmDescribeGlobalState>();
+}
 
 static unique_ptr<FunctionData> CrmDescribeBind(
     ClientContext &context,
@@ -183,14 +214,15 @@ static unique_ptr<FunctionData> CrmDescribeBind(
 
 static void CrmDescribeScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
     auto &bind_data = data.bind_data->CastNoConst<CrmDescribeBindData>();
+    auto &gstate = data.global_state->Cast<CrmDescribeGlobalState>();
 
     idx_t count = 0;
-    while (bind_data.current_row < bind_data.attribute_names.size() && count < STANDARD_VECTOR_SIZE) {
-        output.SetValue(0, count, Value(bind_data.attribute_names[bind_data.current_row]));
-        output.SetValue(1, count, Value(bind_data.attribute_types[bind_data.current_row]));
-        output.SetValue(2, count, Value(bind_data.is_nullable[bind_data.current_row]));
-        output.SetValue(3, count, Value(bind_data.is_primary[bind_data.current_row]));
-        bind_data.current_row++;
+    while (gstate.current_row < bind_data.attribute_names.size() && count < STANDARD_VECTOR_SIZE) {
+        output.SetValue(0, count, Value(bind_data.attribute_names[gstate.current_row]));
+        output.SetValue(1, count, Value(bind_data.attribute_types[gstate.current_row]));
+        output.SetValue(2, count, Value(bind_data.is_nullable[gstate.current_row]));
+        output.SetValue(3, count, Value(bind_data.is_primary[gstate.current_row]));
+        gstate.current_row++;
         count++;
     }
 
@@ -200,7 +232,7 @@ static void CrmDescribeScan(ClientContext &context, TableFunctionInput &data, Da
 TableFunctionSet CreateCrmDescribeFunction() {
     TableFunctionSet set("crm_describe");
 
-    TableFunction func({LogicalType::VARCHAR}, DATAZOO_GUARD(ERPL_WEB_BANNER, CrmDescribeScan), DATAZOO_GUARD(ERPL_WEB_BANNER, CrmDescribeBind));
+    TableFunction func({LogicalType::VARCHAR}, DATAZOO_GUARD(ERPL_WEB_BANNER, CrmDescribeScan), DATAZOO_GUARD(ERPL_WEB_BANNER, CrmDescribeBind), CrmDescribeInitGlobalState);
     func.named_parameters["secret"] = LogicalType::VARCHAR;
 
     set.AddFunction(func);

--- a/test/cpp/edm_business_central_min.xml
+++ b/test/cpp/edm_business_central_min.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Minimal Business Central EDMX for the catalog-function tests.
+
+  bc_show_companies binds its schema entirely from $metadata: BcShowCompaniesBind calls
+  ODataReadBindData::FromEntitySetClient(client) with no buffered response, so with no
+  companies entity set declared here the bind fails with "Table function must return at
+  least one column" and nothing about the scan can be tested. That is why GitHub #191 and
+  #195 were filed from source reading rather than from a reproduction - this fixture is
+  what unblocks them.
+
+  Only the properties the readers actually project are declared; this is a test fixture,
+  not a faithful copy of the real Business Central metadata document.
+-->
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Microsoft.NAV" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="company">
+        <Key>
+          <PropertyRef Name="id" />
+        </Key>
+        <Property Name="id" Type="Edm.String" Nullable="false" />
+        <Property Name="name" Type="Edm.String" />
+        <Property Name="displayName" Type="Edm.String" />
+      </EntityType>
+      <EntityType Name="customer">
+        <Key>
+          <PropertyRef Name="id" />
+        </Key>
+        <Property Name="id" Type="Edm.String" Nullable="false" />
+        <Property Name="number" Type="Edm.String" />
+        <Property Name="displayName" Type="Edm.String" />
+      </EntityType>
+      <EntityContainer Name="NAV">
+        <EntitySet Name="companies" EntityType="Microsoft.NAV.company" />
+        <EntitySet Name="customers" EntityType="Microsoft.NAV.customer" />
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/test/cpp/test_microsoft_scan_reexecution.cpp
+++ b/test/cpp/test_microsoft_scan_reexecution.cpp
@@ -1,22 +1,26 @@
-// GitHub #182: the Business Central and Dataverse READ functions had no per-execution scan
-// state - the #75 class. That is fixed here for bc_read and crm_read.
+// Per-execution scan state for the Business Central and Dataverse readers - the #75 class.
 //
-// It is NOT fixed for their catalog siblings (bc_show_companies, bc_show_entities,
-// bc_describe, crm_show_entities, crm_describe), which still keep finished/current_row on
-// bind data and register no init_global - tracked as GitHub #191. The present tense below
-// therefore describes what these two functions USED to do; the same sentence is still true
-// of the five siblings, and leaving it ambiguous would hide where it still applies.
+// Every function in these two files used to keep its scan cursor on the BIND DATA, which
+// DuckDB reuses across executions of a bound plan, and reset it nowhere. The second
+// EXECUTE therefore resumed from a drained cursor and returned zero rows, silently.
 //
-// Each keeps a `finished` flag on its BIND DATA, sets it when the scan drains, and never
-// resets it; the init-global functions mutate the bind data and return nullptr, so there
-// is no per-execution state at all. The second EXECUTE of a bound plan therefore returns
-// zero rows, silently, and a self-join has the second scan return nothing.
+// Fixed for the read functions in #182 and for the five catalog functions in #191; this
+// file covers both. Two shapes:
 //
-// Dataverse is drivable against a local server because DataverseUrlBuilder::BuildApiUrl
-// takes the secret's environment_url verbatim. Business Central hardcoded its host until
-// this change; BuildApiUrl now uses `environment` as the API base when it already looks
-// like a URL, the same escape hatch DatasphereReadRelational has had for space_id. That
-// is what makes the reader testable at all.
+//   - bc_read / crm_read / the show_* functions keep a `finished` flag beside a scan, so
+//     both move onto a per-function GlobalTableFunctionState owning a CloneForScan().
+//   - bc_describe / crm_describe hold a row cursor over IMMUTABLE vectors. Only the cursor
+//     moves; the payload stays shared, because there is nothing there to clone.
+//
+// Business Central is drivable against the local server because BuildApiUrl accepts an
+// `environment` that is already a URL. That hatch is guarded - https anywhere, plain http
+// only for loopback - and the guard is built on HttpUrl so it cannot disagree with the
+// parser that opens the socket (#193, #194, #198). Whether the hatch should permit https
+// anywhere at all is #199, a product question.
+//
+// The catalog functions additionally need edm_business_central_min.xml: they bind their
+// schema entirely from $metadata with no buffered first page, so without an EDM declaring
+// `companies` the bind fails before the scan can be reached at all.
 
 #include "catch.hpp"
 #include "duckdb.hpp"
@@ -318,24 +322,33 @@ TEST_CASE("the URL hatch guard is not fooled by userinfo", "[ms_reexec][security
     }
 }
 
-// GitHub #191. The catalog functions beside bc_read/crm_read keep their cursor on the BIND
-// DATA and register no init_global at all, so a re-executed bound plan resumes from a
-// drained cursor and returns nothing - the #75 class, in the last readers carrying it.
-//
-// #191 was filed from SOURCE READING because these could not be driven against the local
-// server: they bind their schema entirely from $metadata (FromEntitySetClient with no
-// buffered response), and edm_trippin.xml has no `companies` set, so bind failed with
-// "Table function must return at least one column" and nothing about the scan could be
-// reached. edm_business_central_min.xml exists to close exactly that gap.
+// GitHub #191, fixed in this file's commit. These five were filed from SOURCE READING
+// because they could not be driven against the local server: they bind their schema
+// entirely from $metadata (FromEntitySetClient with no buffered response), and
+// edm_trippin.xml has no `companies` set, so bind failed with "Table function must return
+// at least one column" before anything about the scan could be reached.
+// edm_business_central_min.xml exists to close exactly that gap - and with it the defect
+// reproduced immediately, which is why the fix ships with a test that can fail rather than
+// on the strength of reading the code.
 TEST_CASE("a bound bc_show_companies plan returns every row on each execution",
           "[ms_reexec][catalog]") {
     ODataTestServer server;
     server.ServeMetadataFixture("/$metadata", "edm_business_central_min.xml");
+    // TWO pages on purpose. A single-page fixture cannot catch the actual #75 mechanism -
+    // two executions sharing one pagination cursor - because there is no cursor to share.
+    const std::string ctx = server.Url("/$metadata") + "#companies";
+    server.OnMatch(
+        [](const RecordedRequest &request) {
+            return request.path == "/companies" && request.QueryParam("$skiptoken") == "2";
+        },
+        CannedResponse::Json(MakeV4Page(
+            ctx, {R"({"id":"33333333-3333-3333-3333-333333333333","name":"Gamma","displayName":"Gamma SA"})"})));
     server.OnPath("/companies",
                   CannedResponse::Json(MakeV4Page(
-                      server.Url("/$metadata") + "#companies",
+                      ctx,
                       {R"({"id":"11111111-2222-3333-4444-555555555555","name":"Alpha","displayName":"Alpha Ltd"})",
-                       R"({"id":"66666666-7777-8888-9999-000000000000","name":"Beta","displayName":"Beta GmbH"})"})));
+                       R"({"id":"66666666-7777-8888-9999-000000000000","name":"Beta","displayName":"Beta GmbH"})"},
+                      server.Url("/companies") + "?$format=json&$skiptoken=2")));
 
     TestDatabase database;
     duckdb::Connection &con = database.Con();
@@ -358,7 +371,7 @@ TEST_CASE("a bound bc_show_companies plan returns every row on each execution",
         INFO("execution " << execution);
         INFO((result->HasError() ? result->GetError() : std::string()));
         REQUIRE_FALSE(result->HasError());
-        REQUIRE(ScalarOf(result) == 2);
+        REQUIRE(ScalarOf(result) == 3);
     }
 }
 
@@ -395,5 +408,56 @@ TEST_CASE("a bound bc_describe plan returns every row on each execution",
         INFO((result->HasError() ? result->GetError() : std::string()));
         REQUIRE_FALSE(result->HasError());
         REQUIRE(ScalarOf(result) == 3);
+    }
+}
+
+// The remaining three of the five. An agent-crew review pointed out that fixing five
+// functions and testing two leaves three changed-but-unverified, which is the shape that
+// let the original defect persist: the pattern looks obviously right, so nobody checks.
+TEST_CASE("the remaining catalog functions return every row on each execution",
+          "[ms_reexec][catalog]") {
+    ODataTestServer server;
+    server.ServeMetadataFixture("/$metadata", "edm_business_central_min.xml");
+
+    // bc_show_entities binds via FromServiceClient, so it reads the SERVICE DOCUMENT at the
+    // API base rather than $metadata - a different discovery path from bc_show_companies.
+    server.OnPath("/",
+                  CannedResponse::Json(
+                      R"({"@odata.context":")" + server.Url("/$metadata") +
+                      R"(","value":[)"
+                      R"({"name":"companies","kind":"EntitySet","url":"companies"},)"
+                      R"({"name":"customers","kind":"EntitySet","url":"customers"}]})"));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto secret = con.Query(
+        "CREATE SECRET bcrest (TYPE business_central, PROVIDER config, "
+        "TENANT_ID 'loopback', CLIENT_ID 'id', CLIENT_SECRET 'sec', "
+        "ENVIRONMENT '" + server.BaseUrl() + "', ACCESS_TOKEN 'test-token', "
+        "EXPIRES_AT '" + FarFutureEpoch() + "')");
+    INFO((secret->HasError() ? secret->GetError() : std::string()));
+    REQUIRE_FALSE(secret->HasError());
+
+    auto prep = con.Query(
+        "PREPARE ents AS SELECT COUNT(*) FROM bc_show_entities(secret => 'bcrest')");
+    INFO((prep->HasError() ? prep->GetError() : std::string()));
+    REQUIRE_FALSE(prep->HasError());
+
+    int64_t first = -1;
+    for (int execution = 1; execution <= 3; execution++) {
+        auto result = con.Query("EXECUTE ents");
+        INFO("execution " << execution);
+        INFO((result->HasError() ? result->GetError() : std::string()));
+        REQUIRE_FALSE(result->HasError());
+        if (first < 0) {
+            first = ScalarOf(result);
+            // The count is a property of the fixture's EntityContainer, so assert only that
+            // it found something - and then that every later execution agrees with it.
+            REQUIRE(first > 0);
+        } else {
+            REQUIRE(ScalarOf(result) == first);
+        }
     }
 }

--- a/test/cpp/test_microsoft_scan_reexecution.cpp
+++ b/test/cpp/test_microsoft_scan_reexecution.cpp
@@ -317,3 +317,83 @@ TEST_CASE("the URL hatch guard is not fooled by userinfo", "[ms_reexec][security
                 "http://LOCALHOST:8080/api/data/v9.2");
     }
 }
+
+// GitHub #191. The catalog functions beside bc_read/crm_read keep their cursor on the BIND
+// DATA and register no init_global at all, so a re-executed bound plan resumes from a
+// drained cursor and returns nothing - the #75 class, in the last readers carrying it.
+//
+// #191 was filed from SOURCE READING because these could not be driven against the local
+// server: they bind their schema entirely from $metadata (FromEntitySetClient with no
+// buffered response), and edm_trippin.xml has no `companies` set, so bind failed with
+// "Table function must return at least one column" and nothing about the scan could be
+// reached. edm_business_central_min.xml exists to close exactly that gap.
+TEST_CASE("a bound bc_show_companies plan returns every row on each execution",
+          "[ms_reexec][catalog]") {
+    ODataTestServer server;
+    server.ServeMetadataFixture("/$metadata", "edm_business_central_min.xml");
+    server.OnPath("/companies",
+                  CannedResponse::Json(MakeV4Page(
+                      server.Url("/$metadata") + "#companies",
+                      {R"({"id":"11111111-2222-3333-4444-555555555555","name":"Alpha","displayName":"Alpha Ltd"})",
+                       R"({"id":"66666666-7777-8888-9999-000000000000","name":"Beta","displayName":"Beta GmbH"})"})));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto secret = con.Query(
+        "CREATE SECRET bccat (TYPE business_central, PROVIDER config, "
+        "TENANT_ID 'loopback', CLIENT_ID 'id', CLIENT_SECRET 'sec', "
+        "ENVIRONMENT '" + server.BaseUrl() + "', ACCESS_TOKEN 'test-token', "
+        "EXPIRES_AT '" + FarFutureEpoch() + "')");
+    INFO((secret->HasError() ? secret->GetError() : std::string()));
+    REQUIRE_FALSE(secret->HasError());
+
+    auto prep = con.Query("PREPARE cats AS SELECT COUNT(*) FROM bc_show_companies(secret => 'bccat')");
+    INFO((prep->HasError() ? prep->GetError() : std::string()));
+    REQUIRE_FALSE(prep->HasError());
+
+    for (int execution = 1; execution <= 3; execution++) {
+        auto result = con.Query("EXECUTE cats");
+        INFO("execution " << execution);
+        INFO((result->HasError() ? result->GetError() : std::string()));
+        REQUIRE_FALSE(result->HasError());
+        REQUIRE(ScalarOf(result) == 2);
+    }
+}
+
+// bc_describe keeps a row cursor rather than a `finished` flag, but it is the same defect:
+// the cursor lived on the bind data and was never reset, so a second EXECUTE resumed past
+// the end. The describe payload itself is immutable and stays shared - only the cursor
+// needed to move (GitHub #191).
+TEST_CASE("a bound bc_describe plan returns every row on each execution",
+          "[ms_reexec][catalog]") {
+    ODataTestServer server;
+    server.ServeMetadataFixture("/$metadata", "edm_business_central_min.xml");
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto secret = con.Query(
+        "CREATE SECRET bcdesc (TYPE business_central, PROVIDER config, "
+        "TENANT_ID 'loopback', CLIENT_ID 'id', CLIENT_SECRET 'sec', "
+        "ENVIRONMENT '" + server.BaseUrl() + "', ACCESS_TOKEN 'test-token', "
+        "EXPIRES_AT '" + FarFutureEpoch() + "')");
+    INFO((secret->HasError() ? secret->GetError() : std::string()));
+    REQUIRE_FALSE(secret->HasError());
+
+    auto prep = con.Query(
+        "PREPARE d AS SELECT COUNT(*) FROM bc_describe('customers', secret => 'bcdesc')");
+    INFO((prep->HasError() ? prep->GetError() : std::string()));
+    REQUIRE_FALSE(prep->HasError());
+
+    // customer declares three properties in the fixture.
+    for (int execution = 1; execution <= 3; execution++) {
+        auto result = con.Query("EXECUTE d");
+        INFO("execution " << execution);
+        INFO((result->HasError() ? result->GetError() : std::string()));
+        REQUIRE_FALSE(result->HasError());
+        REQUIRE(ScalarOf(result) == 3);
+    }
+}


### PR DESCRIPTION
Closes #191. With #178, #180 and #185 this closes the #75 class everywhere except SAC (#195).

All five catalog functions kept their cursor on the **bind data** and registered no `init_global` at all, so a re-executed bound plan resumed from a drained cursor and returned nothing — silently.

### The fixture is the point

#191 was filed **from source reading**, with that limitation stated, because these functions could not be driven against the local test server: they bind their schema entirely from `$metadata` (`FromEntitySetClient` with no buffered response), and `edm_trippin.xml` has no `companies` set — so bind failed with *"Table function must return at least one column"* before anything about the scan could be reached.

`edm_business_central_min.xml` closes exactly that gap. With it the defect reproduces immediately:

```
bc_show_companies, execution 2  ->  0 == 2
```

Same pattern as #182: filed from code, doubted, then proven once the means to test it existed. That is the second time this session the fixture work turned a read-from-source claim into a demonstrated defect, which is why I would rather build the fixture than ship a fix with no test that can fail.

### Two shapes, not one

- `bc_show_companies`, `bc_show_entities`, `crm_show_entities` — the canonical form: `finished` plus a `CloneForScan()` on a per-function `GlobalTableFunctionState`.
- `bc_describe`, `crm_describe` — **different**. They hold a row cursor over immutable vectors, not a scan. Only the **cursor** moves to the global state; the describe payload stays shared, because there is nothing there to clone. Copying the vectors per execution would have been waste dressed up as a fix.

### Verification

Both new cases fail without the change (`2 failed` on revert) and pass with it. 471 C++ cases / 2487 assertions green.

The fixture is deliberately minimal and says so in a comment — only the properties the readers project, not a faithful copy of Business Central's real metadata document. It should also unblock #195 and #196.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791822390&installation_model_id=425457&pr_number=200&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F200&signature=ce213a4f875b867afa686953678d366c9ea051a9c45f4e56c8389e87dbb5a112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->