### PR TITLE
fix: give the SAC catalog functions per-execution scan state (#195)

### DIFF
--- a/src/include/sac_generic_bind_data.hpp
+++ b/src/include/sac_generic_bind_data.hpp
@@ -7,6 +7,29 @@
 namespace erpl_web {
 
 /**
+ * Per-execution scan state for the SAC catalog functions (GitHub #195).
+ *
+ * The cursor used to live on the bind data, which DuckDB reuses across executions of a
+ * bound plan. Nothing reset it, so a second EXECUTE resumed past the end of the vector and
+ * returned no rows - silently, the #75 class.
+ *
+ * Only the CURSOR belongs here. The items themselves are fetched once at bind and never
+ * mutated, so they stay on the bind data and are shared; copying them per execution would
+ * be waste dressed up as a fix. Same reasoning as bc_describe / crm_describe in #191.
+ */
+class SacScanGlobalState : public duckdb::GlobalTableFunctionState {
+public:
+    size_t current_index = 0;
+    bool finished = false;
+};
+
+inline duckdb::unique_ptr<duckdb::GlobalTableFunctionState> SacScanInitGlobalState(
+    duckdb::ClientContext &, duckdb::TableFunctionInitInput &) {
+    return duckdb::make_uniq<SacScanGlobalState>();
+}
+
+
+/**
  * Generic bind data template for SAC catalog table functions
  *
  * Consolidates common pattern across all SAC catalog functions:
@@ -22,8 +45,12 @@ template <typename ItemType>
 class SacGenericBindData : public duckdb::TableFunctionData {
 public:
     std::vector<ItemType> items;       // Collection of items (models, stories, etc.)
-    size_t current_index = 0;          // Current iteration position
-    bool finished = false;             // Scan completion flag
+
+    // NOT the scan cursor. Per-execution position lives on SacScanGlobalState above; a
+    // cursor here is shared across executions of a bound plan and made the second EXECUTE
+    // return nothing (GitHub #195). Kept only so existing constructions still compile.
+    size_t current_index = 0;
+    bool finished = false;
 
     SacGenericBindData() = default;
     virtual ~SacGenericBindData() = default;

--- a/src/sac_catalog.cpp
+++ b/src/sac_catalog.cpp
@@ -268,10 +268,11 @@ using SacShowModelsBindData = SacGenericBindData<SacModel>;
 static void SacShowModelsScan(duckdb::ClientContext &context, duckdb::TableFunctionInput &data_p,
                               duckdb::DataChunk &output) {
     auto &bind_data = data_p.bind_data->CastNoConst<SacShowModelsBindData>();
+    auto &gstate = data_p.global_state->Cast<SacScanGlobalState>();
 
     idx_t count = 0;
-    while (bind_data.current_index < bind_data.items.size() && count < output.GetCapacity()) {
-        const auto &model = bind_data.items[bind_data.current_index];
+    while (gstate.current_index < bind_data.items.size() && count < output.GetCapacity()) {
+        const auto &model = bind_data.items[gstate.current_index];
 
         SetStrCellNN(output.data[0], count, model.id.c_str());
         SetStrCellNN(output.data[1], count, model.name.c_str());
@@ -281,11 +282,11 @@ static void SacShowModelsScan(duckdb::ClientContext &context, duckdb::TableFunct
         SetStrCellNN(output.data[5], count, model.created_at.c_str());
         SetStrCellNN(output.data[6], count, model.last_modified_at.c_str());
 
-        bind_data.current_index++;
+        gstate.current_index++;
         count++;
     }
 
-    bind_data.finished = (bind_data.current_index >= bind_data.items.size());
+    gstate.finished = (gstate.current_index >= bind_data.items.size());
     output.SetCardinality(count);
 }
 
@@ -325,7 +326,8 @@ duckdb::TableFunctionSet CreateSacShowModelsFunction() {
         {},  // No parameters
         SacShowModelsScan,
         SacShowModelsBind
-    );
+    ,
+        SacScanInitGlobalState);
 
     // Add optional named parameter for secret name
     func.named_parameters["secret"] = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
@@ -342,10 +344,11 @@ using SacShowStoriesBindData = SacGenericBindData<SacStory>;
 static void SacShowStoriesScan(duckdb::ClientContext &context, duckdb::TableFunctionInput &data_p,
                                duckdb::DataChunk &output) {
     auto &bind_data = data_p.bind_data->CastNoConst<SacShowStoriesBindData>();
+    auto &gstate = data_p.global_state->Cast<SacScanGlobalState>();
 
     idx_t count = 0;
-    while (bind_data.current_index < bind_data.items.size() && count < output.GetCapacity()) {
-        const auto &story = bind_data.items[bind_data.current_index];
+    while (gstate.current_index < bind_data.items.size() && count < output.GetCapacity()) {
+        const auto &story = bind_data.items[gstate.current_index];
 
         SetStrCellNN(output.data[0], count, story.id.c_str());
         SetStrCellNN(output.data[1], count, story.name.c_str());
@@ -355,11 +358,11 @@ static void SacShowStoriesScan(duckdb::ClientContext &context, duckdb::TableFunc
         SetStrCellNN(output.data[5], count, story.last_modified_at.c_str());
         SetStrCellNN(output.data[6], count, story.status.c_str());
 
-        bind_data.current_index++;
+        gstate.current_index++;
         count++;
     }
 
-    bind_data.finished = (bind_data.current_index >= bind_data.items.size());
+    gstate.finished = (gstate.current_index >= bind_data.items.size());
     output.SetCardinality(count);
 }
 
@@ -398,7 +401,8 @@ duckdb::TableFunctionSet CreateSacShowStoriesFunction() {
         {},  // No parameters
         SacShowStoriesScan,
         SacShowStoriesBind
-    );
+    ,
+        SacScanInitGlobalState);
 
     func.named_parameters["secret"] = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
 
@@ -414,17 +418,18 @@ using SacGetModelInfoBindData = SacItemWithDetailsBindData<SacModel>;
 static void SacGetModelInfoScan(duckdb::ClientContext &context, duckdb::TableFunctionInput &data_p,
                                 duckdb::DataChunk &output) {
     auto &bind_data = data_p.bind_data->CastNoConst<SacGetModelInfoBindData>();
+    auto &gstate = data_p.global_state->Cast<SacScanGlobalState>();
 
     if (!bind_data.item_found) {
         output.SetCardinality(0);
-        bind_data.finished = true;
+        gstate.finished = true;
         return;
     }
 
     idx_t count = 0;
 
     // Output one row for the model with dimension list
-    if (bind_data.current_index == 0) {
+    if (gstate.current_index == 0) {
         // Build dimension list as comma-separated string
         std::string dims_str;
         for (size_t i = 0; i < bind_data.details.size(); ++i) {
@@ -439,11 +444,11 @@ static void SacGetModelInfoScan(duckdb::ClientContext &context, duckdb::TableFun
         SetStrCellNN(output.data[4], 0, dims_str.c_str());
         SetStrCellNN(output.data[5], 0, bind_data.item.created_at.c_str());
 
-        bind_data.current_index++;
+        gstate.current_index++;
         count = 1;
     }
 
-    bind_data.finished = true;
+    gstate.finished = true;
     output.SetCardinality(count);
 }
 
@@ -491,7 +496,8 @@ duckdb::TableFunctionSet CreateSacGetModelInfoFunction() {
         {duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR)},  // model_id
         SacGetModelInfoScan,
         SacGetModelInfoBind
-    );
+    ,
+        SacScanInitGlobalState);
 
     func.named_parameters["secret"] = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
 
@@ -507,16 +513,17 @@ using SacGetStoryInfoBindData = SacSingleItemBindData<SacStory>;
 static void SacGetStoryInfoScan(duckdb::ClientContext &context, duckdb::TableFunctionInput &data_p,
                                 duckdb::DataChunk &output) {
     auto &bind_data = data_p.bind_data->CastNoConst<SacGetStoryInfoBindData>();
+    auto &gstate = data_p.global_state->Cast<SacScanGlobalState>();
 
     if (!bind_data.item_found) {
         output.SetCardinality(0);
-        bind_data.finished = true;
+        gstate.finished = true;
         return;
     }
 
     idx_t count = 0;
 
-    if (bind_data.current_index == 0) {
+    if (gstate.current_index == 0) {
         SetStrCellNN(output.data[0], 0, bind_data.item.id.c_str());
         SetStrCellNN(output.data[1], 0, bind_data.item.name.c_str());
         SetStrCellNN(output.data[2], 0, bind_data.item.description.c_str());
@@ -525,11 +532,11 @@ static void SacGetStoryInfoScan(duckdb::ClientContext &context, duckdb::TableFun
         SetStrCellNN(output.data[5], 0, bind_data.item.created_at.c_str());
         SetStrCellNN(output.data[6], 0, bind_data.item.last_modified_at.c_str());
 
-        bind_data.current_index++;
+        gstate.current_index++;
         count = 1;
     }
 
-    bind_data.finished = true;
+    gstate.finished = true;
     output.SetCardinality(count);
 }
 
@@ -576,7 +583,8 @@ duckdb::TableFunctionSet CreateSacGetStoryInfoFunction() {
         {duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR)},  // story_id
         SacGetStoryInfoScan,
         SacGetStoryInfoBind
-    );
+    ,
+        SacScanInitGlobalState);
 
     func.named_parameters["secret"] = duckdb::LogicalType(duckdb::LogicalTypeId::VARCHAR);
 


### PR DESCRIPTION
Closes #195. With #178, #180, #185 and #200 this closes the #75 class across every reader family in the extension.

`sac_show_models`, `sac_show_stories`, `sac_describe_model` and `sac_describe_story` held their cursor on the **bind data** via the shared `SacGenericBindData` / `SacSingleItemBindData` templates and registered no `init_global`, so a re-executed bound plan resumed past the end of the vector and returned nothing — silently.

One `SacScanGlobalState` serves all four, since the templates are shared. **Only the cursor moves.** The items are fetched once at bind and never mutated, so they stay on the bind data; copying them per execution would be waste dressed up as a fix — the same reasoning as `bc_describe` / `crm_describe` in #191.

The cursor fields stay declared on the templates for source compatibility, with a comment saying they are no longer the scan's source of truth so nobody reaches for them again.

## This ships without a test, deliberately — please weigh that

`SacUrlBuilder::BuildBaseUrl` hardcodes `https://{tenant}.{region}.sapanalytics.cloud`. There is no loopback path, so driving these against `ODataTestServer` would require adding **another verbatim-URL hatch** — the exact construct #199 is an open question about. Adding one unilaterally, to make my own change testable, while that question is unresolved, seemed like the wrong trade.

So: the change is mechanical, mirrors a pattern that #191's tests prove (three cases, all red without the fix), the build is green, and no stale bind-data cursor uses remain — **but I have not demonstrated either the defect or the fix.**

That matters because twice this session a finding I filed from source reading turned out to be real only once I built the means to test it (#182, #191), and once a change I was confident in had silently reverted itself while local tests passed. Reading the code is not the same as running it, and I would rather say so than imply coverage this does not have.

**If you would rather this waited for a SAC URL override, say so and I will hold it behind #199.** The alternative is merging a correct-looking fix on the strength of a pattern.

472 C++ cases / 2496 assertions green (the suite, not this path).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791825127&installation_model_id=425457&pr_number=201&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F201&signature=e5f2456dcff102468bfa9a51ab2763e27d2016e739e89fdae534d06d6ccd77df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->