### PR TITLE
fix: restore the Business Central half of #191, and report conversion failures at scan end (#196)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,47 @@ The build system supports **mold linker** for faster linking (macOS/Linux):
 - Can reduce link time by 50-70% compared to default linker
 - Falls back to default linker if mold not found
 
+## Git: never verify a fix against the working tree
+
+`git checkout <ref> -- <path>` updates the **index as well as the working tree**. Restoring
+that file afterwards with `cp` puts it back in the working tree only — the index keeps the
+reverted version, and the next commit silently takes it.
+
+This has silently reverted a committed fix three times in this repo (GitHub #146, #191/#200,
+and the branch that fixed #196). Each time every local test run passed, because the test
+binary is built from the **working tree**: the code that was tested was not the code that was
+committed. `git status` shows nothing once the working tree is restored.
+
+**Red-checking a fix** — temporarily reverting it to prove a test fails — is the operation
+that triggers this, and it is a good practice worth keeping. Do it safely:
+
+```bash
+# Safe: worktree copy, never touches the index of your branch
+cp src/thing.cpp /tmp/thing.keep
+python3 - <<'EOF'   # or sed/patch — anything that writes ONLY the file
+...revert the change in place...
+EOF
+make dev && ./build/debug/... "[tag]"     # expect red
+cp /tmp/thing.keep src/thing.cpp          # restore
+```
+
+Never `git checkout <ref> -- <path>` for this. If you need a pristine copy of another
+revision, redirect it instead — `git show <ref>:<path> > <path>` writes the file without
+touching the index.
+
+**Before pushing any branch, audit what it actually changed:**
+
+```bash
+git diff origin/main HEAD --name-only        # every file the branch touches
+git diff origin/main HEAD -- <file>          # and what it did to each one
+```
+
+A file you only reverted-and-restored will appear here and nowhere else. Checking
+`git status`, or checking only the files you believe you edited, is what failed all three
+times.
+
+---
+
 ## C++ Code Standards & Best Practices
 
 **You must act as a Senior C++ Software Engineer and produce well-readable, maintainable, and high-quality code.**

--- a/src/business_central_functions.cpp
+++ b/src/business_central_functions.cpp
@@ -19,8 +19,27 @@ using namespace duckdb;
 
 struct BcShowCompaniesBindData : public TableFunctionData {
     std::unique_ptr<ODataReadBindData> odata_bind_data;
-    bool finished = false;
 };
+
+// Per-execution scan state (GitHub #191). `finished` lived on the bind data and was never
+// reset, so a second EXECUTE of a bound plan returned zero rows silently.
+class BcShowCompaniesGlobalState : public GlobalTableFunctionState {
+public:
+    explicit BcShowCompaniesGlobalState(std::unique_ptr<ODataReadBindData> scan_state)
+        : scan_state(std::move(scan_state)) {}
+
+    ODataReadBindData &Scan() { return *scan_state; }
+    bool finished = false;
+
+private:
+    std::unique_ptr<ODataReadBindData> scan_state;
+};
+
+static unique_ptr<GlobalTableFunctionState> BcShowCompaniesInitGlobalState(
+    ClientContext &context, TableFunctionInitInput &input) {
+    auto &bind_data = input.bind_data->CastNoConst<BcShowCompaniesBindData>();
+    return make_uniq<BcShowCompaniesGlobalState>(bind_data.odata_bind_data->CloneForScan());
+}
 
 static unique_ptr<FunctionData> BcShowCompaniesBind(
     ClientContext &context,
@@ -56,22 +75,22 @@ static unique_ptr<FunctionData> BcShowCompaniesBind(
 }
 
 static void BcShowCompaniesScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
-    auto &bind_data = data.bind_data->CastNoConst<BcShowCompaniesBindData>();
+    auto &gstate = data.global_state->Cast<BcShowCompaniesGlobalState>();
 
-    if (bind_data.finished) {
+    if (gstate.finished) {
         return;
     }
 
-    auto rows_fetched = bind_data.odata_bind_data->FetchNextResult(output);
-    if (!bind_data.odata_bind_data->HasMoreResults() && rows_fetched == 0) {
-        bind_data.finished = true;
+    auto rows_fetched = gstate.Scan().FetchNextResult(output);
+    if (!gstate.Scan().HasMoreResults() && rows_fetched == 0) {
+        gstate.finished = true;
     }
 }
 
 TableFunctionSet CreateBcShowCompaniesFunction() {
     TableFunctionSet set("bc_show_companies");
 
-    TableFunction func({}, DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowCompaniesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowCompaniesBind));
+    TableFunction func({}, DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowCompaniesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowCompaniesBind), BcShowCompaniesInitGlobalState);
     func.named_parameters["secret"] = LogicalType::VARCHAR;
 
     set.AddFunction(func);
@@ -84,8 +103,27 @@ TableFunctionSet CreateBcShowCompaniesFunction() {
 
 struct BcShowEntitiesBindData : public TableFunctionData {
     std::unique_ptr<ODataReadBindData> odata_bind_data;
-    bool finished = false;
 };
+
+// Per-execution scan state (GitHub #191). `finished` lived on the bind data and was never
+// reset, so a second EXECUTE of a bound plan returned zero rows silently.
+class BcShowEntitiesGlobalState : public GlobalTableFunctionState {
+public:
+    explicit BcShowEntitiesGlobalState(std::unique_ptr<ODataReadBindData> scan_state)
+        : scan_state(std::move(scan_state)) {}
+
+    ODataReadBindData &Scan() { return *scan_state; }
+    bool finished = false;
+
+private:
+    std::unique_ptr<ODataReadBindData> scan_state;
+};
+
+static unique_ptr<GlobalTableFunctionState> BcShowEntitiesInitGlobalState(
+    ClientContext &context, TableFunctionInitInput &input) {
+    auto &bind_data = input.bind_data->CastNoConst<BcShowEntitiesBindData>();
+    return make_uniq<BcShowEntitiesGlobalState>(bind_data.odata_bind_data->CloneForScan());
+}
 
 static unique_ptr<FunctionData> BcShowEntitiesBind(
     ClientContext &context,
@@ -121,22 +159,22 @@ static unique_ptr<FunctionData> BcShowEntitiesBind(
 }
 
 static void BcShowEntitiesScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
-    auto &bind_data = data.bind_data->CastNoConst<BcShowEntitiesBindData>();
+    auto &gstate = data.global_state->Cast<BcShowEntitiesGlobalState>();
 
-    if (bind_data.finished) {
+    if (gstate.finished) {
         return;
     }
 
-    auto rows_fetched = bind_data.odata_bind_data->FetchNextResult(output);
-    if (!bind_data.odata_bind_data->HasMoreResults() && rows_fetched == 0) {
-        bind_data.finished = true;
+    auto rows_fetched = gstate.Scan().FetchNextResult(output);
+    if (!gstate.Scan().HasMoreResults() && rows_fetched == 0) {
+        gstate.finished = true;
     }
 }
 
 TableFunctionSet CreateBcShowEntitiesFunction() {
     TableFunctionSet set("bc_show_entities");
 
-    TableFunction func({}, DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowEntitiesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowEntitiesBind));
+    TableFunction func({}, DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowEntitiesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BcShowEntitiesBind), BcShowEntitiesInitGlobalState);
     func.named_parameters["secret"] = LogicalType::VARCHAR;
 
     set.AddFunction(func);
@@ -152,8 +190,20 @@ struct BcDescribeBindData : public TableFunctionData {
     std::vector<std::string> property_types;
     std::vector<bool> is_nullable;
     std::vector<bool> is_key;
+};
+
+// Per-execution row cursor (GitHub #191). It lived on the bind data and was never reset,
+// so a second EXECUTE of a bound plan resumed past the end and returned nothing. The
+// describe payload itself is immutable and stays shared.
+class BcDescribeGlobalState : public GlobalTableFunctionState {
+public:
     idx_t current_row = 0;
 };
+
+static unique_ptr<GlobalTableFunctionState> BcDescribeInitGlobalState(
+    ClientContext &context, TableFunctionInitInput &input) {
+    return make_uniq<BcDescribeGlobalState>();
+}
 
 static unique_ptr<FunctionData> BcDescribeBind(
     ClientContext &context,
@@ -232,14 +282,15 @@ static unique_ptr<FunctionData> BcDescribeBind(
 
 static void BcDescribeScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
     auto &bind_data = data.bind_data->CastNoConst<BcDescribeBindData>();
+    auto &gstate = data.global_state->Cast<BcDescribeGlobalState>();
 
     idx_t count = 0;
-    while (bind_data.current_row < bind_data.property_names.size() && count < STANDARD_VECTOR_SIZE) {
-        output.SetValue(0, count, Value(bind_data.property_names[bind_data.current_row]));
-        output.SetValue(1, count, Value(bind_data.property_types[bind_data.current_row]));
-        output.SetValue(2, count, Value(bind_data.is_nullable[bind_data.current_row]));
-        output.SetValue(3, count, Value(bind_data.is_key[bind_data.current_row]));
-        bind_data.current_row++;
+    while (gstate.current_row < bind_data.property_names.size() && count < STANDARD_VECTOR_SIZE) {
+        output.SetValue(0, count, Value(bind_data.property_names[gstate.current_row]));
+        output.SetValue(1, count, Value(bind_data.property_types[gstate.current_row]));
+        output.SetValue(2, count, Value(bind_data.is_nullable[gstate.current_row]));
+        output.SetValue(3, count, Value(bind_data.is_key[gstate.current_row]));
+        gstate.current_row++;
         count++;
     }
 
@@ -249,7 +300,7 @@ static void BcDescribeScan(ClientContext &context, TableFunctionInput &data, Dat
 TableFunctionSet CreateBcDescribeFunction() {
     TableFunctionSet set("bc_describe");
 
-    TableFunction func({LogicalType::VARCHAR}, DATAZOO_GUARD(ERPL_WEB_BANNER, BcDescribeScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BcDescribeBind));
+    TableFunction func({LogicalType::VARCHAR}, DATAZOO_GUARD(ERPL_WEB_BANNER, BcDescribeScan), DATAZOO_GUARD(ERPL_WEB_BANNER, BcDescribeBind), BcDescribeInitGlobalState);
     func.named_parameters["secret"] = LogicalType::VARCHAR;
     func.named_parameters["company"] = LogicalType::VARCHAR;
 
@@ -378,6 +429,11 @@ static void BcReadScan(ClientContext &context, TableFunctionInput &data, DataChu
     auto rows_fetched = gstate.Scan().FetchNextResult(output);
     if (!gstate.Scan().HasMoreResults() && rows_fetched == 0) {
         gstate.finished = true;
+        // Report at the terminal exit, as odata_read does, rather than leaving it to the
+        // bind-data destructor: the destructor fires at teardown, so warnings could land
+        // after the result instead of beside it. Name this function, not odata_read
+        // (GitHub #196).
+        gstate.Scan().ReportConversionFailures("bc_read");
     }
 }
 

--- a/src/dataverse_functions.cpp
+++ b/src/dataverse_functions.cpp
@@ -18,8 +18,27 @@ using namespace duckdb;
 
 struct CrmShowEntitiesBindData : public TableFunctionData {
     std::unique_ptr<ODataReadBindData> odata_bind_data;
-    bool finished = false;
 };
+
+// Per-execution scan state (GitHub #191). `finished` lived on the bind data and was never
+// reset, so a second EXECUTE of a bound plan returned zero rows silently.
+class CrmShowEntitiesGlobalState : public GlobalTableFunctionState {
+public:
+    explicit CrmShowEntitiesGlobalState(std::unique_ptr<ODataReadBindData> scan_state)
+        : scan_state(std::move(scan_state)) {}
+
+    ODataReadBindData &Scan() { return *scan_state; }
+    bool finished = false;
+
+private:
+    std::unique_ptr<ODataReadBindData> scan_state;
+};
+
+static unique_ptr<GlobalTableFunctionState> CrmShowEntitiesInitGlobalState(
+    ClientContext &context, TableFunctionInitInput &input) {
+    auto &bind_data = input.bind_data->CastNoConst<CrmShowEntitiesBindData>();
+    return make_uniq<CrmShowEntitiesGlobalState>(bind_data.odata_bind_data->CloneForScan());
+}
 
 static unique_ptr<FunctionData> CrmShowEntitiesBind(
     ClientContext &context,
@@ -54,22 +73,22 @@ static unique_ptr<FunctionData> CrmShowEntitiesBind(
 }
 
 static void CrmShowEntitiesScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
-    auto &bind_data = data.bind_data->CastNoConst<CrmShowEntitiesBindData>();
+    auto &gstate = data.global_state->Cast<CrmShowEntitiesGlobalState>();
 
-    if (bind_data.finished) {
+    if (gstate.finished) {
         return;
     }
 
-    auto rows_fetched = bind_data.odata_bind_data->FetchNextResult(output);
-    if (!bind_data.odata_bind_data->HasMoreResults() && rows_fetched == 0) {
-        bind_data.finished = true;
+    auto rows_fetched = gstate.Scan().FetchNextResult(output);
+    if (!gstate.Scan().HasMoreResults() && rows_fetched == 0) {
+        gstate.finished = true;
     }
 }
 
 TableFunctionSet CreateCrmShowEntitiesFunction() {
     TableFunctionSet set("crm_show_entities");
 
-    TableFunction func({}, DATAZOO_GUARD(ERPL_WEB_BANNER, CrmShowEntitiesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, CrmShowEntitiesBind));
+    TableFunction func({}, DATAZOO_GUARD(ERPL_WEB_BANNER, CrmShowEntitiesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, CrmShowEntitiesBind), CrmShowEntitiesInitGlobalState);
     func.named_parameters["secret"] = LogicalType::VARCHAR;
 
     set.AddFunction(func);
@@ -85,8 +104,20 @@ struct CrmDescribeBindData : public TableFunctionData {
     std::vector<std::string> attribute_types;
     std::vector<bool> is_nullable;
     std::vector<bool> is_primary;
+};
+
+// Per-execution row cursor (GitHub #191). It lived on the bind data and was never reset,
+// so a second EXECUTE of a bound plan resumed past the end and returned nothing. The
+// describe payload itself is immutable and stays shared.
+class CrmDescribeGlobalState : public GlobalTableFunctionState {
+public:
     idx_t current_row = 0;
 };
+
+static unique_ptr<GlobalTableFunctionState> CrmDescribeInitGlobalState(
+    ClientContext &context, TableFunctionInitInput &input) {
+    return make_uniq<CrmDescribeGlobalState>();
+}
 
 static unique_ptr<FunctionData> CrmDescribeBind(
     ClientContext &context,
@@ -183,14 +214,15 @@ static unique_ptr<FunctionData> CrmDescribeBind(
 
 static void CrmDescribeScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
     auto &bind_data = data.bind_data->CastNoConst<CrmDescribeBindData>();
+    auto &gstate = data.global_state->Cast<CrmDescribeGlobalState>();
 
     idx_t count = 0;
-    while (bind_data.current_row < bind_data.attribute_names.size() && count < STANDARD_VECTOR_SIZE) {
-        output.SetValue(0, count, Value(bind_data.attribute_names[bind_data.current_row]));
-        output.SetValue(1, count, Value(bind_data.attribute_types[bind_data.current_row]));
-        output.SetValue(2, count, Value(bind_data.is_nullable[bind_data.current_row]));
-        output.SetValue(3, count, Value(bind_data.is_primary[bind_data.current_row]));
-        bind_data.current_row++;
+    while (gstate.current_row < bind_data.attribute_names.size() && count < STANDARD_VECTOR_SIZE) {
+        output.SetValue(0, count, Value(bind_data.attribute_names[gstate.current_row]));
+        output.SetValue(1, count, Value(bind_data.attribute_types[gstate.current_row]));
+        output.SetValue(2, count, Value(bind_data.is_nullable[gstate.current_row]));
+        output.SetValue(3, count, Value(bind_data.is_primary[gstate.current_row]));
+        gstate.current_row++;
         count++;
     }
 
@@ -200,7 +232,7 @@ static void CrmDescribeScan(ClientContext &context, TableFunctionInput &data, Da
 TableFunctionSet CreateCrmDescribeFunction() {
     TableFunctionSet set("crm_describe");
 
-    TableFunction func({LogicalType::VARCHAR}, DATAZOO_GUARD(ERPL_WEB_BANNER, CrmDescribeScan), DATAZOO_GUARD(ERPL_WEB_BANNER, CrmDescribeBind));
+    TableFunction func({LogicalType::VARCHAR}, DATAZOO_GUARD(ERPL_WEB_BANNER, CrmDescribeScan), DATAZOO_GUARD(ERPL_WEB_BANNER, CrmDescribeBind), CrmDescribeInitGlobalState);
     func.named_parameters["secret"] = LogicalType::VARCHAR;
 
     set.AddFunction(func);
@@ -305,6 +337,11 @@ static void CrmReadScan(ClientContext &context, TableFunctionInput &data, DataCh
     auto rows_fetched = gstate.Scan().FetchNextResult(output);
     if (!gstate.Scan().HasMoreResults() && rows_fetched == 0) {
         gstate.finished = true;
+        // Report at the terminal exit, as odata_read does, rather than leaving it to the
+        // bind-data destructor: the destructor fires at teardown, so warnings could land
+        // after the result instead of beside it. Name this function, not odata_read
+        // (GitHub #196).
+        gstate.Scan().ReportConversionFailures("crm_read");
     }
 }
 

--- a/src/dataverse_functions.cpp
+++ b/src/dataverse_functions.cpp
@@ -337,6 +337,11 @@ static void CrmReadScan(ClientContext &context, TableFunctionInput &data, DataCh
     auto rows_fetched = gstate.Scan().FetchNextResult(output);
     if (!gstate.Scan().HasMoreResults() && rows_fetched == 0) {
         gstate.finished = true;
+        // Report at the terminal exit, as odata_read does, rather than leaving it to the
+        // bind-data destructor: the destructor fires at teardown, so warnings could land
+        // after the result instead of beside it. Name this function, not odata_read
+        // (GitHub #196).
+        gstate.Scan().ReportConversionFailures("crm_read");
     }
 }
 

--- a/src/dataverse_functions.cpp
+++ b/src/dataverse_functions.cpp
@@ -18,27 +18,8 @@ using namespace duckdb;
 
 struct CrmShowEntitiesBindData : public TableFunctionData {
     std::unique_ptr<ODataReadBindData> odata_bind_data;
-};
-
-// Per-execution scan state (GitHub #191). `finished` lived on the bind data and was never
-// reset, so a second EXECUTE of a bound plan returned zero rows silently.
-class CrmShowEntitiesGlobalState : public GlobalTableFunctionState {
-public:
-    explicit CrmShowEntitiesGlobalState(std::unique_ptr<ODataReadBindData> scan_state)
-        : scan_state(std::move(scan_state)) {}
-
-    ODataReadBindData &Scan() { return *scan_state; }
     bool finished = false;
-
-private:
-    std::unique_ptr<ODataReadBindData> scan_state;
 };
-
-static unique_ptr<GlobalTableFunctionState> CrmShowEntitiesInitGlobalState(
-    ClientContext &context, TableFunctionInitInput &input) {
-    auto &bind_data = input.bind_data->CastNoConst<CrmShowEntitiesBindData>();
-    return make_uniq<CrmShowEntitiesGlobalState>(bind_data.odata_bind_data->CloneForScan());
-}
 
 static unique_ptr<FunctionData> CrmShowEntitiesBind(
     ClientContext &context,
@@ -73,22 +54,22 @@ static unique_ptr<FunctionData> CrmShowEntitiesBind(
 }
 
 static void CrmShowEntitiesScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
-    auto &gstate = data.global_state->Cast<CrmShowEntitiesGlobalState>();
+    auto &bind_data = data.bind_data->CastNoConst<CrmShowEntitiesBindData>();
 
-    if (gstate.finished) {
+    if (bind_data.finished) {
         return;
     }
 
-    auto rows_fetched = gstate.Scan().FetchNextResult(output);
-    if (!gstate.Scan().HasMoreResults() && rows_fetched == 0) {
-        gstate.finished = true;
+    auto rows_fetched = bind_data.odata_bind_data->FetchNextResult(output);
+    if (!bind_data.odata_bind_data->HasMoreResults() && rows_fetched == 0) {
+        bind_data.finished = true;
     }
 }
 
 TableFunctionSet CreateCrmShowEntitiesFunction() {
     TableFunctionSet set("crm_show_entities");
 
-    TableFunction func({}, DATAZOO_GUARD(ERPL_WEB_BANNER, CrmShowEntitiesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, CrmShowEntitiesBind), CrmShowEntitiesInitGlobalState);
+    TableFunction func({}, DATAZOO_GUARD(ERPL_WEB_BANNER, CrmShowEntitiesScan), DATAZOO_GUARD(ERPL_WEB_BANNER, CrmShowEntitiesBind));
     func.named_parameters["secret"] = LogicalType::VARCHAR;
 
     set.AddFunction(func);
@@ -104,20 +85,8 @@ struct CrmDescribeBindData : public TableFunctionData {
     std::vector<std::string> attribute_types;
     std::vector<bool> is_nullable;
     std::vector<bool> is_primary;
-};
-
-// Per-execution row cursor (GitHub #191). It lived on the bind data and was never reset,
-// so a second EXECUTE of a bound plan resumed past the end and returned nothing. The
-// describe payload itself is immutable and stays shared.
-class CrmDescribeGlobalState : public GlobalTableFunctionState {
-public:
     idx_t current_row = 0;
 };
-
-static unique_ptr<GlobalTableFunctionState> CrmDescribeInitGlobalState(
-    ClientContext &context, TableFunctionInitInput &input) {
-    return make_uniq<CrmDescribeGlobalState>();
-}
 
 static unique_ptr<FunctionData> CrmDescribeBind(
     ClientContext &context,
@@ -214,15 +183,14 @@ static unique_ptr<FunctionData> CrmDescribeBind(
 
 static void CrmDescribeScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
     auto &bind_data = data.bind_data->CastNoConst<CrmDescribeBindData>();
-    auto &gstate = data.global_state->Cast<CrmDescribeGlobalState>();
 
     idx_t count = 0;
-    while (gstate.current_row < bind_data.attribute_names.size() && count < STANDARD_VECTOR_SIZE) {
-        output.SetValue(0, count, Value(bind_data.attribute_names[gstate.current_row]));
-        output.SetValue(1, count, Value(bind_data.attribute_types[gstate.current_row]));
-        output.SetValue(2, count, Value(bind_data.is_nullable[gstate.current_row]));
-        output.SetValue(3, count, Value(bind_data.is_primary[gstate.current_row]));
-        gstate.current_row++;
+    while (bind_data.current_row < bind_data.attribute_names.size() && count < STANDARD_VECTOR_SIZE) {
+        output.SetValue(0, count, Value(bind_data.attribute_names[bind_data.current_row]));
+        output.SetValue(1, count, Value(bind_data.attribute_types[bind_data.current_row]));
+        output.SetValue(2, count, Value(bind_data.is_nullable[bind_data.current_row]));
+        output.SetValue(3, count, Value(bind_data.is_primary[bind_data.current_row]));
+        bind_data.current_row++;
         count++;
     }
 
@@ -232,7 +200,7 @@ static void CrmDescribeScan(ClientContext &context, TableFunctionInput &data, Da
 TableFunctionSet CreateCrmDescribeFunction() {
     TableFunctionSet set("crm_describe");
 
-    TableFunction func({LogicalType::VARCHAR}, DATAZOO_GUARD(ERPL_WEB_BANNER, CrmDescribeScan), DATAZOO_GUARD(ERPL_WEB_BANNER, CrmDescribeBind), CrmDescribeInitGlobalState);
+    TableFunction func({LogicalType::VARCHAR}, DATAZOO_GUARD(ERPL_WEB_BANNER, CrmDescribeScan), DATAZOO_GUARD(ERPL_WEB_BANNER, CrmDescribeBind));
     func.named_parameters["secret"] = LogicalType::VARCHAR;
 
     set.AddFunction(func);
@@ -337,11 +305,6 @@ static void CrmReadScan(ClientContext &context, TableFunctionInput &data, DataCh
     auto rows_fetched = gstate.Scan().FetchNextResult(output);
     if (!gstate.Scan().HasMoreResults() && rows_fetched == 0) {
         gstate.finished = true;
-        // Report at the terminal exit, as odata_read does, rather than leaving it to the
-        // bind-data destructor: the destructor fires at teardown, so warnings could land
-        // after the result instead of beside it. Name this function, not odata_read
-        // (GitHub #196).
-        gstate.Scan().ReportConversionFailures("crm_read");
     }
 }
 

--- a/src/include/odata_read_functions.hpp
+++ b/src/include/odata_read_functions.hpp
@@ -148,7 +148,11 @@ public:
     void SetStrictTyping(bool strict);
     std::shared_ptr<ConversionFailureLog> GetConversionFailureLog() const;
     // Emit the accumulated per-column failure summary once, at end of scan.
-    void ReportConversionFailures();
+    // `source` names the SQL function in the warning. It defaults to odata_read because
+    // that is where this path began, but every other reader that embeds an
+    // ODataReadBindData must pass its own name - a bc_read user being warned about
+    // "odata_read" is being told about a function they did not call (GitHub #196).
+    void ReportConversionFailures(const std::string &source = "odata_read");
     // Produce an independent scan instance for one execution of a bound plan.
     // See ODataReadGlobalState below and GitHub #75: all mutable scan state
     // (row buffer, paging cursor, progress, emitted-row counter, request

--- a/src/odata_read_bind_data.cpp
+++ b/src/odata_read_bind_data.cpp
@@ -262,12 +262,12 @@ ODataReadBindData::GetConversionFailureLog() const {
   return conversion_failure_log;
 }
 
-void ODataReadBindData::ReportConversionFailures() {
+void ODataReadBindData::ReportConversionFailures(const std::string &source) {
   if (conversion_failures_reported_ || !conversion_failure_log) {
     return;
   }
   conversion_failures_reported_ = true;
-  conversion_failure_log->ReportAndDrain("odata_read");
+  conversion_failure_log->ReportAndDrain(source);
 }
 
 // Helper methods for URL detection

--- a/test/cpp/edm_dataverse_min.xml
+++ b/test/cpp/edm_dataverse_min.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Minimal Dataverse EDMX for the catalog-function tests.
+
+  crm_show_entities binds against the EntityDefinitions endpoint via
+  FromEntitySetClient with no buffered response, so its schema comes entirely from
+  $metadata. Without an EDM declaring EntityDefinitions the bind fails with
+  "Table function must return at least one column" and the scan cannot be reached -
+  the same wall that kept GitHub #191 unreproducible until a fixture existed.
+
+  Only the properties the readers project are declared.
+-->
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Microsoft.Dynamics.CRM" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="EntityMetadata">
+        <Key>
+          <PropertyRef Name="MetadataId" />
+        </Key>
+        <Property Name="MetadataId" Type="Edm.String" Nullable="false" />
+        <Property Name="LogicalName" Type="Edm.String" />
+        <Property Name="EntitySetName" Type="Edm.String" />
+        <Property Name="SchemaName" Type="Edm.String" />
+      </EntityType>
+      <EntityContainer Name="System">
+        <EntitySet Name="EntityDefinitions" EntityType="Microsoft.Dynamics.CRM.EntityMetadata" />
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/test/cpp/test_microsoft_scan_reexecution.cpp
+++ b/test/cpp/test_microsoft_scan_reexecution.cpp
@@ -461,3 +461,47 @@ TEST_CASE("the remaining catalog functions return every row on each execution",
         }
     }
 }
+
+// GitHub #196. An agent-crew review reported that bc_read/crm_read "silently drop"
+// per-column conversion failures. That was narrower than it looked: a destructor safety
+// net on ODataReadBindData reports them, so they were never lost. What was actually wrong
+// is that they arrived at teardown rather than at the end of the scan, and under the name
+// "odata_read" - a function the caller never invoked.
+//
+// WHAT THIS CASE DOES AND DOES NOT COVER. It is a regression guard for wiring
+// ReportConversionFailures() into the scan's terminal exit: the read must still succeed
+// and deliver every row, because reporting is a diagnostic and must not become a failure
+// mode. It does NOT assert the warning text or its timing - those go out through the
+// tracer, and this harness has no way to capture them. Naming the limitation rather than
+// letting the test imply coverage it does not have.
+TEST_CASE("wiring conversion reporting into the bc_read scan does not break the read",
+          "[ms_reexec][conversion]") {
+    ODataTestServer server;
+    server.ServeMetadataFixture("/$metadata", "edm_business_central_min.xml");
+    const std::string COMPANY = "11111111-2222-3333-4444-555555555555";
+    const std::string path = "/companies(" + COMPANY + ")/customers";
+    server.OnPath(path,
+                  CannedResponse::Json(MakeV4Page(
+                      server.Url("/$metadata") + "#customers",
+                      {R"({"id":"c1","number":"N1","displayName":"Acme"})",
+                       R"({"id":"c2","number":"N2","displayName":"Beta"})"})));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto secret = con.Query(
+        "CREATE SECRET bcconv (TYPE business_central, PROVIDER config, "
+        "TENANT_ID 'loopback', CLIENT_ID 'id', CLIENT_SECRET 'sec', "
+        "ENVIRONMENT '" + server.BaseUrl() + "', ACCESS_TOKEN 'test-token', "
+        "EXPIRES_AT '" + FarFutureEpoch() + "')");
+    REQUIRE_FALSE(secret->HasError());
+
+    // The read itself must still succeed and deliver every row - reporting is a diagnostic,
+    // not a failure mode.
+    auto result = con.Query("SELECT COUNT(*) FROM bc_read('customers', secret => 'bcconv', "
+                            "company => '" + COMPANY + "')");
+    INFO((result->HasError() ? result->GetError() : std::string()));
+    REQUIRE_FALSE(result->HasError());
+    REQUIRE(ScalarOf(result) == 2);
+}

--- a/test/cpp/test_microsoft_scan_reexecution.cpp
+++ b/test/cpp/test_microsoft_scan_reexecution.cpp
@@ -505,3 +505,56 @@ TEST_CASE("wiring conversion reporting into the bc_read scan does not break the 
     REQUIRE_FALSE(result->HasError());
     REQUIRE(ScalarOf(result) == 2);
 }
+
+// The two Dataverse catalog functions #191 fixed but did not test. An agent-crew review
+// pointed out that five functions were changed and three tested, which leaves two
+// changed-but-unverified - the shape that let this defect survive in seven places.
+//
+// crm_show_entities reads the EntityDefinitions endpoint, so it needs its own EDM:
+// edm_dataverse_min.xml, for the same reason edm_business_central_min.xml exists.
+TEST_CASE("a bound crm_show_entities plan returns every row on each execution",
+          "[ms_reexec][catalog]") {
+    ODataTestServer server;
+    const std::string api = "/api/data/v9.2";
+    server.ServeMetadataFixture(api + "/$metadata", "edm_dataverse_min.xml");
+
+    const std::string ctx = server.Url(api + "/$metadata") + "#EntityDefinitions";
+    // Two pages, so a shared pagination cursor would be observable.
+    server.OnMatch(
+        [api](const RecordedRequest &request) {
+            return request.path == api + "/EntityDefinitions" &&
+                   request.QueryParam("$skiptoken") == "2";
+        },
+        CannedResponse::Json(MakeV4Page(
+            ctx, {R"({"MetadataId":"m3","LogicalName":"lead","EntitySetName":"leads","SchemaName":"Lead"})"})));
+    server.OnPath(api + "/EntityDefinitions",
+                  CannedResponse::Json(MakeV4Page(
+                      ctx,
+                      {R"({"MetadataId":"m1","LogicalName":"account","EntitySetName":"accounts","SchemaName":"Account"})",
+                       R"({"MetadataId":"m2","LogicalName":"contact","EntitySetName":"contacts","SchemaName":"Contact"})"},
+                      server.Url(api + "/EntityDefinitions") + "?$format=json&$skiptoken=2")));
+
+    TestDatabase database;
+    duckdb::Connection &con = database.Con();
+    REQUIRE_FALSE(con.Query("LOAD erpl_web")->HasError());
+
+    auto secret = con.Query(
+        "CREATE SECRET crmcat (TYPE dataverse, PROVIDER config, "
+        "TENANT_ID 'loopback', CLIENT_ID 'id', CLIENT_SECRET 'sec', "
+        "ENVIRONMENT_URL '" + server.BaseUrl() + "', ACCESS_TOKEN 'test-token', "
+        "EXPIRES_AT '" + FarFutureEpoch() + "')");
+    INFO((secret->HasError() ? secret->GetError() : std::string()));
+    REQUIRE_FALSE(secret->HasError());
+
+    auto prep = con.Query("PREPARE ce AS SELECT COUNT(*) FROM crm_show_entities(secret => 'crmcat')");
+    INFO((prep->HasError() ? prep->GetError() : std::string()));
+    REQUIRE_FALSE(prep->HasError());
+
+    for (int execution = 1; execution <= 3; execution++) {
+        auto result = con.Query("EXECUTE ce");
+        INFO("execution " << execution);
+        INFO((result->HasError() ? result->GetError() : std::string()));
+        REQUIRE_FALSE(result->HasError());
+        REQUIRE(ScalarOf(result) == 3);
+    }
+}


### PR DESCRIPTION
Closes #196. **Also restores the Business Central half of #191, which is currently missing from main.**

The title and scope changed after the fact, which is worth explaining rather than quietly editing.

## The regression this fixes

`git show origin/main:src/business_central_functions.cpp | grep -c BcShowCompaniesGlobalState` returns **0**. PR #200 merged as `fae3e11` without ever touching that file, so `bc_show_companies`, `bc_show_entities` and `bc_describe` are still defective on main — cursor on bind data, no `init_global`, second `EXECUTE` returns zero rows silently. The three `[catalog]` tests merged with it and **should be failing on main right now**.

### Cause

`git checkout <ref> -- <path>` stages as well as writing the working tree. My red-check for #200 reverted the file that way, then restored it with `cp` — which touches only the working tree. The index kept the revert and the commit took it. Local runs passed throughout, because the test binary is built from the working tree: *the code I tested was not the code I merged.*

The same trap had also reverted the **Dataverse** half on this branch, during a later red-check. Both halves are restored here and verified with `git diff origin/main HEAD -- <file>` per file — `git status` shows nothing once the working tree is back, which is why it went unnoticed twice.

This is the third occurrence (#146, #191/#200, this branch). A CLAUDE.md rule is going in separately so the check is written down rather than remembered.

## The #196 work

An agent-crew review reported that `bc_read`/`crm_read` "silently drop" per-column conversion failures. They do not — `ODataReadBindData::~ODataReadBindData` reports them as an explicit safety net. Two narrower defects, both real:

- **Timing**: the destructor fires at teardown, so warnings could land after the result rather than beside it. Both scans now report at their terminal exit, as `odata_read` does.
- **Naming**: `ReportAndDrain("odata_read")` was hardcoded, so a `bc_read` user was warned about a function they never called.

"Silently dropped" would have justified a much larger change than the evidence supports.

## Tests

- `crm_show_entities` re-execution, with its own `edm_dataverse_min.xml` and a **two-page** fixture — a single page cannot catch pagination-cursor sharing, the actual #75 mechanism. Verified red against the real pre-#191 file, after a first attempt at a hand-written revert failed to compile and produced a **stale-binary false pass**.
- The `bc_read` conversion case is a regression guard for the wiring only: the read must still succeed and deliver every row. It deliberately does **not** assert warning text or timing — those go through the tracer and this harness cannot capture them, and its name says so.

474 C++ cases / 2513 assertions green.
