### PR TITLE
feat: gate non-loopback https for the readers whose token audience is fixed (#199)

### DIFF
--- a/docs/TLS.md
+++ b/docs/TLS.md
@@ -86,3 +86,39 @@ Setting it back to `''` restores verification immediately.
   extension; without the probe `SSL_CTX_set_default_verify_paths()` yields an
   empty trust store and *every* handshake fails. If your distribution keeps its
   bundle somewhere unusual, set `SSL_CERT_FILE` or `erpl_ca_cert_file`.
+
+---
+
+## Pointing a reader at a different host
+
+Separate from TLS, but the same kind of decision: `erpl_unsafe_allow_custom_service_urls`.
+
+Business Central and Datasphere obtain their OAuth token for a **fixed audience** — Business
+Central's is hardcoded to `https://api.businesscentral.dynamics.com`, Datasphere's is a
+fixed `default`/`apiaccess` scope. So pointing one of those readers at an https host it was
+not built for hands that host a credential minted for a different one. By default this is
+refused:
+
+```
+Business Central 'environment' points at 'api.example.com'. This service's OAuth token
+audience is fixed, so its token would be sent to a host it was not minted for.
+```
+
+If you are deliberately proxying the service, opt in:
+
+```sql
+SET erpl_unsafe_allow_custom_service_urls = 'I_UNDERSTAND_THIS_SENDS_TOKENS_ELSEWHERE';
+```
+
+Like the TLS opt-out, it accepts only that exact literal.
+
+**Loopback addresses never need this setting.** `localhost` and `127.0.0.1` are always
+permitted, over http or https, which is what makes the readers testable against a local
+server.
+
+**Dataverse is deliberately not gated.** Its scope is `environment_url + "/.default"`, so
+the token is minted for whichever host you configure — a customer-specific org URL is the
+normal product, not an exposure. Gating it would have required every real deployment to set
+an unsafe flag for ordinary use, and a flag needed for normal operation is not a gate.
+
+See GitHub #199.

--- a/src/business_central_client.cpp
+++ b/src/business_central_client.cpp
@@ -32,7 +32,7 @@ std::string BusinessCentralUrlBuilder::BuildApiUrl(const std::string &tenant_id,
         }
         // Shared with Datasphere's space_id and Dataverse's environment_url hatches, so the
         // loopback rule - and the IPv6 and prefix subtleties in it - has one implementation.
-        RequireSecureOrLoopbackUrl(base, "Business Central 'environment'");
+        RequireGatedServiceUrl(base, "Business Central 'environment'");
         return base;
     }
     return "https://api.businesscentral.dynamics.com/v2.0/" + tenant_id + "/" + environment + "/api/v2.0";

--- a/src/datasphere_read.cpp
+++ b/src/datasphere_read.cpp
@@ -81,7 +81,7 @@ namespace {
             // Same rule as the Business Central and Dataverse hatches: this URL is taken
             // verbatim from the caller and carries an OAuth bearer token, so plain http is
             // allowed only for loopback.
-            RequireSecureOrLoopbackUrl(space_id, "Datasphere 'space_id'");
+            RequireGatedServiceUrl(space_id, "Datasphere 'space_id'");
             std::string data_url = space_id;
             EnsureAssetSegmentPattern(data_url, asset_id);
             return data_url;
@@ -95,7 +95,7 @@ namespace {
     std::string BuildDataUrl(const std::string& space_id, const std::string& asset_id, 
                             const std::string& tenant, const std::string& data_center) {
         if (LooksLikeAbsoluteHttpUrl(space_id)) {
-            RequireSecureOrLoopbackUrl(space_id, "Datasphere 'space_id'");
+            RequireGatedServiceUrl(space_id, "Datasphere 'space_id'");
             std::string data_url = space_id;
             EnsureAssetSegmentPattern(data_url, asset_id);
             return data_url;

--- a/src/erpl_web_extension.cpp
+++ b/src/erpl_web_extension.cpp
@@ -13,6 +13,7 @@
 #include "secret_functions.hpp"
 #include "odata_attach_functions.hpp"
 #include "odata_read_functions.hpp"
+#include "odata_url_helpers.hpp"
 #include "odata_storage.hpp"
 #include "datasphere_catalog.hpp"
 #include "datasphere_read.hpp"
@@ -140,6 +141,35 @@ static void OnUnsafeDisableServerCertVerification(ClientContext &context, SetSco
     }
 
     erpl_web::HttpTlsPolicy::SetServerCertVerificationEnabled(false);
+}
+
+// Gates the verbatim-URL hatches for the services whose OAuth token audience is fixed
+// (Business Central, Datasphere). Named for what it does and, like the TLS opt-out,
+// refuses anything but the exact token - a flag that is easy to set by accident is not a
+// gate. See GitHub #199.
+static void OnUnsafeAllowCustomServiceUrls(ClientContext &context, SetScope scope, Value &parameter)
+{
+    auto value = parameter.IsNull() ? std::string() : parameter.GetValue<std::string>();
+    StringUtil::Trim(value);
+    auto value_upper = StringUtil::Upper(value);
+
+    if (value_upper.empty() || value_upper == "FALSE" || value_upper == "OFF") {
+        erpl_web::ServiceUrlPolicy::SetCustomServiceUrlsAllowed(false);
+        return;
+    }
+
+    if (value_upper != "I_UNDERSTAND_THIS_SENDS_TOKENS_ELSEWHERE") {
+        throw InvalidInputException(
+            "erpl_unsafe_allow_custom_service_urls only accepts the literal string "
+            "'I_UNDERSTAND_THIS_SENDS_TOKENS_ELSEWHERE' (or an empty string to re-enable the "
+            "restriction). Business Central and Datasphere mint their OAuth token for a FIXED "
+            "audience, so pointing a reader at another https host sends that host a credential "
+            "minted for a different one. Loopback addresses are always permitted without this "
+            "setting; Dataverse is unaffected, because its token is minted for whichever "
+            "environment_url you configure.");
+    }
+
+    erpl_web::ServiceUrlPolicy::SetCustomServiceUrlsAllowed(true);
 }
 
 // Tracing configuration callbacks
@@ -293,6 +323,14 @@ static void RegisterConfiguration(DatabaseInstance &instance)
                                   "made by this extension. Only accepts the literal string "
                                   "'I_UNDERSTAND_THIS_IS_INSECURE'. Prefer erpl_ca_cert_file.",
                                   LogicalTypeId::VARCHAR, Value(""), OnUnsafeDisableServerCertVerification);
+
+    config.AddExtensionOption("erpl_unsafe_allow_custom_service_urls",
+                                  "DANGEROUS: lets Business Central and Datasphere readers point at an https host "
+                                  "they were not built for. Those services mint their OAuth token for a fixed "
+                                  "audience, so the token would be sent to a host it was not issued for. Only "
+                                  "accepts the literal string 'I_UNDERSTAND_THIS_SENDS_TOKENS_ELSEWHERE'. Loopback "
+                                  "addresses never need this.",
+                                  LogicalTypeId::VARCHAR, Value(""), OnUnsafeAllowCustomServiceUrls);
 
     // Tracing configuration options
     config.AddExtensionOption("erpl_trace_enabled", "Enable ERPL Web extension tracing functionality", 

--- a/src/include/odata_url_helpers.hpp
+++ b/src/include/odata_url_helpers.hpp
@@ -16,6 +16,31 @@ namespace erpl_web {
 // configured URL IS the origin. https is allowed anywhere; plain http only for loopback.
 //
 // `what` names the setting in the error, so the caller is told which of theirs is wrong.
+// Whether a reader may point at a non-loopback https host it was not built for.
+//
+// This gates Business Central and Datasphere, and deliberately NOT Dataverse. The
+// distinction is where the OAuth token audience comes from:
+//
+//   Dataverse   scope = environment_url + "/.default"  -> minted FOR the configured host,
+//                                                          so a custom host is the normal
+//                                                          product, not an exposure
+//   Business    GetResourceUrl() hardcodes
+//   Central     https://api.businesscentral.dynamics.com -> a token minted for one host
+//                                                          would be sent to another
+//   Datasphere  scope is a fixed 'default'/'apiaccess'  -> same concern, gated to match
+//
+// Gating Dataverse would make every real deployment set an unsafe flag for ordinary use,
+// which devalues the flag (GitHub #199).
+class ServiceUrlPolicy {
+public:
+    static void SetCustomServiceUrlsAllowed(bool allowed);
+    static bool CustomServiceUrlsAllowed();
+};
+
+// Loopback http is always permitted; https to a non-loopback host requires the opt-in
+// above. Use for readers whose token audience is fixed.
+void RequireGatedServiceUrl(const std::string &url, const std::string &what);
+
 void RequireSecureOrLoopbackUrl(const std::string &url, const std::string &what);
 
 // Shared trigger for those same hatches: does this value already look like an absolute

--- a/src/odata_url_helpers.cpp
+++ b/src/odata_url_helpers.cpp
@@ -49,7 +49,10 @@ void RequireGatedServiceUrl(const std::string &url, const std::string &what)
     }
 
     HttpUrl parsed(url);
-    const auto host = parsed.Host();
+    // Same case rule as RequireSecureOrLoopbackUrl below. These two disagreed: that one
+    // lowercases the host, this one compared it raw, so https://LOCALHOST passed the
+    // first check and was then refused by the gate.
+    const auto host = LowercaseAscii(parsed.Host());
     if (host == "localhost" || host == "127.0.0.1") {
         return;  // a local test server, which is what the hatch is for
     }

--- a/src/odata_url_helpers.cpp
+++ b/src/odata_url_helpers.cpp
@@ -1,3 +1,4 @@
+#include <atomic>
 #include <algorithm>
 #include <cctype>
 #include "odata_url_helpers.hpp"
@@ -22,6 +23,44 @@ std::string LowercaseAscii(const std::string &value)
 }
 
 }  // namespace
+
+namespace {
+// Process-wide, like HttpTlsPolicy: this is a session knob, and the guard is called from
+// deep inside URL construction where no ClientContext is in scope.
+std::atomic<bool> g_custom_service_urls_allowed{false};
+}  // namespace
+
+void ServiceUrlPolicy::SetCustomServiceUrlsAllowed(bool allowed)
+{
+    g_custom_service_urls_allowed.store(allowed);
+}
+
+bool ServiceUrlPolicy::CustomServiceUrlsAllowed()
+{
+    return g_custom_service_urls_allowed.load();
+}
+
+void RequireGatedServiceUrl(const std::string &url, const std::string &what)
+{
+    RequireSecureOrLoopbackUrl(url, what);
+
+    if (!LooksLikeAbsoluteHttpUrl(url) || ServiceUrlPolicy::CustomServiceUrlsAllowed()) {
+        return;
+    }
+
+    HttpUrl parsed(url);
+    const auto host = parsed.Host();
+    if (host == "localhost" || host == "127.0.0.1") {
+        return;  // a local test server, which is what the hatch is for
+    }
+
+    throw duckdb::InvalidInputException(
+        "%s points at '%s'. This service's OAuth token audience is fixed, so its token would "
+        "be sent to a host it was not minted for. If you are deliberately proxying the "
+        "service, opt in with SET erpl_unsafe_allow_custom_service_urls = "
+        "'I_UNDERSTAND_THIS_SENDS_TOKENS_ELSEWHERE'.",
+        what.c_str(), host.c_str());
+}
 
 bool LooksLikeAbsoluteHttpUrl(const std::string &value)
 {

--- a/test/cpp/test_datasphere_scan_reexecution.cpp
+++ b/test/cpp/test_datasphere_scan_reexecution.cpp
@@ -20,6 +20,7 @@
 #include "duckdb.hpp"
 
 #include "odata_test_server.hpp"
+#include "odata_url_helpers.hpp"
 
 #include <string>
 
@@ -314,11 +315,35 @@ TEST_CASE("the Datasphere space_id hatch refuses plain http off loopback",
     // A caller mistake, not a broken invariant of ours.
     REQUIRE(result->GetErrorObject().Type() != duckdb::ExceptionType::INTERNAL);
 
-    // https anywhere is still accepted - the guard must not have become "loopback only".
-    auto https_ok = con.Query(
+    // Datasphere's token audience is a fixed 'default'/'apiaccess' scope, so a non-loopback
+    // https host is GATED (GitHub #199) - it is not simply accepted.
+    //
+    // This assertion used to read "https anywhere is still accepted", checking only that
+    // the error did not mention "loopback". The gate's message does not contain that word
+    // either, so that check survived the behaviour change without failing: it could no
+    // longer detect anything. Asserting the gate explicitly instead.
+    auto gated = con.Query(
         "SELECT * FROM datasphere_read_relational('https://tenant.datasphere.example/sp', 'A', "
         "secret => 'dssec')");
-    REQUIRE(https_ok->HasError());  // it will fail to CONNECT, but not on the guard
-    INFO("https error was: " << https_ok->GetError());
-    REQUIRE(https_ok->GetError().find("loopback") == std::string::npos);
+    REQUIRE(gated->HasError());
+    INFO("gated error was: " << gated->GetError());
+    REQUIRE(gated->GetError().find("erpl_unsafe_allow_custom_service_urls") != std::string::npos);
+
+    // ...and permitted once the caller opts in. RAII because the policy is process-wide.
+    {
+        struct OptInGuard {
+            OptInGuard() { erpl_web::ServiceUrlPolicy::SetCustomServiceUrlsAllowed(true); }
+            ~OptInGuard() { erpl_web::ServiceUrlPolicy::SetCustomServiceUrlsAllowed(false); }
+        } opt_in;
+
+        auto allowed = con.Query(
+            "SELECT * FROM datasphere_read_relational('https://tenant.datasphere.example/sp', 'A', "
+            "secret => 'dssec')");
+        // It will fail to CONNECT to a host that does not exist - the point is that it no
+        // longer fails on the GATE.
+        REQUIRE(allowed->HasError());
+        INFO("opted-in error was: " << allowed->GetError());
+        REQUIRE(allowed->GetError().find("erpl_unsafe_allow_custom_service_urls") ==
+                std::string::npos);
+    }
 }

--- a/test/cpp/test_microsoft_scan_reexecution.cpp
+++ b/test/cpp/test_microsoft_scan_reexecution.cpp
@@ -211,10 +211,21 @@ TEST_CASE("the Business Central URL hatch refuses plain http off loopback",
     }
 
     SECTION("...and permitted once the caller opts in") {
-        erpl_web::ServiceUrlPolicy::SetCustomServiceUrlsAllowed(true);
+        // RAII, because the policy is process-wide: a bare set/REQUIRE/unset leaves the
+        // gate OPEN for the whole binary if the assertion fails, silently weakening every
+        // later test in the run.
+        struct OptInGuard {
+            OptInGuard() { erpl_web::ServiceUrlPolicy::SetCustomServiceUrlsAllowed(true); }
+            ~OptInGuard() { erpl_web::ServiceUrlPolicy::SetCustomServiceUrlsAllowed(false); }
+        } opt_in;
+
         REQUIRE(erpl_web::BusinessCentralUrlBuilder::BuildApiUrl("t", "https://api.example.com/v2") ==
                 "https://api.example.com/v2");
-        erpl_web::ServiceUrlPolicy::SetCustomServiceUrlsAllowed(false);
+    }
+
+    SECTION("the gate agrees with its sibling on host case") {
+        REQUIRE(erpl_web::BusinessCentralUrlBuilder::BuildApiUrl("t", "http://LOCALHOST:8080") ==
+                "http://LOCALHOST:8080");
     }
 
     SECTION("Dataverse is not gated - a custom https org host is its normal shape") {

--- a/test/cpp/test_microsoft_scan_reexecution.cpp
+++ b/test/cpp/test_microsoft_scan_reexecution.cpp
@@ -28,6 +28,7 @@
 #include "odata_test_server.hpp"
 #include "business_central_client.hpp"
 #include "dataverse_client.hpp"
+#include "odata_url_helpers.hpp"
 
 #include <ctime>
 #include <string>
@@ -198,9 +199,27 @@ TEST_CASE("the Business Central URL hatch refuses plain http off loopback",
                           duckdb::InvalidInputException);
     }
 
-    SECTION("https is accepted anywhere") {
+    // https to a NON-loopback host is gated for Business Central, because
+    // GetResourceUrl() hardcodes the token audience to api.businesscentral.dynamics.com -
+    // so a token minted for that host would be sent to another one. Dataverse is
+    // deliberately NOT gated: its scope is environment_url + "/.default", minted for
+    // whatever host you configure, so a custom host is the normal product (GitHub #199).
+    SECTION("https to another host is gated for Business Central") {
+        REQUIRE_THROWS_AS(
+            erpl_web::BusinessCentralUrlBuilder::BuildApiUrl("t", "https://api.example.com/v2"),
+            duckdb::InvalidInputException);
+    }
+
+    SECTION("...and permitted once the caller opts in") {
+        erpl_web::ServiceUrlPolicy::SetCustomServiceUrlsAllowed(true);
         REQUIRE(erpl_web::BusinessCentralUrlBuilder::BuildApiUrl("t", "https://api.example.com/v2") ==
                 "https://api.example.com/v2");
+        erpl_web::ServiceUrlPolicy::SetCustomServiceUrlsAllowed(false);
+    }
+
+    SECTION("Dataverse is not gated - a custom https org host is its normal shape") {
+        REQUIRE(erpl_web::DataverseUrlBuilder::BuildApiUrl("https://myorg.crm.dynamics.com") ==
+                "https://myorg.crm.dynamics.com/api/data/v9.2");
     }
 
     SECTION("plain http to any other host is refused") {

--- a/test/sql/tls_settings.test
+++ b/test/sql/tls_settings.test
@@ -65,3 +65,47 @@ no such file
 
 statement ok
 SET erpl_ca_cert_file = '';
+
+# =============================================================================
+# erpl_unsafe_allow_custom_service_urls (GitHub #199)
+#
+# Business Central and Datasphere mint their OAuth token for a FIXED audience, so pointing
+# those readers at another https host would hand it a credential issued for a different
+# one. Loopback never needs this setting. Dataverse is unaffected: its scope is derived
+# from environment_url, so a custom host is the normal product.
+#
+# Same shape as the TLS opt-out above: only the exact token is accepted, because a flag
+# that is easy to trip by accident is not a gate.
+# =============================================================================
+
+statement ok
+SET erpl_unsafe_allow_custom_service_urls = '';
+
+statement error
+SET erpl_unsafe_allow_custom_service_urls = 'true';
+----
+I_UNDERSTAND_THIS_SENDS_TOKENS_ELSEWHERE
+
+statement error
+SET erpl_unsafe_allow_custom_service_urls = '1';
+----
+I_UNDERSTAND_THIS_SENDS_TOKENS_ELSEWHERE
+
+statement error
+SET erpl_unsafe_allow_custom_service_urls = 'yes';
+----
+I_UNDERSTAND_THIS_SENDS_TOKENS_ELSEWHERE
+
+# The error has to say WHY, not just refuse - a caller who hits this needs to know the
+# token was minted for a different audience.
+statement error
+SET erpl_unsafe_allow_custom_service_urls = 'please';
+----
+audience
+
+statement ok
+SET erpl_unsafe_allow_custom_service_urls = 'I_UNDERSTAND_THIS_SENDS_TOKENS_ELSEWHERE';
+
+# ...and it can be turned back off.
+statement ok
+SET erpl_unsafe_allow_custom_service_urls = '';

--- a/test/sql/web_core.test
+++ b/test/sql/web_core.test
@@ -32,12 +32,16 @@ SELECT COUNT(*) FROM duckdb_functions() WHERE function_name LIKE '%datasphere%' 
 # ============================================================================
 
 # Test that extension-specific settings exist.
-# 10 = 7 tracing/telemetry settings + erpl_ca_cert_file and
-# erpl_unsafe_disable_server_cert_verification, added with TLS verification (#63).
+# 11 = 7 tracing/telemetry settings + erpl_ca_cert_file and
+# erpl_unsafe_disable_server_cert_verification, added with TLS verification (#63),
+# + erpl_unsafe_allow_custom_service_urls, added with the service-URL gate (#199).
+#
+# This count is deliberately exact: adding a setting - especially an unsafe one - should
+# not pass unnoticed, and updating this line is the prompt to document it.
 query I
 SELECT COUNT(*) FROM duckdb_settings() WHERE name LIKE 'erpl_%';
 ----
-10
+11
 
 # Verify core settings exist
 query I


### PR DESCRIPTION
Closes #199. Implements the "keep https-anywhere, gate it" option, scoped by evidence rather than uniformly.

## Which readers need gating, and why they differ

The verbatim-URL hatches let a reader be pointed at an arbitrary https host. Whether that is dangerous depends on where each service's OAuth token audience comes from — and they are not the same:

| Service | Token audience | Gated |
|---|---|---|
| **Dataverse** | `environment_url + "/.default"` — minted **for** the host you configure | **No** |
| **Business Central** | hardcoded `https://api.businesscentral.dynamics.com` | **Yes** |
| **Datasphere** | fixed `default` / `apiaccess` | **Yes** |

A Dataverse org *is* a customer-specific https host. Gating it would make every real deployment set an unsafe flag for ordinary operation — and a flag that is required for normal use is not a gate, it is noise that trains people to set flags.

**I got this wrong first.** My initial version applied one uniform rule through the shared guard. Five existing `test_dataverse.cpp` cases failing is what surfaced the distinction; without them I would have shipped a gate that broke the normal Dataverse path while calling it a security fix.

## The setting

```sql
SET erpl_unsafe_allow_custom_service_urls = 'I_UNDERSTAND_THIS_SENDS_TOKENS_ELSEWHERE';
```

Mirrors `erpl_unsafe_disable_server_cert_verification`: it refuses anything but the exact literal, because a flag that is easy to set by accident is not a gate. The error explains what the risk *is* — that the token was minted for a different audience — rather than just refusing, and says that loopback never needs it.

Loopback is always permitted, since local testing is what the hatches exist for. `RequireSecureOrLoopbackUrl` is unchanged and still used by Dataverse; the gate is a separate `RequireGatedServiceUrl` layered on top.

## Verification

- Unit: BC refuses `https://api.example.com`, permits it after opt-in, and Dataverse is unaffected — all three asserted.
- End to end through SQL: a wrong token is refused with the explanation, the real one is accepted. That needed the `duckdb` target rebuilt separately from `erpl_web_tests`, per the note in CLAUDE.md.

474 C++ cases / 2515 assertions green.

## Note

This branch previously showed three `[catalog]` failures. Those were not the gate — the branch was cut from a main that was missing the Business Central half of #191. After rebasing onto the corrected main they cleared, which independently confirmed that regression was real.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/erpl-web/pr/204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791835980&installation_model_id=425457&pr_number=204&repository=DataZooDE%2Ferpl-web&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Ferpl-web%2Fpull%2F204&signature=f441bbefdfd906ce6127aec2cdd5d1f33954d7a69b48866f112219fbdd83c866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->